### PR TITLE
Fix broken image URLs and add CORS error handling

### DIFF
--- a/kgx/public/testbed/demo-data.ttl
+++ b/kgx/public/testbed/demo-data.ttl
@@ -7,8 +7,8 @@
 
 <http://demo.imagesnippets.com/image/eiffel-tower> a schema:ImageObject ;
     schema:name "Eiffel Tower at Sunset"@en ;
-    schema:thumbnail <https://images.unsplash.com/photo-1543349689-9a4d426bee8e?w=320&h=213&fit=crop> ;
-    schema:contentUrl <https://images.unsplash.com/photo-1543349689-9a4d426bee8e?w=800> ;
+    schema:thumbnail <https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=320&h=213&fit=crop> ;
+    schema:contentUrl <https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=800> ;
     lio:depicts dbr:Eiffel_Tower ;
     lio:depicts dbr:Paris .
 
@@ -89,8 +89,8 @@ dbr:Sydney rdfs:label "Sydney"@en .
 
 <http://demo.imagesnippets.com/image/red-fox> a schema:ImageObject ;
     schema:name "Red Fox"@en ;
-    schema:thumbnail <https://images.unsplash.com/photo-1474511320723-9a56873571b7?w=320&h=213&fit=crop> ;
-    schema:contentUrl <https://images.unsplash.com/photo-1474511320723-9a56873571b7?w=800> ;
+    schema:thumbnail <https://images.unsplash.com/photo-1516934024742-b461fba47600?w=320&h=213&fit=crop> ;
+    schema:contentUrl <https://images.unsplash.com/photo-1516934024742-b461fba47600?w=800> ;
     lio:depicts dbr:Red_fox ;
     lio:depicts dbr:Wildlife .
 

--- a/kgx/public/testbed/index.html
+++ b/kgx/public/testbed/index.html
@@ -440,12 +440,29 @@
             const start = performance.now();
 
             try {
-                // Fetch large dataset
+                // Fetch large dataset via SPARQL endpoint
                 const query = encodeURIComponent('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 50000');
-                const res = await fetch(`${ENDPOINT}?query=${query}`, { headers: { 'Accept': 'text/turtle' } });
-                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const url = `${ENDPOINT}?query=${query}`;
+                console.log('Fetching from:', url);
+
+                const res = await fetch(url, {
+                    headers: { 'Accept': 'text/turtle' },
+                    mode: 'cors'
+                });
+
+                console.log('Response status:', res.status, res.statusText);
+                console.log('Response headers:', [...res.headers.entries()]);
+
+                if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
 
                 const turtle = await res.text();
+                console.log('Received turtle data, length:', turtle.length);
+                console.log('First 500 chars:', turtle.substring(0, 500));
+
+                if (!turtle || turtle.trim().length === 0) {
+                    throw new Error('Empty response from server');
+                }
+
                 store.load(turtle, { format: 'text/turtle' });
 
                 loadTimeEl.textContent = ((performance.now() - start) / 1000).toFixed(1) + 's';
@@ -453,7 +470,13 @@
                 setStatus('All data loaded! Search or browse images.', 'ready');
                 showAllImages();
             } catch (e) {
-                setStatus('Error: ' + e.message, 'error');
+                console.error('Load all data error:', e);
+                // Check if it's a CORS error
+                if (e.message.includes('Failed to fetch') || e.name === 'TypeError') {
+                    setStatus('CORS blocked: ImageSnippets endpoint may not allow browser access. Use Demo Data instead.', 'error');
+                } else {
+                    setStatus('Error: ' + e.message, 'error');
+                }
             }
         }
 


### PR DESCRIPTION
- Replace broken Unsplash URLs for Eiffel Tower and Red Fox with verified working images
- Add detailed console logging for endpoint fetch debugging
- Add CORS-specific error message when browser access is blocked
- Improve error handling for empty responses from server