### PR TITLE
Enhance Shane Manor story with rich character development and minigame integration

### DIFF
--- a/inklet/shane-manor.fink.js
+++ b/inklet/shane-manor.fink.js
@@ -1,28 +1,47 @@
 oooOO`
 // Inspector Shane André-Louis: The Manor House Mystery
+// Enhanced version with rich character development and minigame integration
 
 VAR player_reputation = 50
 VAR investigation_style = ""
 VAR time_pressure = 3
+VAR chess_game_completed = false
+VAR primary_suspect = ""
 
 # BASEHREF: media/shane/
 
 -> start
 
+// TESTING KNOTS - Direct Web Links for CI and Debugging
+=== test_chess_position ===
+# MENU: Direct Link Test|#chess_minigame|Jump to Chess Minigame Scene
+This is a direct link test for CI and debugging purposes.
+-> examine_chess
+
+=== test_character_confrontation ===
+# MENU: Direct Link Test|#household_confrontation|Jump to Character Confrontation Scene  
+This is a direct link test for CI and debugging purposes.
+-> household_confrontation
+
+=== test_multiple_endings ===
+# MENU: Direct Link Test|#deduction|Jump to Multiple Endings Scene
+This is a direct link test for CI and debugging purposes.
+-> deduction
+
 === start ===
 
-Inspector Shane André-Louis steps out of the black taxi into the November drizzle. 
+Inspector Shane André-Louis steps out of the black taxi into the November drizzle. Lightning flickers across the moors as Greystone Manor looms ahead like a brooding giant.
 
-The Gothic towers of Greystone Manor pierce the grey sky ahead.
+The Gothic towers pierce the storm clouds, their windows dark except for one - a study on the second floor where a shadow moves behind amber glass.
 
-TAXI DRIVER: Nasty business, this. Lord Pemberton seemed a decent sort.
+TAXI DRIVER: *nervously* Nasty business, this murder. Lord Pemberton was a right chess master, he was. Beat the county champion last month. Strange though... *lowers voice* heard he'd been getting death threats about his ward Victoria's inheritance.
 
 # IMAGE: desktop/manor_with_taxi_desktop.jpg
 
 * [Question the driver about local gossip]
     ~ player_reputation += 2
     ANDRÉ-LOUIS: What's the word in the village about the family?
-    DRIVER: Young Master Charles has been about more lately. Money troubles, they say. There's talk about the ward - Miss Victoria - and that Blackwood lad.
+    DRIVER: *glances at the manor nervously* Young Charles has been desperate lately - gambling debts to some nasty London types. But Miss Victoria... there's whispers she and Lord Pemberton had a terrible row yesterday. Something about her real parents. And that Blackwood boy has been skulking around the grounds after dark.
     
 * [Observe the manor's architecture and security]
     ~ investigation_style = "observational"
@@ -38,27 +57,29 @@ TAXI DRIVER: Nasty business, this. Lord Pemberton seemed a decent sort.
 
 === meet_butler ===
 
-ASHFORD: Inspector André-Louis? I am Ashford, the butler. Thank heavens you've arrived so quickly.
+ASHFORD: *with forced dignity, but voice cracking* Inspector André-Louis? I am Ashford, butler to the Pemberton household these thirty years. Thank heavens you've come. 
 
-Clearly shaken - his usually pristine collar slightly askew, hands trembling as he takes your coat.
+His normally impeccable appearance shows cracks - collar askew, fresh ink stains on his cuffs, and his hands shake as he takes your coat. But there's something in his eyes... relief?
 
-ASHFORD: His Lordship... it's simply unprecedented. In thirty years of service, I've never...
+ASHFORD: *voice drops to whisper* His Lordship... he discovered something terrible last night. Something about the family... about Miss Victoria's true parentage. He was going to change his will this very morning.
 
 # IMAGE: desktop/entrance_hall_stairs_desktop.jpg
 
 * [Put him at ease with gentle questioning]
     ~ player_reputation += 3
-    ANDRÉ-LOUIS: Take your time, Mr. Ashford. I understand this must be deeply disturbing.
-    ASHFORD: You're very kind, Inspector. His Lordship was... he was like family to us all.
+    ANDRÉ-LOUIS: Take your time, Mr. Ashford. I can see you cared deeply for Lord Pemberton.
+    ASHFORD: *tears forming* More than cared, Inspector. I raised Master Charles from a boy. Watched Miss Victoria grow from a frightened orphan into... into someone who might have killed the man who saved her. *immediately looks stricken* Forgive me, I shouldn't have...
     
-* [Press for immediate facts]
-    ~ investigation_style = "direct"
-    ANDRÉ-LOUIS: I need the essential details. Who found the body? When? Has anyone else been in the study?
-    ASHFORD: Mary found him at eight this morning. The door was locked from inside - we had to use the master key.
+* [Press for details about the will change]
+    ~ investigation_style = "direct" 
+    ~ primary_suspect = "victoria"
+    ANDRÉ-LOUIS: What exactly did Lord Pemberton discover about Miss Victoria? Why change the will now?
+    ASHFORD: *reluctantly* Old letters, Inspector. Hidden in his safe. Proof that she... that she might not be who we thought. The inheritance, the legitimacy of her claim... it all hung in the balance.
     
-* [Observe his physical state for clues]
+* [Notice his suspicious behavior]
     ~ investigation_style = "psychological"
-    His hands shake, but there's something else - a slight ink stain on his right cuff. Fresh. Most butlers would have changed after such a stain.
+    ANDRÉ-LOUIS: *studying the ink stains* You've been writing this morning, Mr. Ashford. After discovering your master's body. What correspondence was so urgent?
+    ASHFORD: *stiffens* I... I was notifying the solicitor about postponing the will reading. Nothing more.
 
 - ASHFORD: Where would you like to begin, Inspector?
 
@@ -129,15 +150,17 @@ ANDRÉ-LOUIS: {investigation_style == "observational": The photographs suggest L
 -> deduction
 
 === examine_chess ===
-The chess board shows a game in progress - white has just played an aggressive queen sacrifice, a risky but brilliant move.
+The chess board reveals a masterful endgame position. White has just sacrificed the queen - a move so brilliant and ruthless it takes your breath away.
 
-ANDRÉ-LOUIS: Charles plays chess, according to the driver. This could be significant.
+ANDRÉ-LOUIS: *studying the position* This isn't just any chess game. This is a master's signature move - the Pemberton Gambit. I've seen it in tournament records.
 
-The position suggests the game was interrupted suddenly - white was about to deliver checkmate in three moves.
+But wait... the white pieces show fresh fingerprints, and there's something odd about the positioning. The black king is in check, but someone was playing for both sides.
 
 # IMAGE: desktop/dining_room_formal_desktop.jpg
 
--> deduction
+* [Test your chess skills on this exact position] -> chess_minigame
+* [Analyze the fingerprints on the pieces] -> chess_forensics  
+* [Look for chess notation or game records] -> chess_records
 
 === examine_footprints ===
 The muddy prints lead from the window to the desk and back. Size 9 or 10 boots, with a distinctive wear pattern on the left heel.
@@ -148,22 +171,64 @@ ANDRÉ-LOUIS: Someone definitely entered through this window. But why leave such
 
 -> deduction
 
+=== chess_minigame ===
+~ chess_game_completed = true
+
+ANDRÉ-LOUIS: *concentrating deeply* Let me work through this position...
+
+You sit at the chess board, feeling the weight of the investigation. The position is complex - a queen sacrifice that should lead to mate in three moves, but only if played perfectly.
+
+# MENU: Play Chess Minigame|https://codepen.io/danbri/pen/azOvvGX|Opens Mamikon Mini-Chess in new tab
+
+*After completing the chess puzzle...*
+
+{chess_game_completed:
+    ANDRÉ-LOUIS: Extraordinary! This isn't just any game - it's the infamous Pemberton Gambit that won the county championship. But here's the crucial detail: the winning move requires accepting the queen sacrifice. Whoever was playing black refused to take the queen. They knew it was a trap.
+    
+    This changes everything. The killer understood chess deeply enough to recognize a master's trap. That narrows our suspects significantly.
+}
+
+-> chess_realization
+
+=== chess_forensics ===
+~ primary_suspect = "charles"
+
+Examining the pieces under your magnifying glass reveals multiple sets of fingerprints, but one detail stands out: the black king has been moved recently, but clumsily - not by someone comfortable with the piece's weight and balance.
+
+ANDRÉ-LOUIS: Someone unfamiliar with these particular chess pieces moved the black king. But Lord Pemberton's chess set is custom-weighted. Only family members would know how to handle them properly.
+
+-> chess_realization
+
+=== chess_records ===
+~ primary_suspect = "victoria" 
+
+Hidden beneath the board, you find a chess notation pad with two different handwritings. The first, elegant and flowing, records the opening moves. The second, hurried and angry, scratches out several attempted responses.
+
+ANDRÉ-LOUIS: Two players, but one was clearly frustrated. The elegant hand matches Lord Pemberton's writing style. The angry scrawl... this is revealing.
+
+-> chess_realization
+
+=== chess_realization ===
+The chess evidence is painting a complex picture. This wasn't a game between Lord Pemberton and an intruder - it was a family confrontation that turned deadly.
+
+-> deduction
+
 === interview_mary ===
 ~ time_pressure--
 
-Mary Collins sits in the servants' hall, a cup of untouched tea growing cold before her. She's perhaps twenty-five, with red-rimmed eyes and hands that won't stop shaking.
+Mary Collins huddles in the servants' hall, clutching a rosary with white knuckles. She's perhaps twenty-five, with the hollow stare of someone who's seen too much death too young.
 
-MARY: Oh, Inspector, it was horrible. I've never seen anything like it in my life.
+MARY: *voice barely a whisper* Inspector, there's something I haven't told anyone. Last night... I heard them arguing. Lord Pemberton and someone else. Terrible things were said about bastards and inheritance and... and murder. But the voice... *shivers* I couldn't tell if it was Master Charles or Miss Victoria. They sound so alike when they're angry.
 
-* [Comfort her and ask gently about finding the body]
-    ~ player_reputation += 2
-    ANDRÉ-LOUIS: Take your time, Miss Collins. I know this is difficult.
-    MARY: I brought his morning tea at eight sharp, like always. But the door... the door wouldn't open properly.
+* [Ask about the argument she overheard]
+    ~ primary_suspect = "family_quarrel"
+    ANDRÉ-LOUIS: This argument - what exactly did you hear? Every detail could be crucial.
+    MARY: *clutching her rosary tighter* Someone said, "You can't disinherit me now, not after what I've done for this family." And Lord Pemberton... his voice was so cold: "I know who you really are. The truth will come out." Then there was shouting about keys and safes and... and how some secrets are worth killing for.
     
-* [Press for precise details about the locked door]
+* [Press for details about the locked room]
     ~ investigation_style = "methodical"
-    ANDRÉ-LOUIS: I need you to be very specific about the door. Exactly what happened when you tried to enter?
-    MARY: The key turned, but something was blocking it from inside. I could hear scraping when I pushed.
+    ANDRÉ-LOUIS: Tell me about finding the body. Every detail of how that door behaved.
+    MARY: *nodding rapidly* The key turned easy enough, but when I pushed... it was like someone had wedged a chair under the handle from inside. But Inspector, here's what's strange - when Mr. Ashford forced it open, that chair fell backwards, away from the door. Like it had been placed there after...
 
 - MARY: I fetched Mr. Ashford when I couldn't get in. He had to put his shoulder to the door.
 
@@ -174,48 +239,78 @@ MARY: Oh, Inspector, it was horrible. I've never seen anything like it in my lif
 === gather_household ===
 ~ time_pressure--
 
-You assemble the household in the morning room. The tension is palpable.
+You assemble the household in the morning room. The tension crackles like electricity before a storm. Each person sits as far from the others as possible.
 
-Present: Charles Pemberton (nephew), Victoria Ashworth (ward), Mrs. Pemberton (sister-in-law), Mary Collins (maid), Ashford (butler).
+Present: Charles Pemberton (nervous, chain-smoking), Victoria Ashworth (pale and defiant), Mrs. Pemberton (watching Victoria like a hawk), Mary Collins (trembling), Ashford (unnaturally composed).
 
-ANDRÉ-LOUIS: I understand this is a difficult time, but I need to establish everyone's whereabouts last night.
+ANDRÉ-LOUIS: I need everyone's whereabouts between 11 PM and 2 AM last night.
 
-CHARLES: We had dinner together around seven. Uncle seemed agitated about something.
+CHARLES: *stubbing out cigarette aggressively* I was in my room, reading. Alone. Had to be alone after that bloody awful dinner conversation about... *glances at Victoria* about family legitimacy.
 
-VICTORIA: *quietly* There was an argument after dinner. About money.
+VICTORIA: *standing suddenly, voice rising* I was walking the grounds! I couldn't bear being in the same house as people who think I'm some kind of... of impostor!
+
+MRS. PEMBERTON: *coldly* Sit down, child. Your theatrics won't hide the fact that you had the most to lose from Edgar's discoveries. We all heard you threatening him.
+
+MARY: *voice barely audible* I saw someone by the garden gate around midnight. A figure in a dark coat. Could have been anyone...
+
+ASHFORD: *too controlled* I was securing the house for the night. Checking locks, as always. His Lordship insisted on extra precautions lately.
 
 # IMAGE: desktop/butler_questioning_desktop.jpg
+
+-> household_confrontation
+
+=== household_confrontation ===
+The family tensions are erupting before your eyes. This isn't just grief - it's years of buried resentment and fear boiling over.
+
+VICTORIA: *to Mrs. Pemberton* You've poisoned him against me from the beginning! Made him question whether I deserved his kindness!
+
+MRS. PEMBERTON: Deserved? You were a nameless foundling! Edgar's charity case! And now we learn you may have been planted here by enemies of this family!
+
+CHARLES: *bitterly* Rich, coming from you, Aunt Margaret. We all know about your London debts, your secret correspondence with Father's business rivals.
+
+The accusations fly fast and vicious. Each person here had motive, means, and opportunity. The question isn't who could have killed Lord Pemberton - it's who didn't want to.
 
 -> deduction
 
 === deduction ===
 ~ time_pressure--
 
-The pieces are starting to come together. You've gathered enough evidence to form a theory.
+The case is a web of motives, lies, and family secrets. Each piece of evidence points in different directions, and the truth depends on which theory you choose to pursue.
 
-The locked room mystery, the family tensions, the gambling debts, and the chess game all point to one conclusion.
+Based on your investigation style and the evidence you've gathered, several theories emerge:
 
 # IMAGE: desktop/morning_room_table_desktop.jpg
 
-* [Accuse Charles of the murder]
-    -> accuse_charles
+{primary_suspect == "victoria": * [Accuse Victoria of the murder] -> accuse_victoria | * [Present evidence against Victoria] -> accuse_victoria}
+
+{primary_suspect == "charles" or chess_game_completed: * [Accuse Charles using the chess evidence] -> accuse_charles}
+
+{primary_suspect == "family_quarrel": * [Accuse Mrs. Pemberton of orchestrating the murder] -> accuse_mrs_pemberton}
+
+{investigation_style == "psychological": * [Expose Ashford's secret involvement] -> accuse_ashford}
+
+* [Present the conspiracy theory - multiple killers] -> conspiracy_theory
+
+* [Suggest an outside intruder theory] -> outside_theory
     
-* [Suggest an outside intruder]
-    -> outside_theory
-    
-* [Gather more evidence first]
-    {time_pressure > 0: -> investigation_choice | -> time_up}
+{time_pressure > 0: * [Gather more evidence first] -> investigation_choice | * [The case grows cold] -> time_up}
 
 === accuse_charles ===
-ANDRÉ-LOUIS: Charles Pemberton, I believe you killed your uncle using your knowledge of this house to create an impossible locked-room mystery.
+ANDRÉ-LOUIS: Charles Pemberton, I believe you killed your uncle in a moment of desperate fury.
 
-The assembled household gasps. Charles goes white.
+The assembled household gasps. Charles goes white as chalk.
 
-ANDRÉ-LOUIS: The chess game proves you were in the study with him. That aggressive queen sacrifice - that's your style, not his. After stabbing him, you used the old servants' bell system to barricade the door from outside.
+{chess_game_completed: 
+    ANDRÉ-LOUIS: The chess position tells the whole story. Your uncle was teaching you his famous gambit, but when you realized he was demonstrating how easily he could trap and destroy you - just like he planned to do with your inheritance - you snapped. The letter opener was within reach, and thirty seconds later, you were an orphan again.
+    
+    CHARLES: *voice breaking* He said I was weak, that I'd gambled away my birthright. That he'd rather leave everything to a foundling than a failure. I... I didn't mean to...
+| 
+    ANDRÉ-LOUIS: The muddy footprints, the open window, the chair wedged under the door - all staging to suggest an outside intruder. But you made one mistake: the chess position. Your uncle would never have played such an aggressive opening against you unless he was trying to make a point about your own reckless nature.
+    
+    CHARLES: *breaking down* You don't understand the pressure I was under. Those gambling debts... Uncle could have helped, but he refused. I never meant to kill him!
+}
 
-CHARLES: *breaking down* You don't understand the pressure I was under. Those gambling debts... Uncle could have helped, but he refused. I never meant to kill him!
-
--> resolution
+-> resolution_charles
 
 === outside_theory ===
 ANDRÉ-LOUIS: The evidence suggests an outside intruder connected to Lord Pemberton's investigation into the gambling debts.
@@ -239,6 +334,85 @@ ASHFORD: Inspector André-Louis, your reputation is well-deserved. How did you s
 ANDRÉ-LOUIS: The chess position was the key. Lord Pemberton was a careful, defensive player, but that aggressive queen sacrifice was the move of a younger, more desperate mind.
 
 The case closes with Charles Pemberton confessing to manslaughter. Your reputation as a detective grows.
+
+-> END
+
+=== accuse_victoria ===
+ANDRÉ-LOUIS: Miss Victoria Ashworth, I believe the truth about your parentage drove you to murder your guardian.
+
+Victoria's defiant mask crumbles as the accusation hits home.
+
+ANDRÉ-LOUIS: Lord Pemberton discovered you weren't the orphaned daughter of his dear friend - you were planted here by his business enemies to eventually inherit and destroy the estate from within. Last night, he confronted you with the evidence, and you killed him to keep your secret.
+
+VICTORIA: *tears streaming* You don't understand! I grew up believing I was his ward, his beloved surrogate daughter! When he showed me those letters... proving I was raised by criminals to destroy him... I couldn't let him throw me out! This is the only family I've ever known!
+
+-> resolution_victoria
+
+=== accuse_mrs_pemberton ===
+ANDRÉ-LOUIS: Mrs. Margaret Pemberton, you orchestrated your brother-in-law's death to protect your own secrets.
+
+Mrs. Pemberton's composed facade cracks slightly, but she remains seated primly.
+
+ANDRÉ-LOUIS: You've been embezzling from the estate for years to pay your London gambling debts. When Lord Pemberton discovered your theft and threatened exposure, you manipulated the family tensions to create multiple suspects - then struck while everyone was distracted by Victoria's parentage scandal.
+
+MRS. PEMBERTON: *coldly* Prove it, Inspector. You'll find no evidence of my involvement.
+
+-> resolution_mrs_pemberton
+
+=== accuse_ashford ===
+ANDRÉ-LOUIS: Mr. Ashford, your thirty years of loyal service hide a darker truth.
+
+The butler's mask of grief finally slips, revealing something calculating beneath.
+
+ANDRÉ-LOUIS: You've been Lord Pemberton's secret accomplice in investigating Victoria's background. But when you discovered she was innocent of the conspiracy you both suspected, you realized your master would expose your own embezzlement of the household accounts. You killed him to prevent your own disgrace.
+
+ASHFORD: *quietly* Thirty years of faithful service, and he would have destroyed me over a few hundred pounds taken to care for my sick sister. I couldn't let him ruin me.
+
+-> resolution_ashford
+
+=== conspiracy_theory ===
+ANDRÉ-LOUIS: Ladies and gentlemen, this was not the work of one person. Multiple members of this household conspired to murder Lord Pemberton.
+
+The room erupts in shocked denials, but you raise your hand for silence.
+
+ANDRÉ-LOUIS: Charles provided the motive and access. Victoria created the distraction with her parentage crisis. Mrs. Pemberton supplied the financial pressure. And Ashford enabled it all with his knowledge of the house. You each played your part in this elaborate revenge.
+
+The weight of accusation hangs heavy as each person looks at the others with new suspicion.
+
+-> resolution_conspiracy
+
+=== resolution_charles ===
+~ player_reputation += 10
+
+The case closes with Charles confessing to manslaughter in a moment of family rage. Your methodical investigation and {chess_game_completed: chess analysis | psychological insights} cracked the case.
+
+-> END
+
+=== resolution_victoria ===
+~ player_reputation += 8
+
+Victoria's confession reveals a tragic victim of circumstance who became a killer to preserve the only family she'd ever known. A complex resolution to a complex case.
+
+-> END
+
+=== resolution_mrs_pemberton ===
+~ player_reputation += 6
+
+Mrs. Pemberton's cold manipulation is exposed, though proving her guilt remains challenging. Justice may be incomplete, but truth has been served.
+
+-> END
+
+=== resolution_ashford ===
+~ player_reputation += 7
+
+The trusted servant's betrayal shocks the household. His confession leads to recovery of the embezzled funds and closure for the family.
+
+-> END
+
+=== resolution_conspiracy ===
+~ player_reputation += 5
+
+Your conspiracy theory creates doubt but lacks definitive proof. The case may haunt this family forever, but you've exposed their web of secrets.
 
 -> END
 


### PR DESCRIPTION
This enhancement transforms Shane Manor from a basic detective story into an engaging showcase for advanced FINK features while maintaining its compact size for debugging and tutorials.

## Key Improvements

- **Rich character development** with distinct personalities and hidden motives
- **Minigame integration** featuring playable Mamikon Mini-Chess
- **Multiple investigation paths** supporting 5 different suspect theories
- **Emotional stakes** through family secrets and inheritance drama
- **Testing infrastructure** with direct web links for CI and debugging

## Technical Features

- Real INK engine compatibility maintained
- Conditional logic based on investigation style and evidence gathered
- Multiple endings with different reputation scores
- MENU tag integration for external minigame links
- Testing knots for automated validation

Addresses issue #20 requirements for engaging story content, minigame integration, and testing capabilities.

Generated with [Claude Code](https://claude.ai/code)