### PR TITLE
Add keyboard navigation for hamburger menu

### DIFF
--- a/lucid/index.html
+++ b/lucid/index.html
@@ -631,6 +631,17 @@
       pointer-events: none;
     }
 
+    /* Keyboard focus for menu navigation */
+    .menu-focus {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+      background: var(--border);
+    }
+
+    .submenu-category-header.menu-focus {
+      background: var(--border);
+    }
+
     /* Legacy - keep for compatibility */
     .template-gallery {
       display: none;
@@ -3319,6 +3330,119 @@
     }
 
     // ============================================
+    // MENU KEYBOARD NAVIGATION
+    // ============================================
+    let menuFocusIndex = -1;  // Current focused item in menu navigation
+
+    function clearMenuFocus() {
+      mainMenu?.querySelectorAll('.menu-focus').forEach(el => el.classList.remove('menu-focus'));
+    }
+
+    function getMenuNavigableItems() {
+      // Get all navigable items in current menu state
+      const items = [];
+      const menuDemos = $('menu-demos');
+      const isSubmenuOpen = menuDemos?.classList.contains('submenu-open');
+
+      // Main menu items (excluding dividers)
+      mainMenu.querySelectorAll(':scope > .menu-item').forEach(item => {
+        items.push({ el: item, type: 'menu-item', id: item.id });
+      });
+
+      // If demos submenu is open, add its items
+      if (isSubmenuOpen) {
+        const submenu = $('demos-submenu');
+        // Add category headers and scene items
+        submenu.querySelectorAll('.submenu-category').forEach(cat => {
+          const header = cat.querySelector('.submenu-category-header');
+          if (header) {
+            items.push({ el: header, type: 'category', category: cat });
+          }
+          // If category is open, add its scenes
+          if (cat.classList.contains('open')) {
+            cat.querySelectorAll('.submenu-scene').forEach(scene => {
+              items.push({ el: scene, type: 'scene' });
+            });
+          }
+        });
+      }
+
+      return items;
+    }
+
+    function navigateMenu(key) {
+      const items = getMenuNavigableItems();
+      if (items.length === 0) return;
+
+      // Find current focus
+      const currentEl = mainMenu.querySelector('.menu-focus');
+      let currentIndex = items.findIndex(item => item.el === currentEl);
+      if (currentIndex === -1) currentIndex = -1;
+
+      // Remove current focus
+      mainMenu.querySelectorAll('.menu-focus').forEach(el => el.classList.remove('menu-focus'));
+
+      if (key === 'ArrowDown') {
+        currentIndex = (currentIndex + 1) % items.length;
+      } else if (key === 'ArrowUp') {
+        currentIndex = currentIndex <= 0 ? items.length - 1 : currentIndex - 1;
+      } else if (key === 'ArrowRight') {
+        const item = items[currentIndex];
+        if (item?.type === 'menu-item' && item.id === 'menu-demos') {
+          // Expand demos submenu
+          $('menu-demos').classList.add('submenu-open');
+          // Move focus to first category
+          const newItems = getMenuNavigableItems();
+          const firstCat = newItems.findIndex(i => i.type === 'category');
+          if (firstCat !== -1) currentIndex = firstCat;
+        } else if (item?.type === 'category' && !item.category.classList.contains('open')) {
+          // Expand category
+          item.category.classList.add('open');
+          // Move focus to first scene in category
+          const newItems = getMenuNavigableItems();
+          const firstScene = newItems.findIndex((i, idx) => idx > currentIndex && i.type === 'scene');
+          if (firstScene !== -1) currentIndex = firstScene;
+        }
+        // Re-fetch items after potential expansion
+        const newItems = getMenuNavigableItems();
+        if (currentIndex >= newItems.length) currentIndex = newItems.length - 1;
+      } else if (key === 'ArrowLeft') {
+        const item = items[currentIndex];
+        if (item?.type === 'scene') {
+          // Find parent category and collapse it, move focus to category header
+          const parentCat = item.el.closest('.submenu-category');
+          if (parentCat) {
+            parentCat.classList.remove('open');
+            const newItems = getMenuNavigableItems();
+            currentIndex = newItems.findIndex(i => i.category === parentCat);
+          }
+        } else if (item?.type === 'category') {
+          // Close submenu, move focus back to Demos menu item
+          $('menu-demos').classList.remove('submenu-open');
+          const newItems = getMenuNavigableItems();
+          currentIndex = newItems.findIndex(i => i.id === 'menu-demos');
+        }
+      } else if (key === 'Enter' || key === ' ') {
+        const item = items[currentIndex];
+        if (item) {
+          item.el.click();
+          // Don't close menu for category expansion, do close for scene/action selection
+          if (item.type === 'scene' || (item.type === 'menu-item' && item.id !== 'menu-demos')) {
+            // Menu will close via click handler for actions
+          }
+        }
+        return;
+      }
+
+      // Apply new focus
+      const newItems = getMenuNavigableItems();
+      if (currentIndex >= 0 && currentIndex < newItems.length) {
+        newItems[currentIndex].el.classList.add('menu-focus');
+        newItems[currentIndex].el.scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    // ============================================
     // EVENT LISTENERS
     // ============================================
     function setupEventListeners() {
@@ -3330,6 +3454,24 @@
       // Keyboard navigation
       document.addEventListener('keydown', (e) => {
         if (e.target === jsonEditor) return;
+
+        // Menu keyboard navigation when menu is open
+        if (menuOpen) {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            menuOpen = false;
+            mainMenu.classList.remove('open');
+            $('btn-menu').classList.remove('active');
+            $('menu-demos')?.classList.remove('submenu-open');
+            clearMenuFocus();
+            return;
+          }
+          if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', ' '].includes(e.key)) {
+            e.preventDefault();
+            navigateMenu(e.key);
+            return;
+          }
+        }
 
         // When tree tab is active, arrow keys navigate editable values
         if (editorOpen && activeTab === 'tree' && (e.key === 'ArrowRight' || e.key === 'ArrowLeft')) {
@@ -3570,9 +3712,10 @@
         mainMenu.classList.toggle('open', menuOpen);
         $('btn-menu').classList.toggle('active', menuOpen);
         lastMenuInteraction = Date.now(); // Guard against immediate close on mobile
-        // Close submenu when menu closes
+        // Close submenu and clear keyboard focus when menu closes
         if (!menuOpen) {
           $('menu-demos').classList.remove('submenu-open');
+          clearMenuFocus();
         }
       });
 
@@ -3814,6 +3957,7 @@
           menuOpen = false;
           mainMenu.classList.remove('open');
           $('menu-demos')?.classList.remove('submenu-open');
+          clearMenuFocus();
         }
       });
       } catch (e) { console.error('setupEventListeners error:', e); }


### PR DESCRIPTION
- M key already opens menu (was existing)
- Arrow Up/Down: Navigate between menu items
- Arrow Right: Expand demos submenu or category
- Arrow Left: Collapse category or close submenu
- Enter/Space: Activate focused item
- Escape: Close menu

Navigation flows through:
1. Main menu items (Debug, Editor, Tree, etc.)
2. Demos submenu when expanded
3. Category headers within demos
4. Scene items within expanded categories

Visual feedback via .menu-focus class with accent outline.