### PR TITLE
Fix swipe/arrow navigation to traverse ALL demos

### DIFF
--- a/lucid/index.html
+++ b/lucid/index.html
@@ -514,52 +514,36 @@
       background: var(--border);
     }
 
-    .menu-item.has-submenu::after {
-      content: '▶';
-      font-size: 0.6rem;
-      opacity: 0.6;
-    }
-
     .menu-divider {
       height: 1px;
       background: var(--border);
       margin: 0.5rem 0;
     }
 
-    /* Submenu */
+    /* Submenu - always inline to avoid overflow clipping */
     .submenu {
-      position: absolute;
-      left: 100%;
-      top: 0;
-      background: var(--panel-bg);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 0.5rem;
-      min-width: 200px;
-      max-height: 400px;
-      overflow-y: auto;
       display: none;
+      margin-top: 0.5rem;
+      margin-left: 1rem;
+      border-left: 2px solid var(--border);
+      padding-left: 0.5rem;
+      max-height: 300px;
+      overflow-y: auto;
     }
 
-    .menu-item:hover > .submenu {
+    .menu-item.has-submenu::after {
+      content: '▼';
+      font-size: 0.6rem;
+      opacity: 0.6;
+      transition: transform 0.2s;
+    }
+
+    .menu-item.submenu-open::after {
+      transform: rotate(180deg);
+    }
+
+    .menu-item.submenu-open > .submenu {
       display: block;
-    }
-
-    @media (max-width: 768px) {
-      .submenu {
-        position: static;
-        margin-top: 0.5rem;
-        margin-left: 1rem;
-        border: none;
-        border-left: 2px solid var(--border);
-        border-radius: 0;
-      }
-      .menu-item.has-submenu::after {
-        content: '▼';
-      }
-      .menu-item.submenu-open > .submenu {
-        display: block;
-      }
     }
 
     .submenu-item {


### PR DESCRIPTION
- Build flat allScenePaths[] from TOC at init
- Track currentSceneIndex for position in full list
- Add navigateToNextScene() and navigateToPrevScene()
- Swipe and arrow keys now lazy-load and switch through all scenes
- No longer limited to already-loaded demos array