### PR TITLE
Add modular UI components and minimal invader test page

### DIFF
--- a/lucid/ui/demo-viewer.js
+++ b/lucid/ui/demo-viewer.js
@@ -1,0 +1,185 @@
+/**
+ * Demo viewer UI - code panel and edit panel management
+ * Provides DSL and GLSL viewing/editing capabilities
+ */
+import { parseDslToSceneGraph, generateGlslFromSceneGraph } from '../core/index.js';
+
+export class DemoViewer {
+  constructor(options = {}) {
+    this.renderer = options.renderer;
+    this.onDslChange = options.onDslChange || (() => {});
+
+    this.currentDsl = '';
+    this.currentGlsl = '';
+    this.currentSceneGraph = null;
+
+    this.setupUI();
+  }
+
+  setupUI() {
+    // Code toggle button
+    const codeToggle = document.querySelector('.code-toggle');
+    const codePanel = document.getElementById('codePanel');
+    const codeClose = document.querySelector('.code-close');
+
+    if (codeToggle && codePanel) {
+      codeToggle.addEventListener('click', () => {
+        codePanel.classList.toggle('open');
+      });
+    }
+
+    if (codeClose && codePanel) {
+      codeClose.addEventListener('click', () => {
+        codePanel.classList.remove('open');
+      });
+    }
+
+    // Edit panel setup
+    const editToggle = document.querySelector('.edit-toggle');
+    const editPanel = document.getElementById('editPanel');
+    const editTextarea = document.getElementById('editTextarea');
+    const editApply = document.getElementById('editApply');
+    const editCancel = document.getElementById('editCancel');
+    const editError = document.getElementById('editError');
+
+    if (editToggle && editPanel && editTextarea) {
+      editToggle.addEventListener('click', () => {
+        editPanel.classList.add('active');
+        editTextarea.value = this.currentDsl;
+        if (editError) editError.classList.remove('visible');
+        editTextarea.focus();
+      });
+    }
+
+    if (editCancel && editPanel) {
+      editCancel.addEventListener('click', () => {
+        editPanel.classList.remove('active');
+      });
+    }
+
+    if (editApply && editPanel && editTextarea && editError) {
+      editApply.addEventListener('click', () => {
+        const newDsl = editTextarea.value;
+
+        try {
+          // Parse and generate GLSL
+          const sceneGraph = parseDslToSceneGraph(newDsl);
+          const glslCode = generateGlslFromSceneGraph(sceneGraph);
+
+          // Update renderer
+          if (this.renderer) {
+            this.renderer.updateScene(glslCode);
+          }
+
+          // Update stored values
+          this.currentDsl = newDsl;
+          this.currentGlsl = glslCode;
+          this.currentSceneGraph = sceneGraph;
+
+          // Update code display
+          this.updateCodeDisplay();
+
+          // Notify callback
+          this.onDslChange(newDsl);
+
+          // Close edit panel
+          editPanel.classList.remove('active');
+          editError.classList.remove('visible');
+
+          console.log('✅ DSL updated successfully');
+        } catch (error) {
+          console.error('❌ DSL parsing failed:', error);
+          editError.textContent = `Error: ${error.message}`;
+          editError.classList.add('visible');
+        }
+      });
+    }
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'c' || e.key === 'C') {
+        if (codePanel) {
+          codePanel.classList.toggle('open');
+        }
+      } else if (e.key === 'e' || e.key === 'E') {
+        if (editPanel && !editPanel.classList.contains('active')) {
+          editPanel.classList.add('active');
+          if (editTextarea) {
+            editTextarea.value = this.currentDsl;
+            editTextarea.focus();
+          }
+          if (editError) editError.classList.remove('visible');
+        }
+      } else if (e.key === 'Escape') {
+        if (editPanel && editPanel.classList.contains('active')) {
+          editPanel.classList.remove('active');
+        }
+        if (codePanel && codePanel.classList.contains('open')) {
+          codePanel.classList.remove('open');
+        }
+      }
+    });
+  }
+
+  loadDsl(dsl) {
+    try {
+      // Parse DSL to scene graph
+      const sceneGraph = parseDslToSceneGraph(dsl);
+
+      // Generate GLSL from scene graph
+      const glslCode = generateGlslFromSceneGraph(sceneGraph);
+
+      // Update renderer
+      if (this.renderer) {
+        this.renderer.updateScene(glslCode);
+      }
+
+      // Store values
+      this.currentDsl = dsl;
+      this.currentGlsl = glslCode;
+      this.currentSceneGraph = sceneGraph;
+
+      // Update UI
+      this.updateCodeDisplay();
+
+      console.log('✅ Scene loaded successfully');
+      console.log('Scene graph:', sceneGraph);
+
+    } catch (error) {
+      console.error('❌ Failed to load scene:', error);
+      throw error;
+    }
+  }
+
+  updateCodeDisplay() {
+    // Update DSL display
+    const dslCode = document.getElementById('dslCode');
+    if (dslCode) {
+      dslCode.textContent = this.currentDsl;
+    }
+
+    // Update GLSL display
+    const glslCode = document.getElementById('glslCode');
+    if (glslCode) {
+      glslCode.textContent = this.currentGlsl;
+    }
+
+    // Update scene graph display
+    const sceneGraphCode = document.getElementById('sceneGraphCode');
+    if (sceneGraphCode) {
+      sceneGraphCode.textContent = JSON.stringify(this.currentSceneGraph, null, 2);
+    }
+  }
+
+  getDsl() {
+    return this.currentDsl;
+  }
+
+  getGlsl() {
+    return this.currentGlsl;
+  }
+
+  getSceneGraph() {
+    return this.currentSceneGraph;
+  }
+}

