### PR TITLE
Add imported dragon scene mapped from Graph-GLSL format

### DIFF
--- a/lucid/scenes/creatures/dragon-imported.json
+++ b/lucid/scenes/creatures/dragon-imported.json
@@ -1,0 +1,459 @@
+{
+  "title": "Imported Dragon",
+  "subtitle": "Raymarched dragon mapped from Graph-GLSL format",
+  "version": "1.0",
+  "quality": "high",
+  "notes": "Dragon imported from Graph→GLSL format. Original features: organic body with smooth blending, detailed head with skull/snout/jaw, articulated neck, four legs, curving tail with ridges, and membrane wings.",
+  "camera": {
+    "distance": 9,
+    "phi": 0.25,
+    "theta": 0.5,
+    "target": [0, 0, 0]
+  },
+  "root": {
+    "type": "union",
+    "children": [
+      {
+        "notes": "BODY - Main torso with chest and belly blended organically",
+        "type": "material",
+        "params": {
+          "color": [0.18, 0.34, 0.26],
+          "roughness": 0.05
+        },
+        "child": {
+          "type": "smoothUnion",
+          "k": 0.15,
+          "children": [
+            {
+              "notes": "Torso - Main body ellipsoid",
+              "type": "ellipsoid",
+              "params": { "radii": [0.74, 0.68, 1.28] }
+            },
+            {
+              "notes": "Chest - Forward upper body",
+              "type": "ellipsoid",
+              "params": { "radii": [0.6, 0.51, 0.64] },
+              "transform": { "translate": [0, -0.23, 0.64] }
+            },
+            {
+              "notes": "Belly - Lower rear section",
+              "type": "ellipsoid",
+              "params": { "radii": [0.64, 0.43, 0.84] },
+              "transform": { "translate": [0, -0.45, -0.24] }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "NECK - Three segments connecting body to head",
+        "type": "material",
+        "params": {
+          "color": [0.18, 0.357, 0.26],
+          "roughness": 0.05
+        },
+        "child": {
+          "type": "smoothUnion",
+          "k": 0.1,
+          "children": [
+            {
+              "notes": "Neck base - connects to body",
+              "type": "capsule",
+              "params": { "h": 0.2, "r": 0.26 },
+              "transform": { "translate": [0, -0.25, 2.1], "rotate": [15, 0, 0] }
+            },
+            {
+              "notes": "Neck middle",
+              "type": "capsule",
+              "params": { "h": 0.25, "r": 0.28 },
+              "transform": { "translate": [0, -0.35, 1.65], "rotate": [10, 0, 0] }
+            },
+            {
+              "notes": "Neck lower - connects to torso",
+              "type": "capsule",
+              "params": { "h": 0.25, "r": 0.3 },
+              "transform": { "translate": [0, -0.45, 1.15], "rotate": [5, 0, 0] }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "HEAD - Detailed dragon skull with snout, jaw, brow and crest",
+        "type": "material",
+        "params": {
+          "color": [0.198, 0.374, 0.286],
+          "roughness": 0.05
+        },
+        "child": {
+          "type": "smoothUnion",
+          "k": 0.08,
+          "children": [
+            {
+              "notes": "Skull - Main cranium",
+              "type": "ellipsoid",
+              "params": { "radii": [0.37, 0.3, 0.5] },
+              "transform": { "translate": [0, 0, 2.8] }
+            },
+            {
+              "notes": "Snout - Forward projection",
+              "type": "ellipsoid",
+              "params": { "radii": [0.22, 0.15, 0.33] },
+              "transform": { "translate": [0, -0.05, 3.22] }
+            },
+            {
+              "notes": "Lower jaw",
+              "type": "ellipsoid",
+              "params": { "radii": [0.19, 0.08, 0.29] },
+              "transform": { "translate": [0, -0.17, 3.11] }
+            },
+            {
+              "notes": "Cheek area",
+              "type": "ellipsoid",
+              "params": { "radii": [0.27, 0.11, 0.22] },
+              "transform": { "translate": [0, 0.03, 3.02] }
+            },
+            {
+              "notes": "Brow ridge",
+              "type": "ellipsoid",
+              "params": { "radii": [0.22, 0.07, 0.2] },
+              "transform": { "translate": [0, 0.15, 2.98] }
+            },
+            {
+              "notes": "Crest - Top of head",
+              "type": "ellipsoid",
+              "params": { "radii": [0.1, 0.13, 0.24] },
+              "transform": { "translate": [0, 0.23, 2.78] }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "GLOWING EYES - Mirrored pair",
+        "type": "material",
+        "params": {
+          "color": [1.0, 0.6, 0.1],
+          "emit": 3.0
+        },
+        "child": {
+          "type": "mirror",
+          "axis": "x",
+          "child": {
+            "type": "sphere",
+            "params": { "r": 0.06 },
+            "transform": { "translate": [0.15, 0.08, 3.1] }
+          }
+        }
+      },
+      {
+        "notes": "LEGS - Four limbs with organic blending",
+        "type": "material",
+        "params": {
+          "color": [0.171, 0.323, 0.247],
+          "roughness": 0.06
+        },
+        "child": {
+          "type": "smoothUnion",
+          "k": 0.1,
+          "children": [
+            {
+              "notes": "Front legs (mirrored)",
+              "type": "mirror",
+              "axis": "x",
+              "child": {
+                "type": "capsule",
+                "params": { "h": 0.41, "r": 0.17 },
+                "transform": { "translate": [0.44, -1.01, 0.54], "rotate": [5, 0, 10] }
+              }
+            },
+            {
+              "notes": "Back legs (mirrored) - larger",
+              "type": "mirror",
+              "axis": "x",
+              "child": {
+                "type": "capsule",
+                "params": { "h": 0.46, "r": 0.23 },
+                "transform": { "translate": [0.49, -1.06, -0.79], "rotate": [8, 0, 15] }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "TAIL - Curving segmented tail with tip barb",
+        "type": "material",
+        "params": {
+          "color": [0.171, 0.34, 0.247],
+          "roughness": 0.055
+        },
+        "child": {
+          "type": "smoothUnion",
+          "k": 0.1,
+          "children": [
+            {
+              "notes": "Tail base segment",
+              "type": "capsule",
+              "params": { "h": 0.35, "r": 0.27 },
+              "transform": { "translate": [0, -0.25, -1.85], "rotate": [-10, 0, 0] }
+            },
+            {
+              "notes": "Tail mid segment",
+              "type": "capsule",
+              "params": { "h": 0.3, "r": 0.21 },
+              "transform": { "translate": [0.1, -0.25, -2.5], "rotate": [-8, 10, 0] }
+            },
+            {
+              "notes": "Tail upper segment",
+              "type": "capsule",
+              "params": { "h": 0.25, "r": 0.16 },
+              "transform": { "translate": [0.3, -0.1, -3.05], "rotate": [-5, 15, 0] }
+            },
+            {
+              "notes": "Tail tip segment",
+              "type": "capsule",
+              "params": { "h": 0.2, "r": 0.11 },
+              "transform": { "translate": [0.45, 0.175, -3.5], "rotate": [10, 20, 0] }
+            },
+            {
+              "notes": "Tail barb/spade",
+              "type": "cone",
+              "params": { "h": 0.24, "r": 0.08 },
+              "transform": { "translate": [0.56, 0.22, -3.75], "rotate": [20, 0, 0] }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "TAIL RIDGES - Spiky ridges along the tail",
+        "type": "material",
+        "params": {
+          "color": [0.15, 0.28, 0.2],
+          "roughness": 0.04
+        },
+        "child": {
+          "type": "union",
+          "children": [
+            {
+              "type": "cone",
+              "params": { "h": 0.16, "r": 0.04 },
+              "transform": { "translate": [0, 0.02, -2.0], "rotate": [160, 0, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.16, "r": 0.04 },
+              "transform": { "translate": [0.05, 0.0, -2.28], "rotate": [155, 5, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.16, "r": 0.04 },
+              "transform": { "translate": [0.12, 0.0, -2.56], "rotate": [150, 10, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.16, "r": 0.04 },
+              "transform": { "translate": [0.2, 0.02, -2.84], "rotate": [145, 12, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.16, "r": 0.04 },
+              "transform": { "translate": [0.3, 0.06, -3.12], "rotate": [140, 15, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.14, "r": 0.035 },
+              "transform": { "translate": [0.4, 0.12, -3.4], "rotate": [135, 18, 0] }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "WINGS - Membrane wings with bone structure (mirrored)",
+        "type": "material",
+        "params": {
+          "color": [0.16, 0.32, 0.36],
+          "roughness": 0.04
+        },
+        "child": {
+          "type": "mirror",
+          "axis": "x",
+          "child": {
+            "type": "smoothUnion",
+            "k": 0.05,
+            "children": [
+              {
+                "notes": "Wing bone 1 - Inner arm",
+                "type": "capsule",
+                "params": { "h": 0.55, "r": 0.08 },
+                "transform": { "translate": [0.75, 0.18, -0.05], "rotate": [10, -50, -15] }
+              },
+              {
+                "notes": "Wing bone 2 - Outer arm",
+                "type": "capsule",
+                "params": { "h": 0.4, "r": 0.06 },
+                "transform": { "translate": [1.5, 0.14, -0.5], "rotate": [5, -40, -10] }
+              },
+              {
+                "notes": "Wing bone 3 - Lower strut",
+                "type": "capsule",
+                "params": { "h": 0.45, "r": 0.05 },
+                "transform": { "translate": [1.31, 0.06, -0.5], "rotate": [-5, -55, -5] }
+              },
+              {
+                "notes": "Wing membrane panel 1",
+                "type": "box",
+                "params": { "size": [0.5, 0.015, 0.35] },
+                "transform": { "translate": [1.0, 0.12, -0.25], "rotate": [5, -35, -8] }
+              },
+              {
+                "notes": "Wing membrane panel 2",
+                "type": "box",
+                "params": { "size": [0.45, 0.012, 0.3] },
+                "transform": { "translate": [1.4, 0.1, -0.55], "rotate": [3, -45, -5] }
+              },
+              {
+                "notes": "Wing membrane panel 3",
+                "type": "box",
+                "params": { "size": [0.35, 0.01, 0.25] },
+                "transform": { "translate": [1.65, 0.06, -0.8], "rotate": [0, -50, -3] }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "notes": "HEAD HORNS - Two curved horns on head (mirrored)",
+        "type": "material",
+        "params": {
+          "color": [0.25, 0.2, 0.15],
+          "roughness": 0.3
+        },
+        "child": {
+          "type": "mirror",
+          "axis": "x",
+          "child": {
+            "type": "union",
+            "children": [
+              {
+                "notes": "Main horn",
+                "type": "cone",
+                "params": { "h": 0.35, "r": 0.06 },
+                "transform": { "translate": [0.2, 0.35, 2.65], "rotate": [140, 20, 0] }
+              },
+              {
+                "notes": "Secondary horn",
+                "type": "cone",
+                "params": { "h": 0.2, "r": 0.04 },
+                "transform": { "translate": [0.28, 0.25, 2.55], "rotate": [150, 30, 0] }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "notes": "SPINE RIDGE - Spikes along the back",
+        "type": "material",
+        "params": {
+          "color": [0.15, 0.3, 0.22],
+          "roughness": 0.04
+        },
+        "child": {
+          "type": "union",
+          "children": [
+            {
+              "type": "cone",
+              "params": { "h": 0.2, "r": 0.04 },
+              "transform": { "translate": [0, 0.7, 0.8], "rotate": [165, 0, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.22, "r": 0.045 },
+              "transform": { "translate": [0, 0.72, 0.4], "rotate": [170, 0, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.24, "r": 0.05 },
+              "transform": { "translate": [0, 0.7, 0.0], "rotate": [175, 0, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.22, "r": 0.045 },
+              "transform": { "translate": [0, 0.65, -0.4], "rotate": [172, 0, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.2, "r": 0.04 },
+              "transform": { "translate": [0, 0.55, -0.8], "rotate": [168, 0, 0] }
+            },
+            {
+              "type": "cone",
+              "params": { "h": 0.18, "r": 0.035 },
+              "transform": { "translate": [0, 0.4, -1.2], "rotate": [165, 0, 0] }
+            }
+          ]
+        }
+      },
+      {
+        "notes": "FOOT CLAWS (front legs)",
+        "type": "material",
+        "params": {
+          "color": [0.2, 0.15, 0.1],
+          "roughness": 0.2
+        },
+        "child": {
+          "type": "mirror",
+          "axis": "x",
+          "child": {
+            "type": "union",
+            "children": [
+              {
+                "type": "cone",
+                "params": { "h": 0.1, "r": 0.02 },
+                "transform": { "translate": [0.4, -1.45, 0.58], "rotate": [175, 0, 8] }
+              },
+              {
+                "type": "cone",
+                "params": { "h": 0.1, "r": 0.02 },
+                "transform": { "translate": [0.48, -1.45, 0.54], "rotate": [175, 0, 15] }
+              },
+              {
+                "type": "cone",
+                "params": { "h": 0.1, "r": 0.02 },
+                "transform": { "translate": [0.44, -1.45, 0.5], "rotate": [175, 0, 12] }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "notes": "FOOT CLAWS (back legs)",
+        "type": "material",
+        "params": {
+          "color": [0.2, 0.15, 0.1],
+          "roughness": 0.2
+        },
+        "child": {
+          "type": "mirror",
+          "axis": "x",
+          "child": {
+            "type": "union",
+            "children": [
+              {
+                "type": "cone",
+                "params": { "h": 0.12, "r": 0.025 },
+                "transform": { "translate": [0.52, -1.55, -0.72], "rotate": [170, 0, 12] }
+              },
+              {
+                "type": "cone",
+                "params": { "h": 0.12, "r": 0.025 },
+                "transform": { "translate": [0.58, -1.55, -0.78], "rotate": [170, 0, 18] }
+              },
+              {
+                "type": "cone",
+                "params": { "h": 0.12, "r": 0.025 },
+                "transform": { "translate": [0.55, -1.55, -0.85], "rotate": [170, 0, 15] }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/lucid/scenes/toc.json
+++ b/lucid/scenes/toc.json
@@ -83,7 +83,8 @@
         { "path": "creatures/draggo5.json", "title": "Solaris Drake ☀️", "subtitle": "Solar-panel wings" },
         { "path": "creatures/invaders.json", "title": "Space Invaders 👾", "subtitle": "Arcade aliens" },
         { "path": "creatures/radial-invaders.json", "title": "Radial Invaders 🛸", "subtitle": "Circular formation" },
-        { "path": "creatures/spirit-creatures.json", "title": "Spirits 👻", "subtitle": "Ethereal beings" }
+        { "path": "creatures/spirit-creatures.json", "title": "Spirits 👻", "subtitle": "Ethereal beings" },
+        { "path": "creatures/dragon-imported.json", "title": "Imported Dragon 🐲", "subtitle": "Graph-GLSL mapped dragon" }
       ]
     },
     {


### PR DESCRIPTION
Maps the raymarched dragon model from the Graph→GLSL format into the
lucid SDF CDC representation. The dragon includes:
- Organic body with torso, chest, and belly using smoothUnion blending
- Detailed head with skull, snout, jaw, cheek, brow, and crest
- Three-segment articulated neck
- Four limbs with mirrored legs and claws
- Curving segmented tail with ridge spikes and barb tip
- Membrane wings with bone structure and panel approximation
- Head horns and spine ridge details
- Glowing eyes with emission material

Also updates toc.json to include the new dragon in the Creatures category.