### PR TITLE
Tune demo defaults and enhance visual effects

### DIFF
--- a/lucid/splats/demo.html
+++ b/lucid/splats/demo.html
@@ -386,8 +386,8 @@
         <div class="control-row">
           <label>Sampling Mode</label>
           <select id="samplingMode" style="width: 110px; padding: 4px;">
-            <option value="3dgs" selected>3DGS (Gemini)</option>
-            <option value="gpu">GPU (WebGL2)</option>
+            <option value="3dgs">3DGS (Gemini)</option>
+            <option value="gpu" selected>GPU (WebGL2)</option>
             <option value="cpu">CPU (Legacy)</option>
           </select>
         </div>
@@ -398,18 +398,18 @@
         </div>
         <div class="control-row" id="directionsRow">
           <label>Directions</label>
-          <input type="range" id="sampleDirs" min="6" max="26" step="1" value="6">
-          <span class="value" id="sampleDirsVal">6</span>
+          <input type="range" id="sampleDirs" min="6" max="26" step="1" value="10">
+          <span class="value" id="sampleDirsVal">10</span>
         </div>
         <div class="control-row">
           <label>Splat Count</label>
-          <input type="range" id="targetSplats" min="500" max="50000" step="500" value="2000">
-          <span class="value" id="targetSplatsVal">2k</span>
+          <input type="range" id="targetSplats" min="500" max="50000" step="500" value="50000">
+          <span class="value" id="targetSplatsVal">50k</span>
         </div>
         <div class="control-row">
           <label>Splat Size</label>
-          <input type="range" id="splatScale" min="0.3" max="5.0" step="0.1" value="2.5">
-          <span class="value" id="splatScaleVal">2.5x</span>
+          <input type="range" id="splatScale" min="0.3" max="5.0" step="0.1" value="0.3">
+          <span class="value" id="splatScaleVal">0.3x</span>
         </div>
         <button id="goBtn" class="primary">Load &amp; Convert</button>
         <div class="progress-bar"><div class="progress-fill" id="progressFill" style="width:0%"></div></div>

--- a/lucid/splats/render/renderer.js
+++ b/lucid/splats/render/renderer.js
@@ -593,10 +593,10 @@ void main() {
         pos.y += sin(u_time + dist * 3.0) * 0.1;
     }
 
-    // Noise field effect - jittery displacement
+    // Noise field effect - slow gentle displacement
     if (u_fxNoise > 0.5) {
-        vec3 n = noise3(pos * 5.0 + u_time * 0.5);
-        pos += n * 0.05;
+        vec3 n = noise3(pos * 3.0 + u_time * 0.08);  // Much slower, gentler
+        pos += n * 0.03;
     }
 
     vec4 worldPos = a_instanceTransform * vec4(pos, 1.0);
@@ -724,19 +724,40 @@ void main() {
     // Early discard for nearly transparent
     if (alpha < 0.004) discard;
 
-    // Color with subtle ambient boost
-    vec3 color = v_color * 1.1 + vec3(0.05);
+    // Base color with enhanced saturation
+    vec3 color = v_color;
 
-    // Dynamic lighting effect - rim glow and color shifting
+    // Boost color saturation and vibrancy
+    float luminance = dot(color, vec3(0.299, 0.587, 0.114));
+    color = mix(vec3(luminance), color, 1.4);  // 40% more saturated
+    color = color * 1.15 + vec3(0.03);  // Slight boost + ambient
+
+    // Dynamic lighting effect - enhanced with multiple light contributions
     if (u_fxLighting > 0.5) {
-        // Use the gaussian falloff for rim lighting
-        float rim = 1.0 - exp(exponent * 0.3);
-        vec3 rimColor = vec3(0.3, 0.5, 1.0) * rim * 0.4;
-        color += rimColor;
+        // Rim glow using gaussian falloff
+        float rim = 1.0 - exp(exponent * 0.25);
 
-        // Subtle color shift based on time
-        float shift = sin(u_time * 0.5) * 0.5 + 0.5;
-        color = mix(color, color.gbr, shift * 0.1);
+        // Orbiting key light (warm)
+        float keyAngle = u_time * 0.3;
+        vec3 keyDir = normalize(vec3(cos(keyAngle), 0.5, sin(keyAngle)));
+        float keyLight = max(0.0, dot(normalize(v_coord.xyy), keyDir)) * 0.5;
+        vec3 keyColor = vec3(1.0, 0.9, 0.7) * keyLight;
+
+        // Static fill light (cool)
+        vec3 fillColor = vec3(0.4, 0.6, 1.0) * rim * 0.35;
+
+        // Color-dependent rim (use splat's own color for glow)
+        vec3 selfGlow = v_color * rim * 0.25;
+
+        color += keyColor + fillColor + selfGlow;
+
+        // Subtle hue rotation over time
+        float shift = sin(u_time * 0.4) * 0.5 + 0.5;
+        color = mix(color, color.gbr, shift * 0.08);
+
+        // Add subtle specular highlights
+        float spec = pow(rim, 3.0) * 0.3;
+        color += vec3(spec);
     }
 
     color = clamp(color, 0.0, 1.0);


### PR DESCRIPTION
- Default to GPU (WebGL2) mode instead of 3DGS
- Set directions=10, splat count=50k, splat size=0.3x (minimum)
- Slow down noise field effect (0.08x speed, gentler displacement)
- Enhanced dynamic lighting:
  - Orbiting warm key light
  - Cool fill light using rim glow
  - Color-dependent self-glow from splat colors
  - Subtle specular highlights
  - Increased color saturation (+40%)