--- a/lucid/ui/raymarcher.js
+++ b/lucid/ui/raymarcher.js
@@ -1,0 +1,284 @@
+/**
+ * Simple WebGL raymarcher for SDF scenes
+ * Supports orbit camera, ground plane, and volume rendering modes
+ */
+export class SimpleRaymarcher {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+    if (!this.gl) {
+      throw new Error('WebGL not supported');
+    }
+
+    this.params = {
+      maxSteps: 100,
+      maxDist: 50.0,
+      surfDist: 0.001,
+      stepSize: 1.0
+    };
+
+    this.currentGlsl = '';
+    this.program = null;
+    this.startTime = performance.now();
+
+    // Camera orbit controls
+    this.camera = {
+      distance: 4.0,
+      theta: 0.0,      // horizontal angle
+      phi: Math.PI / 4, // vertical angle (45 degrees)
+      target: [0, 0, 0]
+    };
+
+    this.showGroundPlane = true;
+    this.volumeRender = false;
+
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+  }
+
+  resize() {
+    const dpr = window.devicePixelRatio || 1;
+    this.canvas.width = window.innerWidth * dpr;
+    this.canvas.height = window.innerHeight * dpr;
+    if (this.gl) {
+      this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    }
+  }
+
+  updateScene(glslCode) {
+    this.currentGlsl = glslCode;
+    this.compileShaders();
+  }
+
+  compileShaders() {
+    const gl = this.gl;
+
+    const vertexShaderSource = `
+      attribute vec4 a_position;
+      void main() {
+        gl_Position = a_position;
+      }
+    `;
+
+    const fragmentShaderSource = `
+      precision highp float;
+      uniform vec2 u_resolution;
+      uniform float u_time;
+      uniform vec3 u_cameraPos;
+      uniform vec3 u_cameraTarget;
+      uniform float u_showGroundPlane;
+      uniform float u_volumeRender;
+
+      ${this.currentGlsl}
+
+      // Ground plane SDF with checkerboard pattern
+      float sdGroundPlane(vec3 p) {
+        return p.y + 1.5; // Plane at y = -1.5
+      }
+
+      vec3 getGroundColor(vec3 p) {
+        // Checkerboard pattern
+        float scale = 0.5;
+        vec2 q = floor(p.xz / scale);
+        float checker = mod(q.x + q.y, 2.0);
+        vec3 color1 = vec3(0.15, 0.15, 0.2);
+        vec3 color2 = vec3(0.25, 0.25, 0.3);
+        return mix(color1, color2, checker);
+      }
+
+      vec3 calcNormal(vec3 p) {
+        vec2 e = vec2(0.001, 0.0);
+        return normalize(vec3(
+          g_df_scene(p + e.xyy).x - g_df_scene(p - e.xyy).x,
+          g_df_scene(p + e.yxy).x - g_df_scene(p - e.yxy).x,
+          g_df_scene(p + e.yyx).x - g_df_scene(p - e.yyx).x
+        ));
+      }
+
+      vec4 raymarch(vec3 ro, vec3 rd) {
+        float t = 0.0;
+        vec3 colVol = vec3(0.0);
+        float trans = 1.0;
+        bool hitGround = false;
+        vec3 hitPos = vec3(0.0);
+        float stepSize = 0.05;
+
+        for (int i = 0; i < 100; i++) {
+          if (t > 50.0) break;
+          if (u_volumeRender > 0.5 && trans < 0.01) break;
+
+          vec3 p = ro + rd * t;
+          vec4 scene = g_df_scene(p);
+          float d = scene.x;
+
+          // Check ground plane if enabled
+          if (u_showGroundPlane > 0.5) {
+            float dGround = sdGroundPlane(p);
+            if (dGround < d) {
+              d = dGround;
+              if (abs(d) < 0.001) {
+                hitGround = true;
+                hitPos = p;
+              }
+            }
+          }
+
+          // Surface mode - traditional raymarching
+          if (u_volumeRender < 0.5) {
+            if (abs(d) < 0.001 && !hitGround) {
+              vec3 normal = calcNormal(p);
+              vec3 light = normalize(vec3(1.0, 1.0, -1.0));
+              float diff = max(dot(normal, light), 0.0);
+              float amb = 0.3;
+              float spec = pow(max(dot(reflect(-light, normal), -rd), 0.0), 32.0);
+              vec3 col = scene.yzw * (amb + diff * 0.7) + spec * 0.3;
+              return vec4(col, 1.0);
+            }
+
+            if (hitGround) {
+              vec3 normal = vec3(0.0, 1.0, 0.0);
+              vec3 light = normalize(vec3(1.0, 1.0, -1.0));
+              float diff = max(dot(normal, light), 0.0);
+              float amb = 0.3;
+              vec3 col = getGroundColor(hitPos) * (amb + diff * 0.7);
+              return vec4(col, 1.0);
+            }
+
+            t += abs(d) * 0.9;
+          } else {
+            // Volume mode - accumulate density near surface
+            // Use smooth density falloff instead of hard inside/outside
+            float density = exp(-abs(d) * 5.0); // Density peaks at surface (d=0)
+
+            // Accumulate color with proper weighting
+            float absorption = density * stepSize * 8.0;
+            colVol += trans * scene.yzw * absorption;
+            trans *= 1.0 - absorption; // Reduce transmission
+
+            // Fixed step size for consistent appearance
+            t += stepSize;
+          }
+        }
+
+        // Return background or accumulated volume
+        if (u_volumeRender > 0.5) {
+          return vec4(colVol, 1.0);
+        }
+        return vec4(0.0);
+      }
+
+      void main() {
+        vec2 uv = (gl_FragCoord.xy - 0.5 * u_resolution) / u_resolution.y;
+
+        // Camera setup with orbit controls
+        vec3 ro = u_cameraPos;
+        vec3 forward = normalize(u_cameraTarget - u_cameraPos);
+        vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), forward));
+        vec3 up = cross(forward, right);
+        vec3 rd = normalize(forward + uv.x * right + uv.y * up);
+
+        vec4 col = raymarch(ro, rd);
+
+        // Background gradient
+        if (col.a < 0.5) {
+          vec3 bg = mix(vec3(0.02, 0.02, 0.08), vec3(0.05, 0.0, 0.1), uv.y * 0.5 + 0.5);
+          col = vec4(bg, 1.0);
+        }
+
+        gl_FragColor = col;
+      }
+    `;
+
+    // Clean up old program
+    if (this.program) {
+      gl.deleteProgram(this.program);
+    }
+
+    // Compile shaders
+    const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vertexShader, vertexShaderSource);
+    gl.compileShader(vertexShader);
+
+    const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fragmentShader, fragmentShaderSource);
+    gl.compileShader(fragmentShader);
+
+    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+      const error = gl.getShaderInfoLog(fragmentShader);
+      console.error('❌ Fragment shader compilation FAILED:');
+      console.error(error);
+      console.log('Shader source:', fragmentShaderSource);
+      return;
+    }
+
+    // Link program
+    this.program = gl.createProgram();
+    gl.attachShader(this.program, vertexShader);
+    gl.attachShader(this.program, fragmentShader);
+    gl.linkProgram(this.program);
+
+    if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
+      const error = gl.getProgramInfoLog(this.program);
+      console.error('❌ Program linking FAILED:');
+      console.error(error);
+      return;
+    }
+
+    console.log('✅ Shader compiled and linked successfully');
+
+    // Set up geometry
+    const positions = new Float32Array([
+      -1, -1,
+       1, -1,
+      -1,  1,
+       1,  1,
+    ]);
+
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+    const positionLocation = gl.getAttribLocation(this.program, 'a_position');
+    gl.enableVertexAttribArray(positionLocation);
+    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+  }
+
+  getCameraPosition() {
+    const { distance, theta, phi, target } = this.camera;
+    return [
+      target[0] + distance * Math.sin(phi) * Math.sin(theta),
+      target[1] + distance * Math.cos(phi),
+      target[2] + distance * Math.sin(phi) * Math.cos(theta)
+    ];
+  }
+
+  render() {
+    if (!this.program) return;
+
+    const gl = this.gl;
+    gl.useProgram(this.program);
+
+    const resolutionLocation = gl.getUniformLocation(this.program, 'u_resolution');
+    gl.uniform2f(resolutionLocation, this.canvas.width, this.canvas.height);
+
+    const timeLocation = gl.getUniformLocation(this.program, 'u_time');
+    const time = (performance.now() - this.startTime) / 1000.0;
+    gl.uniform1f(timeLocation, time);
+
+    // Camera uniforms
+    const cameraPos = this.getCameraPosition();
+    const cameraPosLocation = gl.getUniformLocation(this.program, 'u_cameraPos');
+    gl.uniform3f(cameraPosLocation, cameraPos[0], cameraPos[1], cameraPos[2]);
+
+    const cameraTargetLocation = gl.getUniformLocation(this.program, 'u_cameraTarget');
+    gl.uniform3f(cameraTargetLocation, this.camera.target[0], this.camera.target[1], this.camera.target[2]);
+
+    const groundPlaneLocation = gl.getUniformLocation(this.program, 'u_showGroundPlane');
+    gl.uniform1f(groundPlaneLocation, this.showGroundPlane ? 1.0 : 0.0);
+
+    const volumeRenderLocation = gl.getUniformLocation(this.program, 'u_volumeRender');
+    gl.uniform1f(volumeRenderLocation, this.volumeRender ? 1.0 : 0.0);
+
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  }
+}

