### PR TITLE
Fix INK syntax errors in shane-manor.fink.js

### DIFF
--- a/inklet/shane-manor.fink.js
+++ b/inklet/shane-manor.fink.js
@@ -281,19 +281,33 @@ Based on your investigation style and the evidence you've gathered, several theo
 
 # IMAGE: desktop/morning_room_table_desktop.jpg
 
-{primary_suspect == "victoria": * [Accuse Victoria of the murder] -> accuse_victoria | * [Present evidence against Victoria] -> accuse_victoria}
+{ primary_suspect == "victoria":
+  + [Accuse Victoria of the murder] -> accuse_victoria
+}
 
-{primary_suspect == "charles" or chess_game_completed: * [Accuse Charles using the chess evidence] -> accuse_charles}
+{ primary_suspect == "charles" or chess_game_completed:
+  + [Accuse Charles using the chess evidence] -> accuse_charles
+}
 
-{primary_suspect == "family_quarrel": * [Accuse Mrs. Pemberton of orchestrating the murder] -> accuse_mrs_pemberton}
+{ primary_suspect == "family_quarrel":
+  + [Accuse Mrs. Pemberton of orchestrating the murder] -> accuse_mrs_pemberton
+}
 
-{investigation_style == "psychological": * [Expose Ashford's secret involvement] -> accuse_ashford}
+{ investigation_style == "psychological":
+  + [Expose Ashford's secret involvement] -> accuse_ashford
+}
 
-* [Present the conspiracy theory - multiple killers] -> conspiracy_theory
++ [Present the conspiracy theory - multiple killers] -> conspiracy_theory
 
-* [Suggest an outside intruder theory] -> outside_theory
++ [Suggest an outside intruder theory] -> outside_theory
     
-{time_pressure > 0: * [Gather more evidence first] -> investigation_choice | * [The case grows cold] -> time_up}
+{ time_pressure > 0:
+  + [Gather more evidence first] -> investigation_choice
+}
+
+{ time_pressure <= 0:
+  + [The case grows cold] -> time_up
+}
 
 === accuse_charles ===
 ANDRÉ-LOUIS: Charles Pemberton, I believe you killed your uncle in a moment of desperate fury.


### PR DESCRIPTION
Fixed critical INK compilation errors in Shane Manor story while preserving all enhanced content.

## Key Fixes

- Fixed conditional choice syntax: changed `*` to `+` for conditional choices
- Removed duplicate Victoria accusation choice that caused compilation error
- Fixed complex conditional structure formatting
- Used proper INK syntax matching working FINK files like hampstead.fink.js

## Story Content Preserved

- Rich character development with distinct personalities
- Minigame integration featuring playable chess
- Multiple investigation paths with 5 suspect theories
- Emotional stakes through family secrets and inheritance drama
- Testing infrastructure for CI and debugging

Addresses compilation failures reported in issue #20.

🤖 Generated with [Claude Code](https://claude.ai/code)