### PR TITLE
Fix GLSL variable redeclaration in repeat with exposeId

### DIFF
--- a/lucid/core/json-codegen.js
+++ b/lucid/core/json-codegen.js
@@ -773,8 +773,8 @@ function generateRepeat(node, ctx) {
   vec3 q = ${p};
   // Calculate instance ID from grid cell before domain folding
   // Use safePeriodVec to avoid division by zero on non-repeating axes
-  vec3 cellId = floor(q / ${safePeriodVec});
-  float ${exposeId} = dot(cellId, vec3(1.0, 157.0, 113.0));
+  vec3 _gridCell = floor(q / ${safePeriodVec});
+  float ${exposeId} = dot(_gridCell, vec3(1.0, 157.0, 113.0));
 ${repeatCode}  return ${childExpr.replace(/\bp\b/g, 'q')};
 }`;
 


### PR DESCRIPTION
When exposeId was set to "cellId", the codegen produced:
  vec3 cellId = floor(...)
  float cellId = dot(cellId, ...)  // Redeclaration error!

Renamed internal temporary to _gridCell to avoid collision with any user-specified exposeId value.