--- a/lucid/vader_tc1.html
+++ b/lucid/vader_tc1.html
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Space Invaders Template Test – Lucid SDF</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #000;
+      color: #fff;
+      overflow: hidden;
+      height: 100vh;
+    }
+
+    .demo-container {
+      position: relative;
+      width: 100vw;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      touch-action: none;
+    }
+
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      touch-action: none;
+    }
+
+    /* Code Panel */
+    .code-panel {
+      position: fixed;
+      top: 0;
+      right: -400px;
+      width: 400px;
+      max-width: 90vw;
+      height: 100vh;
+      background: rgba(2, 6, 23, 0.95);
+      backdrop-filter: blur(20px);
+      border-left: 1px solid rgba(255, 255, 255, 0.1);
+      transition: right 0.3s ease;
+      z-index: 50;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .code-panel.open {
+      right: 0;
+    }
+
+    .code-header {
+      padding: 16px 20px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .code-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: #22d3ee;
+    }
+
+    .code-close {
+      background: none;
+      border: none;
+      color: #9ca3af;
+      font-size: 24px;
+      cursor: pointer;
+      padding: 0;
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 4px;
+      transition: all 0.2s;
+    }
+
+    .code-close:hover {
+      background: rgba(255, 255, 255, 0.1);
+      color: #fff;
+    }
+
+    .code-content {
+      padding: 20px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .code-block {
+      background: rgba(0, 0, 0, 0.4);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+
+    .code-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #9ca3af;
+      margin-bottom: 8px;
+    }
+
+    pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      color: #e5e7eb;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    /* Code Toggle Button */
+    .code-toggle {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      color: #22d3ee;
+      font-size: 20px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 60;
+      transition: all 0.3s ease;
+    }
+
+    .code-toggle:hover {
+      background: rgba(34, 211, 238, 0.2);
+      transform: scale(1.1);
+    }
+
+    /* Edit Toggle Button */
+    .edit-toggle {
+      position: fixed;
+      top: 80px;
+      right: 20px;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      color: #a78bfa;
+      font-size: 20px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 60;
+      transition: all 0.3s ease;
+    }
+
+    .edit-toggle:hover {
+      background: rgba(167, 139, 250, 0.2);
+      transform: scale(1.1);
+    }
+
+    /* Demo Title */
+    .demo-title {
+      position: fixed;
+      top: 20px;
+      left: 20px;
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(10px);
+      padding: 12px 20px;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      z-index: 60;
+    }
+
+    .demo-title h1 {
+      font-size: 18px;
+      font-weight: 700;
+      margin-bottom: 2px;
+      color: #22d3ee;
+    }
+
+    .demo-title p {
+      font-size: 12px;
+      color: #9ca3af;
+    }
+
+    /* Edit Panel */
+    .edit-panel {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.9);
+      backdrop-filter: blur(10px);
+      z-index: 100;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+
+    .edit-panel.active {
+      display: flex;
+    }
+
+    .edit-container {
+      background: rgba(2, 6, 23, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 16px;
+      padding: 24px;
+      max-width: 800px;
+      width: 100%;
+      max-height: 90vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .edit-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+
+    .edit-header h2 {
+      font-size: 18px;
+      color: #a78bfa;
+    }
+
+    .edit-textarea {
+      flex: 1;
+      background: rgba(0, 0, 0, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      padding: 16px;
+      color: #e5e7eb;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 14px;
+      line-height: 1.5;
+      resize: none;
+      margin-bottom: 16px;
+    }
+
+    .edit-textarea:focus {
+      outline: none;
+      border-color: #a78bfa;
+    }
+
+    .edit-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
+    }
+
+    .edit-button {
+      padding: 10px 20px;
+      border-radius: 8px;
+      border: none;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .edit-button.primary {
+      background: #a78bfa;
+      color: #000;
+    }
+
+    .edit-button.primary:hover {
+      background: #c4b5fd;
+    }
+
+    .edit-button.secondary {
+      background: rgba(255, 255, 255, 0.1);
+      color: #fff;
+    }
+
+    .edit-button.secondary:hover {
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    .edit-error {
+      background: rgba(239, 68, 68, 0.2);
+      border: 1px solid rgba(239, 68, 68, 0.4);
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 16px;
+      color: #fca5a5;
+      font-size: 13px;
+      display: none;
+    }
+
+    .edit-error.visible {
+      display: block;
+    }
+
+    .loading {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 18px;
+      color: #22d3ee;
+      z-index: 1000;
+    }
+  </style>
+</head>
+<body>
+  <div class="loading">Loading...</div>
+
+  <div class="demo-container">
+    <canvas id="canvas"></canvas>
+  </div>
+
+  <div class="demo-title">
+    <h1>Space Invaders (Template)</h1>
+    <p>Reusable template with 6 instances</p>
+  </div>
+
+  <button class="code-toggle" title="View Code (C)">{ }</button>
+  <button class="edit-toggle" title="Edit DSL (E)">✎</button>
+
+  <!-- Code Panel -->
+  <div id="codePanel" class="code-panel">
+    <div class="code-header">
+      <div class="code-title">Code View</div>
+      <button class="code-close">×</button>
+    </div>
+    <div class="code-content">
+      <div class="code-block">
+        <div class="code-label">DSL Source</div>
+        <pre id="dslCode"></pre>
+      </div>
+      <div class="code-block">
+        <div class="code-label">Generated GLSL</div>
+        <pre id="glslCode"></pre>
+      </div>
+      <div class="code-block">
+        <div class="code-label">Scene Graph IR</div>
+        <pre id="sceneGraphCode"></pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- Edit Panel -->
+  <div id="editPanel" class="edit-panel">
+    <div class="edit-container">
+      <div class="edit-header">
+        <h2>Edit DSL</h2>
+      </div>
+      <div id="editError" class="edit-error"></div>
+      <textarea id="editTextarea" class="edit-textarea" spellcheck="false"></textarea>
+      <div class="edit-actions">
+        <button id="editCancel" class="edit-button secondary">Cancel (ESC)</button>
+        <button id="editApply" class="edit-button primary">Apply Changes</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { SimpleRaymarcher } from './ui/raymarcher.js';
+    import { DemoViewer } from './ui/demo-viewer.js';
+
+    // Space Invaders template demo DSL
+    const invaderDsl = `# Define a reusable invader template
+template invader(x, y, color):
+  body = box(size=[0.5, 0.4, 0.3], center=[x, y, 0], color=color)
+  eye1 = sphere(r=0.1, center=[x-0.12, y+0.08, 0.2], color=[0.0, 0.0, 0.0])
+  eye2 = sphere(r=0.1, center=[x+0.12, y+0.08, 0.2], color=[0.0, 0.0, 0.0])
+  temp = subtract(a=body, b=eye1)
+  return subtract(a=temp, b=eye2)
+
+# Create invader instances - template generates GLSL function
+i1 = invader(-1.5, 0.6, [0.0, 1.0, 0.5])
+i2 = invader(0.0, 0.6, [0.0, 1.0, 0.5])
+i3 = invader(1.5, 0.6, [0.0, 1.0, 0.5])
+i4 = invader(-1.5, -0.6, [1.0, 0.3, 0.8])
+i5 = invader(0.0, -0.6, [1.0, 0.3, 0.8])
+i6 = invader(1.5, -0.6, [1.0, 0.3, 0.8])
+
+# Combine into formation
+formation = union(i1, i2, i3, i4, i5, i6)
+out = formation`;
+
+    // Initialize
+    const canvas = document.getElementById('canvas');
+    const renderer = new SimpleRaymarcher(canvas);
+    const viewer = new DemoViewer({ renderer });
+
+    // Load the invader demo
+    viewer.loadDsl(invaderDsl);
+
+    // Render loop
+    function renderLoop() {
+      renderer.render();
+      requestAnimationFrame(renderLoop);
+    }
+    renderLoop();
+
+    // Hide loading
+    document.querySelector('.loading').style.display = 'none';
+
+    console.log('✅ Space Invaders template demo loaded');
+    console.log('📝 Press C to view code, E to edit DSL');
+  </script>
+</body>
+</html>

--- a/vader-sdf-sample.md
+++ b/vader-sdf-sample.md
@@ -1,0 +1,58 @@
+# Space Invader SDF - Pixel-Perfect GLSL Implementation
+
+This GLSL code renders a classic Space Invader sprite using signed distance fields (SDFs). The invader is constructed from 13 rectangular regions mapped to an 11×8 pixel grid.
+
+## Key Features
+
+- **Pixel-perfect reproduction** of the iconic 8-bit sprite
+- **Coordinate space mapping** from normalized [-1,1]×[-1,1] to discrete [0,11]×[0,8] pixel grid
+- **Efficient rectangle packing** using a preprocessor macro for clean, maintainable code
+- **True SDF representation** enabling smooth scaling, outlining, and distance-based effects
+
+## GLSL Implementation
+
+```glsl
+float boxSDF(vec2 p, vec2 center, vec2 halfSize) {
+    vec2 d = abs(p - center) - halfSize;
+    vec2 dmax = max(d, 0.0);
+    return length(dmax) + min(max(d.x, d.y), 0.0);
+}
+
+float invaderSDF(vec2 p) {
+    // Map p from [-1,1]x[-1,1] to [0,11]x[0,8]
+    vec2 pix = vec2(
+        (p.x * 0.5 + 0.5) * 11.0,
+        (p.y * 0.5 + 0.5) *  8.0
+    );
+
+    float d = 1e9;
+
+    // Helper macro: rectangle [x0,x1) x [y0,y1)
+    #define RECT(x0,x1,y0,y1) \
+        d = min(d, boxSDF(pix, vec2((x0 + x1)*0.5, (y0 + y1)*0.5), vec2((x1 - x0)*0.5, (y1 - y0)*0.5)));
+
+    RECT(2.0,3.0, 0.0,1.0);  RECT(8.0,9.0, 0.0,1.0);
+    RECT(3.0,4.0, 1.0,2.0);  RECT(6.0,7.0, 1.0,2.0);
+    RECT(2.0,9.0, 2.0,3.0);
+    RECT(1.0,3.0, 3.0,4.0);  RECT(4.0,7.0, 3.0,4.0);  RECT(8.0,10.0, 3.0,4.0);
+    RECT(0.0,11.0,4.0,5.0);
+    RECT(0.0,1.0, 5.0,6.0);  RECT(2.0,9.0, 5.0,6.0);  RECT(10.0,11.0,5.0,6.0);
+    RECT(0.0,1.0, 6.0,7.0);  RECT(2.0,3.0, 6.0,7.0);  RECT(8.0,9.0, 6.0,7.0);  RECT(10.0,11.0,6.0,7.0);
+    RECT(3.0,5.0, 7.0,8.0);  RECT(6.0,8.0, 7.0,8.0);
+
+    #undef RECT
+
+    return d;
+}
+```
+
+## Usage Notes
+
+This SDF can be:
+- **Rendered directly** with `step(d, 0.0)` for sharp edges
+- **Smoothed** with `smoothstep()` for anti-aliased rendering
+- **Outlined** by checking distance thresholds
+- **Animated** by passing transformed coordinates (rotation, scaling, translation)
+- **Combined** with other SDFs using union/subtract/intersect operations
+
+The function returns the signed distance in pixel space, where negative values are inside the shape and positive values are outside.


### PR DESCRIPTION
Created reusable modules to eliminate code duplication:
- lucid/ui/raymarcher.js - SimpleRaymarcher WebGL renderer
- lucid/ui/demo-viewer.js - Code viewing and DSL editing UI

New minimal test page:
- lucid/vader_tc1.html - Dedicated Space Invaders template demo
  * Fullscreen rendering with orbit camera
  * Code viewing (DSL, GLSL, scene graph IR)
  * Live DSL editing with error handling
  * Keyboard shortcuts (C for code, E for edit)

Documentation:
- vader-sdf-sample.md - Pixel-perfect invader SDF implementation in GLSL with 11x8 grid mapping and rectangle packing
- see also https://www.shadertoy.com/view/WcdyWl

This enables testing individual demos without the multi-demo navigation overhead of demos.html.