### PR TITLE
feat(yeti): Create bestiary for Lucid/Holoplasm creature experiments

### DIFF
--- a/yeti/4legs/index.html
+++ b/yeti/4legs/index.html
@@ -1,0 +1,764 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>DOOFI – Parametric Engine v3.1</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=0">
+  <style>
+    html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }
+    * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+    body { font-family: -apple-system, system-ui, sans-serif; background: #010409; color: #f0f6fc; touch-action: none; user-select: none; }
+    main { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+    canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: block; background: #000; touch-action: none; }
+
+    /* Property Panel */
+    .prop-panel { position: absolute; top: 12px; right: 12px; width: 280px; max-height: calc(100% - 24px); overflow-y: auto; overflow-x: hidden; background: rgba(13, 17, 23, 0.92); backdrop-filter: blur(30px); -webkit-backdrop-filter: blur(30px); border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 16px; padding: 16px; z-index: 50; transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.35s; }
+    .prop-panel.collapsed { transform: translateX(calc(100% + 20px)); }
+    .prop-panel.faded .slider-group { opacity: 0.15; pointer-events: none; }
+    .prop-panel.faded .slider-group.active { opacity: 1; pointer-events: auto; }
+
+    /* Panel toggle tab - always visible */
+    .panel-tab { position: absolute; top: 50%; right: 0; transform: translateY(-50%); width: 32px; height: 64px; background: rgba(13, 17, 23, 0.9); border: 1px solid rgba(255,255,255,0.1); border-right: none; border-radius: 12px 0 0 12px; cursor: pointer; z-index: 51; display: flex; align-items: center; justify-content: center; font-size: 14px; transition: right 0.35s cubic-bezier(0.16, 1, 0.3, 1); }
+    .panel-tab.panel-open { right: 292px; }
+
+    .panel-title { font-size: 13px; font-weight: 800; text-transform: uppercase; color: #fff; margin-bottom: 2px; }
+    .panel-subtitle { font-size: 9px; opacity: 0.4; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 12px; }
+
+    .section-header { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: #38bdf8; margin: 16px 0 10px 0; padding-bottom: 4px; border-bottom: 1px solid rgba(56, 189, 248, 0.2); }
+    .section-header:first-of-type { margin-top: 8px; }
+
+    .slider-group { margin-bottom: 12px; transition: opacity 0.2s; }
+    .slider-row { display: flex; justify-content: space-between; font-size: 9px; font-weight: 600; text-transform: uppercase; opacity: 0.6; margin-bottom: 4px; }
+    .slider-value { font-family: ui-monospace, monospace; opacity: 0.9; }
+
+    input[type=range] { -webkit-appearance: none; appearance: none; width: 100%; height: 24px; background: transparent; outline: none; margin: 0; padding: 8px 0; }
+    input[type=range]::-webkit-slider-runnable-track { height: 4px; background: rgba(255,255,255,0.1); border-radius: 2px; }
+    input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 28px; height: 28px; background: #38bdf8; border-radius: 50%; cursor: pointer; margin-top: -12px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); }
+    input[type=range]::-moz-range-track { height: 4px; background: rgba(255,255,255,0.1); border-radius: 2px; border: none; }
+    input[type=range]::-moz-range-thumb { width: 28px; height: 28px; background: #38bdf8; border-radius: 50%; cursor: pointer; border: none; box-shadow: 0 2px 8px rgba(0,0,0,0.3); }
+
+    /* Carousel */
+    .carousel-container { position: absolute; bottom: 0; left: 0; width: 100%; height: 140px; z-index: 40; overflow: hidden; display: flex; justify-content: center; align-items: flex-end; padding-bottom: 12px; pointer-events: none; }
+    .carousel-track { display: flex; align-items: center; will-change: transform; pointer-events: auto; cursor: grab; padding: 0 50vw; }
+    .carousel-item { flex: 0 0 80px; height: 100px; display: flex; flex-direction: column; align-items: center; justify-content: center; transition: transform 0.2s, opacity 0.2s; opacity: 0.4; }
+    .carousel-item.selected { transform: scale(1.25); opacity: 1; }
+    .carousel-item .emoji { font-size: 2.4rem; transition: filter 0.2s; filter: grayscale(0.6); }
+    .carousel-item.selected .emoji { filter: grayscale(0); }
+    .carousel-item .label { font-size: 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-top: 6px; opacity: 0.5; }
+    .carousel-item.selected .label { opacity: 1; }
+
+    /* Radial Menu */
+    .menu-trigger { position: absolute; bottom: 20px; left: 20px; width: 48px; height: 48px; background: rgba(13, 17, 23, 0.9); border: 1px solid rgba(255,255,255,0.15); border-radius: 50%; cursor: pointer; z-index: 60; display: flex; align-items: center; justify-content: center; font-size: 22px; transition: transform 0.2s, background 0.2s; }
+    .menu-trigger:hover { background: rgba(30, 40, 50, 0.95); }
+    .menu-trigger.open { transform: rotate(90deg); background: #38bdf8; }
+
+    .radial-menu { position: absolute; bottom: 80px; left: 80px; z-index: 59; pointer-events: none; opacity: 0; transform: scale(0.5); transition: opacity 0.25s, transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+    .radial-menu.open { pointer-events: auto; opacity: 1; transform: scale(1); }
+    .radial-item { position: absolute; width: 44px; height: 44px; background: rgba(13, 17, 23, 0.95); border: 1px solid rgba(255,255,255,0.15); border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 20px; transition: transform 0.15s, background 0.15s, box-shadow 0.15s; }
+    .radial-item:hover { transform: scale(1.15); background: rgba(56, 189, 248, 0.3); }
+    .radial-item.active { background: #38bdf8; box-shadow: 0 0 20px rgba(56, 189, 248, 0.5); }
+    .radial-item .tooltip { position: absolute; left: 54px; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.9); color: #fff; font-size: 10px; font-weight: 600; padding: 4px 8px; border-radius: 4px; white-space: nowrap; opacity: 0; pointer-events: none; transition: opacity 0.15s; }
+    .radial-item:hover .tooltip { opacity: 1; }
+
+    /* Stats */
+    .stats { position: absolute; bottom: 160px; left: 20px; font-size: 10px; font-family: ui-monospace, monospace; opacity: 0.35; pointer-events: none; }
+  </style>
+</head>
+<body>
+
+<main>
+  <canvas id="viewport"></canvas>
+
+  <div class="panel-tab panel-open" id="panel-tab" onclick="togglePanel()">◀</div>
+
+  <div id="prop-sheet" class="prop-panel">
+    <div class="panel-title" id="creature-name">...</div>
+    <div class="panel-subtitle">53 parameters · SDF tree</div>
+    <div id="slider-container"></div>
+  </div>
+
+  <div class="stats"><span id="fps">60</span> FPS · WebGL SDF</div>
+
+  <div class="menu-trigger" id="menu-trigger" onclick="toggleRadialMenu()">⚙️</div>
+  <div class="radial-menu" id="radial-menu">
+    <div class="radial-item" style="transform: translate(-60px, -100px)" onclick="toggleHelicopter()" id="btn-heli">🚁<span class="tooltip">Helicopter Orbit</span></div>
+    <div class="radial-item" style="transform: translate(0px, -120px)" onclick="toggleWiggle()" id="btn-wiggle">🌀<span class="tooltip">Param Wiggle</span></div>
+    <div class="radial-item" style="transform: translate(60px, -100px)" onclick="exportJSON()">💾<span class="tooltip">Export JSON</span></div>
+    <div class="radial-item" style="transform: translate(90px, -50px)" onclick="resetParams()">🔄<span class="tooltip">Reset Params</span></div>
+  </div>
+
+  <div class="carousel-container">
+    <div class="carousel-track" id="wheel-track"></div>
+  </div>
+</main>
+
+<script id="registry-json" type="application/json">
+{
+  "globals": {
+    "smoothness": { "value": 0.15, "min": 0.05, "max": 0.5, "label": "Blobiness" },
+    "globalScale": { "value": 1, "min": 0.3, "max": 2, "label": "Global Scale" },
+    "fatness": { "value": 1, "min": 0.5, "max": 1.8, "label": "Fatness" },
+    "legLength": { "value": 1, "min": 0.4, "max": 1.6, "label": "Leg Length" },
+    "earSize": { "value": 1, "min": 0.3, "max": 2, "label": "Ear Size" },
+    "tailWag": { "value": 0, "min": -1, "max": 1, "label": "Tail Wag" }
+  },
+  "animals": [
+    {
+      "name": "Elephant", "emoji": "🐘",
+      "params": {
+        "color": [0.55, 0.52, 0.5],
+        "bodyRadii": [1.4, 1.1, 1.6],
+        "rumpRadii": [1.2, 1.0, 1.0], "rumpPos": [0, -0.1, -1.3],
+        "headRadii": [0.6, 0.55, 0.55], "headPos": [0, 0.5, 1.8],
+        "snoutRadii": [0.15, 0.12, 0.8], "snoutPos": [0, -0.1, 2.6],
+        "noseSize": 0.12, "nosePos": [0, -0.4, 3.3],
+        "earRadii": [0.6, 0.7, 0.12], "earPos": [0.65, 0.5, 1.4], "earRotate": [0, 0, 0.3],
+        "legThighR": 0.28, "legAnkleR": 0.22,
+        "frontLegH": 0.9, "frontLegPos": [0.6, -1.0, 0.8], "frontLegRot": [0, 0, 0],
+        "backLegH": 0.85, "backLegPos": [0.6, -0.95, -0.8], "backLegRot": [0, 0, 0],
+        "tailLen": 0.5, "tailR": 0.06, "tailPos": [0, 0, -2.2], "tailRot": [-0.8, 0, 0]
+      }
+    },
+    {
+      "name": "Hippo", "emoji": "🦛",
+      "params": {
+        "color": [0.48, 0.4, 0.45],
+        "bodyRadii": [1.2, 0.85, 1.4],
+        "rumpRadii": [1.0, 0.75, 0.8], "rumpPos": [0, -0.05, -1.1],
+        "headRadii": [0.5, 0.45, 0.55], "headPos": [0, 0.15, 1.5],
+        "snoutRadii": [0.42, 0.32, 0.38], "snoutPos": [0, -0.15, 2.0],
+        "noseSize": 0.08, "nosePos": [0, 0.05, 2.35],
+        "earRadii": [0.08, 0.12, 0.06], "earPos": [0.28, 0.52, 1.35], "earRotate": [0, 0, 0],
+        "legThighR": 0.25, "legAnkleR": 0.2,
+        "frontLegH": 0.35, "frontLegPos": [0.55, -0.6, 0.6], "frontLegRot": [0, 0, 0],
+        "backLegH": 0.35, "backLegPos": [0.55, -0.6, -0.6], "backLegRot": [0, 0, 0],
+        "tailLen": 0.25, "tailR": 0.05, "tailPos": [0, 0.2, -1.8], "tailRot": [-0.5, 0, 0]
+      }
+    },
+    {
+      "name": "Dog", "emoji": "🐕",
+      "params": {
+        "color": [0.65, 0.55, 0.4],
+        "bodyRadii": [0.5, 0.45, 0.9],
+        "rumpRadii": [0.45, 0.4, 0.5], "rumpPos": [0, 0.05, -0.9],
+        "headRadii": [0.28, 0.26, 0.32], "headPos": [0, 0.35, 1.1],
+        "snoutRadii": [0.12, 0.1, 0.28], "snoutPos": [0, 0.22, 1.45],
+        "noseSize": 0.06, "nosePos": [0, 0.22, 1.72],
+        "earRadii": [0.08, 0.18, 0.06], "earPos": [0.18, 0.58, 0.95], "earRotate": [0.3, 0, 0.2],
+        "legThighR": 0.12, "legAnkleR": 0.06,
+        "frontLegH": 0.55, "frontLegPos": [0.22, -0.55, 0.4], "frontLegRot": [0, 0, 0],
+        "backLegH": 0.6, "backLegPos": [0.22, -0.55, -0.5], "backLegRot": [0.15, 0, 0],
+        "tailLen": 0.5, "tailR": 0.06, "tailPos": [0, 0.15, -1.35], "tailRot": [-0.3, 0, 0]
+      }
+    },
+    {
+      "name": "Bear", "emoji": "🐻",
+      "params": {
+        "color": [0.32, 0.22, 0.15],
+        "bodyRadii": [1.0, 0.9, 1.1],
+        "rumpRadii": [0.9, 0.8, 0.7], "rumpPos": [0, 0, -0.9],
+        "headRadii": [0.42, 0.4, 0.4], "headPos": [0, 0.35, 1.25],
+        "snoutRadii": [0.2, 0.18, 0.25], "snoutPos": [0, 0.15, 1.6],
+        "noseSize": 0.07, "nosePos": [0, 0.18, 1.85],
+        "earRadii": [0.1, 0.1, 0.08], "earPos": [0.3, 0.65, 1.05], "earRotate": [0, 0, 0],
+        "legThighR": 0.22, "legAnkleR": 0.15,
+        "frontLegH": 0.55, "frontLegPos": [0.45, -0.7, 0.5], "frontLegRot": [0, 0, 0],
+        "backLegH": 0.5, "backLegPos": [0.45, -0.65, -0.5], "backLegRot": [0, 0, 0],
+        "tailLen": 0.1, "tailR": 0.08, "tailPos": [0, 0.3, -1.5], "tailRot": [-0.3, 0, 0]
+      }
+    },
+    {
+      "name": "Pig", "emoji": "🐖",
+      "params": {
+        "color": [0.95, 0.7, 0.65],
+        "bodyRadii": [0.7, 0.6, 1.0],
+        "rumpRadii": [0.65, 0.55, 0.5], "rumpPos": [0, -0.05, -0.85],
+        "headRadii": [0.32, 0.3, 0.32], "headPos": [0, 0.1, 1.15],
+        "snoutRadii": [0.18, 0.14, 0.12], "snoutPos": [0, -0.02, 1.45],
+        "noseSize": 0.1, "nosePos": [0, 0, 1.55],
+        "earRadii": [0.12, 0.18, 0.05], "earPos": [0.2, 0.35, 1.0], "earRotate": [0.5, 0, 0.4],
+        "legThighR": 0.12, "legAnkleR": 0.08,
+        "frontLegH": 0.3, "frontLegPos": [0.32, -0.45, 0.45], "frontLegRot": [0, 0, 0],
+        "backLegH": 0.3, "backLegPos": [0.35, -0.45, -0.45], "backLegRot": [0, 0, 0],
+        "tailLen": 0.15, "tailR": 0.03, "tailPos": [0, 0.15, -1.25], "tailRot": [-1.2, 0, 0]
+      }
+    },
+    {
+      "name": "Cat", "emoji": "🐈",
+      "params": {
+        "color": [0.25, 0.25, 0.28],
+        "bodyRadii": [0.35, 0.3, 0.6],
+        "rumpRadii": [0.32, 0.28, 0.35], "rumpPos": [0, 0, -0.55],
+        "headRadii": [0.22, 0.2, 0.22], "headPos": [0, 0.25, 0.75],
+        "snoutRadii": [0.1, 0.08, 0.12], "snoutPos": [0, 0.15, 0.95],
+        "noseSize": 0.035, "nosePos": [0, 0.16, 1.05],
+        "earRadii": [0.06, 0.14, 0.04], "earPos": [0.14, 0.42, 0.68], "earRotate": [0.2, 0, 0.3],
+        "legThighR": 0.07, "legAnkleR": 0.04,
+        "frontLegH": 0.35, "frontLegPos": [0.15, -0.35, 0.25], "frontLegRot": [0, 0, 0],
+        "backLegH": 0.4, "backLegPos": [0.15, -0.35, -0.35], "backLegRot": [0.2, 0, 0],
+        "tailLen": 0.55, "tailR": 0.04, "tailPos": [0, 0.08, -0.9], "tailRot": [-0.6, 0, 0]
+      }
+    }
+  ]
+}
+</script>
+
+<script>
+var FS_SRC = '\
+precision highp float;\n\
+varying vec2 v_uv;\n\
+uniform vec2 u_res;\n\
+uniform float u_camDist, u_camPhi, u_camTheta;\n\
+uniform float u_yaw, u_pitch;\n\
+uniform float u_smooth, u_scale, u_fat, u_legLen, u_earSize, u_tailWag;\n\
+uniform vec3 u_color;\n\
+uniform vec3 u_bodyR, u_rumpR, u_rumpP;\n\
+uniform vec3 u_headR, u_headP;\n\
+uniform vec3 u_snoutR, u_snoutP;\n\
+uniform float u_noseSize;\n\
+uniform vec3 u_noseP;\n\
+uniform vec3 u_earR, u_earP, u_earRot;\n\
+uniform float u_legThighR, u_legAnkleR;\n\
+uniform float u_frontLegH;\n\
+uniform vec3 u_frontLegP, u_frontLegRot;\n\
+uniform float u_backLegH;\n\
+uniform vec3 u_backLegP, u_backLegRot;\n\
+uniform float u_tailLen, u_tailR;\n\
+uniform vec3 u_tailP, u_tailRot;\n\
+mat3 rotX(float a){float c=cos(a),s=sin(a);return mat3(1,0,0,0,c,-s,0,s,c);}\n\
+mat3 rotY(float a){float c=cos(a),s=sin(a);return mat3(c,0,s,0,1,0,-s,0,c);}\n\
+mat3 rotZ(float a){float c=cos(a),s=sin(a);return mat3(c,-s,0,s,c,0,0,0,1);}\n\
+mat3 rotXYZ(vec3 r){return rotZ(r.z)*rotY(r.y)*rotX(r.x);}\n\
+float sdEllipsoid(vec3 p,vec3 r){float k0=length(p/r);float k1=length(p/(r*r));return k0*(k0-1.0)/k1;}\n\
+float sdSphere(vec3 p,float r){return length(p)-r;}\n\
+float sdCapsule(vec3 p,float h,float r){p.y-=clamp(p.y,0.0,h);return length(p)-r;}\n\
+float sdRoundCone(vec3 p,float r1,float r2,float h){vec2 q=vec2(length(p.xz),p.y);float b=(r1-r2)/h;float a=sqrt(1.0-b*b);float k=dot(q,vec2(-b,a));if(k<0.0)return length(q)-r1;if(k>a*h)return length(q-vec2(0,h))-r2;return dot(q,vec2(a,b))-r1;}\n\
+float smin(float a,float b,float k){float h=clamp(0.5+0.5*(b-a)/k,0.0,1.0);return mix(b,a,h)-k*h*(1.0-h);}\n\
+float sdf(vec3 p){\n\
+  vec3 q=rotX(u_pitch)*rotY(-u_yaw)*(p/u_scale);\n\
+  float k=u_smooth,fat=u_fat;\n\
+  vec3 bodyQ=q/vec3(1.0,fat,1.0);\n\
+  float d=sdEllipsoid(bodyQ,u_bodyR);\n\
+  vec3 rumpQ=(q-u_rumpP)/vec3(1.0,fat,1.0);\n\
+  d=smin(d,sdEllipsoid(rumpQ,u_rumpR),k);\n\
+  d=smin(d,sdEllipsoid(q-u_headP,u_headR),k);\n\
+  d=smin(d,sdEllipsoid(q-u_snoutP,u_snoutR),k);\n\
+  d=smin(d,sdSphere(q-u_noseP,u_noseSize),k*0.5);\n\
+  mat3 earMat=rotXYZ(u_earRot);\n\
+  vec3 earQ1=earMat*((q-u_earP)/u_earSize);\n\
+  vec3 earQ2=earMat*((q-vec3(-u_earP.x,u_earP.y,u_earP.z))/u_earSize);\n\
+  d=smin(d,sdEllipsoid(earQ1,u_earR),k);\n\
+  d=smin(d,sdEllipsoid(earQ2,u_earR),k);\n\
+  float flH=u_frontLegH*u_legLen;\n\
+  float thighR=u_legThighR*fat,ankleR=u_legAnkleR*fat;\n\
+  mat3 flMat=rotXYZ(u_frontLegRot);\n\
+  vec3 flQ1=flMat*(q-u_frontLegP);\n\
+  vec3 flQ2=flMat*(q-vec3(-u_frontLegP.x,u_frontLegP.y,u_frontLegP.z));\n\
+  d=smin(d,sdRoundCone(flQ1,thighR,ankleR,flH),k*0.7);\n\
+  d=smin(d,sdRoundCone(flQ2,thighR,ankleR,flH),k*0.7);\n\
+  float blH=u_backLegH*u_legLen;\n\
+  mat3 blMat=rotXYZ(u_backLegRot);\n\
+  vec3 blQ1=blMat*(q-u_backLegP);\n\
+  vec3 blQ2=blMat*(q-vec3(-u_backLegP.x,u_backLegP.y,u_backLegP.z));\n\
+  d=smin(d,sdRoundCone(blQ1,thighR,ankleR,blH),k*0.7);\n\
+  d=smin(d,sdRoundCone(blQ2,thighR,ankleR,blH),k*0.7);\n\
+  mat3 tailMat=rotXYZ(u_tailRot+vec3(u_tailWag,0.0,0.0));\n\
+  vec3 tailQ=tailMat*(q-u_tailP);\n\
+  d=smin(d,sdCapsule(tailQ,u_tailLen,u_tailR),k*0.5);\n\
+  return d*u_scale;\n\
+}\n\
+vec3 calcNormal(vec3 p){vec2 e=vec2(0.001,0);return normalize(vec3(sdf(p+e.xyy)-sdf(p-e.xyy),sdf(p+e.yxy)-sdf(p-e.yxy),sdf(p+e.yyx)-sdf(p-e.yyx)));}\n\
+void main(){\n\
+  vec2 uv=(v_uv*2.0-1.0)*vec2(u_res.x/u_res.y,1.0);\n\
+  vec3 ro=vec3(u_camDist*cos(u_camPhi)*sin(u_camTheta),u_camDist*sin(u_camPhi),u_camDist*cos(u_camPhi)*cos(u_camTheta));\n\
+  vec3 ta=vec3(0,0.3,0);\n\
+  vec3 ww=normalize(ta-ro),uu=normalize(cross(ww,vec3(0,1,0))),vv=normalize(cross(uu,ww));\n\
+  vec3 rd=normalize(uv.x*uu+uv.y*vv+2.0*ww);\n\
+  vec3 col=vec3(0.08,0.09,0.12)-rd.y*0.05;\n\
+  float floorY=-1.5;\n\
+  float tFloor=(floorY-ro.y)/rd.y;\n\
+  if(tFloor>0.0){vec3 floorP=ro+rd*tFloor;vec2 grid=abs(fract(floorP.xz)-0.5);float line=smoothstep(0.02,0.03,min(grid.x,grid.y));col=mix(vec3(0.15),vec3(0.08,0.09,0.11),line);col*=1.0-smoothstep(5.0,15.0,length(floorP.xz));}\n\
+  float t=0.1;\n\
+  for(int i=0;i<80;i++){vec3 p=ro+rd*t;float d=sdf(p);if(d<0.001){vec3 n=calcNormal(p);vec3 lightDir=normalize(vec3(0.5,0.8,0.3));float diff=max(0.0,dot(n,lightDir));float amb=0.3+0.2*n.y;float rim=pow(1.0-max(0.0,dot(n,-rd)),3.0);float shadow=1.0;vec3 sro=p+n*0.01;float st=0.02;for(int j=0;j<16;j++){float h=sdf(sro+lightDir*st);shadow=min(shadow,8.0*h/st);st+=clamp(h,0.02,0.2);if(shadow<0.01||st>5.0)break;}shadow=clamp(shadow,0.3,1.0);col=u_color*(amb+diff*shadow*0.7)+rim*0.15;if(p.y<floorY+0.5){float gs=smoothstep(floorY,floorY+0.5,p.y);col*=0.7+0.3*gs;}break;}t+=d*0.9;if(t>20.0)break;}\n\
+  vec2 vig=v_uv*(1.0-v_uv);col*=0.3+0.7*pow(vig.x*vig.y*15.0,0.25);\n\
+  gl_FragColor=vec4(pow(col,vec3(0.4545)),1.0);\n\
+}';
+
+var state = {
+  speciesIdx: 0,
+  cam: { theta: 0.5, phi: 0.25, dist: 6.0 },
+  entity: { yaw: Math.PI * 0.1, pitch: 0 },
+  globals: {},
+  params: {},
+  baseParams: {},
+  lastTime: performance.now(),
+  frameCount: 0, fpsTime: performance.now(),
+  helicopter: false,
+  wiggle: false,
+  panelOpen: true,
+  menuOpen: false,
+  activeSlider: null
+};
+
+var wheel = { scroll: 0, velocity: 0, dragging: false, lx: 0, itemW: 80 };
+var gl, program, uniforms = {};
+var data;
+
+// Flattened param definitions with ranges
+var paramDefs = {
+  'color.r': { min: 0, max: 1, idx: 0, arr: 'color' },
+  'color.g': { min: 0, max: 1, idx: 1, arr: 'color' },
+  'color.b': { min: 0, max: 1, idx: 2, arr: 'color' },
+  'body.x': { min: 0.2, max: 2, idx: 0, arr: 'bodyRadii' },
+  'body.y': { min: 0.2, max: 2, idx: 1, arr: 'bodyRadii' },
+  'body.z': { min: 0.2, max: 2, idx: 2, arr: 'bodyRadii' },
+  'rump.x': { min: 0.2, max: 1.5, idx: 0, arr: 'rumpRadii' },
+  'rump.y': { min: 0.2, max: 1.5, idx: 1, arr: 'rumpRadii' },
+  'rump.z': { min: 0.2, max: 1.5, idx: 2, arr: 'rumpRadii' },
+  'rumpPos.y': { min: -1, max: 1, idx: 1, arr: 'rumpPos' },
+  'rumpPos.z': { min: -3, max: 0, idx: 2, arr: 'rumpPos' },
+  'head.x': { min: 0.1, max: 1, idx: 0, arr: 'headRadii' },
+  'head.y': { min: 0.1, max: 1, idx: 1, arr: 'headRadii' },
+  'head.z': { min: 0.1, max: 1, idx: 2, arr: 'headRadii' },
+  'headPos.y': { min: -0.5, max: 1.5, idx: 1, arr: 'headPos' },
+  'headPos.z': { min: 0, max: 3, idx: 2, arr: 'headPos' },
+  'snout.x': { min: 0.05, max: 0.6, idx: 0, arr: 'snoutRadii' },
+  'snout.y': { min: 0.05, max: 0.5, idx: 1, arr: 'snoutRadii' },
+  'snout.z': { min: 0.05, max: 1, idx: 2, arr: 'snoutRadii' },
+  'snoutPos.y': { min: -0.5, max: 0.5, idx: 1, arr: 'snoutPos' },
+  'snoutPos.z': { min: 0.5, max: 4, idx: 2, arr: 'snoutPos' },
+  'noseSize': { min: 0.02, max: 0.2, scalar: true },
+  'ear.x': { min: 0.03, max: 0.8, idx: 0, arr: 'earRadii' },
+  'ear.y': { min: 0.03, max: 0.8, idx: 1, arr: 'earRadii' },
+  'ear.z': { min: 0.02, max: 0.2, idx: 2, arr: 'earRadii' },
+  'earPos.x': { min: 0.1, max: 1, idx: 0, arr: 'earPos' },
+  'earPos.y': { min: 0.2, max: 1, idx: 1, arr: 'earPos' },
+  'earRot.x': { min: -1, max: 1, idx: 0, arr: 'earRotate' },
+  'earRot.z': { min: -0.5, max: 0.5, idx: 2, arr: 'earRotate' },
+  'legThighR': { min: 0.04, max: 0.4, scalar: true },
+  'legAnkleR': { min: 0.02, max: 0.3, scalar: true },
+  'frontLegH': { min: 0.2, max: 1.2, scalar: true },
+  'frontLegPos.x': { min: 0.1, max: 1, idx: 0, arr: 'frontLegPos' },
+  'frontLegPos.y': { min: -1.5, max: 0, idx: 1, arr: 'frontLegPos' },
+  'backLegH': { min: 0.2, max: 1.2, scalar: true },
+  'backLegPos.x': { min: 0.1, max: 1, idx: 0, arr: 'backLegPos' },
+  'backLegRot.x': { min: -0.5, max: 0.5, idx: 0, arr: 'backLegRot' },
+  'tailLen': { min: 0.05, max: 0.8, scalar: true },
+  'tailR': { min: 0.02, max: 0.15, scalar: true },
+  'tailRot.x': { min: -2, max: 0, idx: 0, arr: 'tailRot' }
+};
+
+function init() {
+  data = JSON.parse(document.getElementById('registry-json').textContent);
+
+  for (var key in data.globals) {
+    state.globals[key] = data.globals[key].value;
+  }
+
+  state.params = JSON.parse(JSON.stringify(data.animals[0].params));
+  state.baseParams = JSON.parse(JSON.stringify(data.animals[0].params));
+
+  // Build carousel
+  var track = document.getElementById('wheel-track');
+  data.animals.forEach(function(a, i) {
+    var div = document.createElement('div');
+    div.className = 'carousel-item';
+    div.innerHTML = '<span class="emoji">' + a.emoji + '</span><span class="label">' + a.name + '</span>';
+    div.onclick = function() { wheel.scroll = -(i * wheel.itemW); };
+    track.appendChild(div);
+  });
+
+  buildSliders();
+
+  requestAnimationFrame(function() {
+    initGL();
+    initInteractions();
+    window.addEventListener('resize', handleResize);
+    requestAnimationFrame(render);
+  });
+}
+
+function buildSliders() {
+  var container = document.getElementById('slider-container');
+  container.innerHTML = '';
+
+  // Global params section
+  var globalHeader = document.createElement('div');
+  globalHeader.className = 'section-header';
+  globalHeader.textContent = 'Global Modifiers';
+  container.appendChild(globalHeader);
+
+  for (var key in data.globals) {
+    var param = data.globals[key];
+    addSlider(container, 'g_' + key, param.label, param.value, param.min, param.max, function(k) {
+      return function(val) {
+        state.globals[k] = val;
+      };
+    }(key));
+  }
+
+  // Instance params sections
+  var sections = {
+    'Color': ['color.r', 'color.g', 'color.b'],
+    'Body': ['body.x', 'body.y', 'body.z'],
+    'Rump': ['rump.x', 'rump.y', 'rump.z', 'rumpPos.y', 'rumpPos.z'],
+    'Head': ['head.x', 'head.y', 'head.z', 'headPos.y', 'headPos.z'],
+    'Snout': ['snout.x', 'snout.y', 'snout.z', 'snoutPos.y', 'snoutPos.z', 'noseSize'],
+    'Ears': ['ear.x', 'ear.y', 'ear.z', 'earPos.x', 'earPos.y', 'earRot.x', 'earRot.z'],
+    'Legs': ['legThighR', 'legAnkleR', 'frontLegH', 'frontLegPos.x', 'frontLegPos.y', 'backLegH', 'backLegPos.x', 'backLegRot.x'],
+    'Tail': ['tailLen', 'tailR', 'tailRot.x']
+  };
+
+  for (var section in sections) {
+    var header = document.createElement('div');
+    header.className = 'section-header';
+    header.textContent = section;
+    container.appendChild(header);
+
+    sections[section].forEach(function(key) {
+      var def = paramDefs[key];
+      var val = getParamValue(key);
+      addSlider(container, 'p_' + key, key, val, def.min, def.max, function(k) {
+        return function(v) { setParamValue(k, v); };
+      }(key));
+    });
+  }
+}
+
+function getParamValue(key) {
+  var def = paramDefs[key];
+  if (def.scalar) return state.params[key];
+  return state.params[def.arr][def.idx];
+}
+
+function setParamValue(key, val) {
+  var def = paramDefs[key];
+  if (def.scalar) state.params[key] = val;
+  else state.params[def.arr][def.idx] = val;
+}
+
+function addSlider(container, id, label, value, min, max, onChange) {
+  var div = document.createElement('div');
+  div.className = 'slider-group';
+  div.id = 'grp_' + id;
+  div.innerHTML = '<div class="slider-row"><span>' + label + '</span><span class="slider-value" id="v_' + id + '">' + value.toFixed(2) + '</span></div><input type="range" id="s_' + id + '" min="' + min + '" max="' + max + '" step="0.001" value="' + value + '">';
+  container.appendChild(div);
+
+  var input = div.querySelector('input');
+  input.addEventListener('input', function(e) {
+    var v = parseFloat(e.target.value);
+    document.getElementById('v_' + id).textContent = v.toFixed(2);
+    onChange(v);
+  });
+  input.addEventListener('pointerdown', function() {
+    state.activeSlider = id;
+    document.getElementById('prop-sheet').classList.add('faded');
+    div.classList.add('active');
+  });
+  input.addEventListener('pointerup', clearActiveSlider);
+  input.addEventListener('pointercancel', clearActiveSlider);
+}
+
+function clearActiveSlider() {
+  state.activeSlider = null;
+  document.getElementById('prop-sheet').classList.remove('faded');
+  var active = document.querySelector('.slider-group.active');
+  if (active) active.classList.remove('active');
+}
+
+function updateSliders() {
+  // Update global sliders
+  for (var key in data.globals) {
+    var el = document.getElementById('s_g_' + key);
+    var vEl = document.getElementById('v_g_' + key);
+    if (el) {
+      el.value = state.globals[key];
+      vEl.textContent = state.globals[key].toFixed(2);
+    }
+  }
+  // Update param sliders
+  for (var key in paramDefs) {
+    var el = document.getElementById('s_p_' + key);
+    var vEl = document.getElementById('v_p_' + key);
+    if (el) {
+      var val = getParamValue(key);
+      el.value = val;
+      vEl.textContent = val.toFixed(2);
+    }
+  }
+}
+
+function handleResize() {
+  var c = document.getElementById('viewport');
+  var rect = c.getBoundingClientRect();
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  var w = Math.floor(rect.width * dpr);
+  var h = Math.floor(rect.height * dpr);
+  c.width = w;
+  c.height = h;
+  gl.viewport(0, 0, w, h);
+  gl.uniform2f(uniforms.u_res, w, h);
+}
+
+function initInteractions() {
+  var canvas = document.getElementById('viewport');
+  var maxScroll = function() { return -(data.animals.length - 1) * wheel.itemW; };
+
+  function onDown(e) {
+    var pt = e.touches ? e.touches[0] : e;
+    if (e.target === canvas) state.moving = true;
+    if (e.target.closest('#wheel-track')) {
+      wheel.dragging = true;
+      wheel.lx = pt.clientX;
+    }
+    state.lx = pt.clientX;
+    state.ly = pt.clientY;
+  }
+
+  function onMove(e) {
+    var pt = e.touches ? e.touches[0] : e;
+    if (state.moving && !state.helicopter) {
+      var dx = (pt.clientX - state.lx) * 0.008;
+      var dy = (pt.clientY - state.ly) * 0.008;
+      state.cam.theta += dx;
+      state.cam.phi = Math.max(-0.3, Math.min(1.2, state.cam.phi - dy));
+    }
+    if (wheel.dragging) {
+      wheel.velocity = pt.clientX - wheel.lx;
+      wheel.scroll += wheel.velocity;
+      var ms = maxScroll();
+      if (wheel.scroll > 0) wheel.scroll *= 0.5;
+      if (wheel.scroll < ms) wheel.scroll = ms + (wheel.scroll - ms) * 0.5;
+      wheel.lx = pt.clientX;
+    }
+    state.lx = pt.clientX;
+    state.ly = pt.clientY;
+  }
+
+  function onUp() { state.moving = wheel.dragging = false; }
+
+  window.addEventListener('pointerdown', onDown);
+  window.addEventListener('pointermove', onMove);
+  window.addEventListener('pointerup', onUp);
+  window.addEventListener('pointercancel', onUp);
+
+  canvas.addEventListener('wheel', function(e) {
+    e.preventDefault();
+    state.cam.dist = Math.max(2, Math.min(15, state.cam.dist + e.deltaY * 0.01));
+  }, { passive: false });
+
+  // Close menu on outside click
+  document.addEventListener('pointerdown', function(e) {
+    if (state.menuOpen && !e.target.closest('.radial-menu') && !e.target.closest('.menu-trigger')) {
+      toggleRadialMenu();
+    }
+  });
+}
+
+function render(time) {
+  var dt = (time - state.lastTime) / 1000;
+  state.lastTime = time;
+
+  state.frameCount++;
+  if (time - state.fpsTime > 1000) {
+    document.getElementById('fps').textContent = state.frameCount;
+    state.frameCount = 0;
+    state.fpsTime = time;
+  }
+
+  // Helicopter mode
+  if (state.helicopter) {
+    state.cam.theta += dt * 0.5;
+  }
+
+  // Wiggle mode
+  if (state.wiggle) {
+    var t = time * 0.001;
+    state.globals.smoothness = 0.15 + 0.1 * Math.sin(t * 1.1);
+    state.globals.fatness = 1.0 + 0.3 * Math.sin(t * 0.7);
+    state.globals.legLength = 1.0 + 0.3 * Math.sin(t * 0.9);
+    state.globals.earSize = 1.0 + 0.4 * Math.sin(t * 1.3);
+    state.globals.tailWag = 0.5 * Math.sin(t * 3.0);
+    updateSliders();
+  }
+
+  // Carousel physics
+  var ms = -(data.animals.length - 1) * wheel.itemW;
+  if (!wheel.dragging) {
+    var target = Math.max(ms, Math.min(0, Math.round(wheel.scroll / wheel.itemW) * wheel.itemW));
+    wheel.velocity += (target - wheel.scroll) * 8 * dt;
+    wheel.velocity *= 0.85;
+    wheel.scroll += wheel.velocity;
+  }
+
+  document.getElementById('wheel-track').style.transform = 'translateX(' + wheel.scroll + 'px)';
+  var idx = Math.max(0, Math.min(data.animals.length - 1, Math.round(-wheel.scroll / wheel.itemW)));
+
+  // Switch animal
+  if (idx !== state.speciesIdx) {
+    state.speciesIdx = idx;
+    state.params = JSON.parse(JSON.stringify(data.animals[idx].params));
+    state.baseParams = JSON.parse(JSON.stringify(data.animals[idx].params));
+    updateSliders();
+  }
+
+  var items = document.querySelectorAll('.carousel-item');
+  for (var i = 0; i < items.length; i++) {
+    if (i === idx) items[i].classList.add('selected');
+    else items[i].classList.remove('selected');
+  }
+
+  document.getElementById('creature-name').textContent = data.animals[idx].name;
+
+  var p = state.params;
+  var g = state.globals;
+
+  gl.uniform1f(uniforms.u_camDist, state.cam.dist);
+  gl.uniform1f(uniforms.u_camTheta, state.cam.theta);
+  gl.uniform1f(uniforms.u_camPhi, state.cam.phi);
+  gl.uniform1f(uniforms.u_yaw, state.entity.yaw);
+  gl.uniform1f(uniforms.u_pitch, state.entity.pitch);
+
+  gl.uniform1f(uniforms.u_smooth, g.smoothness);
+  gl.uniform1f(uniforms.u_scale, g.globalScale);
+  gl.uniform1f(uniforms.u_fat, g.fatness);
+  gl.uniform1f(uniforms.u_legLen, g.legLength);
+  gl.uniform1f(uniforms.u_earSize, g.earSize);
+  gl.uniform1f(uniforms.u_tailWag, g.tailWag);
+
+  gl.uniform3fv(uniforms.u_color, p.color);
+  gl.uniform3fv(uniforms.u_bodyR, p.bodyRadii);
+  gl.uniform3fv(uniforms.u_rumpR, p.rumpRadii);
+  gl.uniform3fv(uniforms.u_rumpP, p.rumpPos);
+  gl.uniform3fv(uniforms.u_headR, p.headRadii);
+  gl.uniform3fv(uniforms.u_headP, p.headPos);
+  gl.uniform3fv(uniforms.u_snoutR, p.snoutRadii);
+  gl.uniform3fv(uniforms.u_snoutP, p.snoutPos);
+  gl.uniform1f(uniforms.u_noseSize, p.noseSize);
+  gl.uniform3fv(uniforms.u_noseP, p.nosePos);
+  gl.uniform3fv(uniforms.u_earR, p.earRadii);
+  gl.uniform3fv(uniforms.u_earP, p.earPos);
+  gl.uniform3fv(uniforms.u_earRot, p.earRotate);
+  gl.uniform1f(uniforms.u_legThighR, p.legThighR);
+  gl.uniform1f(uniforms.u_legAnkleR, p.legAnkleR);
+  gl.uniform1f(uniforms.u_frontLegH, p.frontLegH);
+  gl.uniform3fv(uniforms.u_frontLegP, p.frontLegPos);
+  gl.uniform3fv(uniforms.u_frontLegRot, p.frontLegRot);
+  gl.uniform1f(uniforms.u_backLegH, p.backLegH);
+  gl.uniform3fv(uniforms.u_backLegP, p.backLegPos);
+  gl.uniform3fv(uniforms.u_backLegRot, p.backLegRot);
+  gl.uniform1f(uniforms.u_tailLen, p.tailLen);
+  gl.uniform1f(uniforms.u_tailR, p.tailR);
+  gl.uniform3fv(uniforms.u_tailP, p.tailPos);
+  gl.uniform3fv(uniforms.u_tailRot, p.tailRot);
+
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+  requestAnimationFrame(render);
+}
+
+function initGL() {
+  var c = document.getElementById('viewport');
+  gl = c.getContext('webgl', { antialias: false, preserveDrawingBuffer: false });
+
+  var rect = c.getBoundingClientRect();
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  var w = Math.floor(rect.width * dpr);
+  var h = Math.floor(rect.height * dpr);
+  c.width = w;
+  c.height = h;
+  gl.viewport(0, 0, w, h);
+
+  function compile(type, src) {
+    var s = gl.createShader(type);
+    gl.shaderSource(s, src);
+    gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) console.error('Shader:', gl.getShaderInfoLog(s));
+    return s;
+  }
+
+  var VS = 'attribute vec2 p;varying vec2 v_uv;void main(){v_uv=p*0.5+0.5;gl_Position=vec4(p,0,1);}';
+
+  program = gl.createProgram();
+  gl.attachShader(program, compile(gl.VERTEX_SHADER, VS));
+  gl.attachShader(program, compile(gl.FRAGMENT_SHADER, FS_SRC));
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) console.error('Link:', gl.getProgramInfoLog(program));
+
+  var buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1,1,-1,-1,1,-1,1,1,-1,1,1]), gl.STATIC_DRAW);
+
+  var loc = gl.getAttribLocation(program, 'p');
+  gl.enableVertexAttribArray(loc);
+  gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+  gl.useProgram(program);
+
+  var uNames = ['u_res','u_camDist','u_camPhi','u_camTheta','u_yaw','u_pitch','u_smooth','u_scale','u_fat','u_legLen','u_earSize','u_tailWag','u_color','u_bodyR','u_rumpR','u_rumpP','u_headR','u_headP','u_snoutR','u_snoutP','u_noseSize','u_noseP','u_earR','u_earP','u_earRot','u_legThighR','u_legAnkleR','u_frontLegH','u_frontLegP','u_frontLegRot','u_backLegH','u_backLegP','u_backLegRot','u_tailLen','u_tailR','u_tailP','u_tailRot'];
+  for (var i = 0; i < uNames.length; i++) uniforms[uNames[i]] = gl.getUniformLocation(program, uNames[i]);
+  gl.uniform2f(uniforms.u_res, w, h);
+}
+
+function togglePanel() {
+  state.panelOpen = !state.panelOpen;
+  document.getElementById('prop-sheet').classList.toggle('collapsed', !state.panelOpen);
+  document.getElementById('panel-tab').classList.toggle('panel-open', state.panelOpen);
+  document.getElementById('panel-tab').textContent = state.panelOpen ? '◀' : '▶';
+}
+
+function toggleRadialMenu() {
+  state.menuOpen = !state.menuOpen;
+  document.getElementById('radial-menu').classList.toggle('open', state.menuOpen);
+  document.getElementById('menu-trigger').classList.toggle('open', state.menuOpen);
+}
+
+function toggleHelicopter() {
+  state.helicopter = !state.helicopter;
+  document.getElementById('btn-heli').classList.toggle('active', state.helicopter);
+}
+
+function toggleWiggle() {
+  state.wiggle = !state.wiggle;
+  document.getElementById('btn-wiggle').classList.toggle('active', state.wiggle);
+  if (!state.wiggle) {
+    // Reset globals to defaults
+    for (var key in data.globals) {
+      state.globals[key] = data.globals[key].value;
+    }
+    updateSliders();
+  }
+}
+
+function resetParams() {
+  state.params = JSON.parse(JSON.stringify(state.baseParams));
+  for (var key in data.globals) {
+    state.globals[key] = data.globals[key].value;
+  }
+  updateSliders();
+  toggleRadialMenu();
+}
+
+function exportJSON() {
+  var exportData = {
+    name: data.animals[state.speciesIdx].name,
+    globals: JSON.parse(JSON.stringify(state.globals)),
+    params: JSON.parse(JSON.stringify(state.params))
+  };
+
+  var blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = exportData.name.toLowerCase() + '-params.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  toggleRadialMenu();
+}
+
+window.onload = init;
+</script>
+
+</body>
+</html>

--- a/yeti/CLAUDE.md
+++ b/yeti/CLAUDE.md
@@ -1,0 +1,132 @@
+# CLAUDE.md - Yeti Bestiary
+
+## Core Principle: Zero Code Dependencies
+
+**CRITICAL**: Yeti has **zero code dependencies** with `lucid/*`.
+
+- Do NOT import from `../lucid/`
+- Do NOT share JavaScript modules
+- Do NOT reference Lucid's core libraries
+
+The ONLY shared element is **data format compatibility** - Yeti's JSON creature definitions should be structured so they could theoretically be imported into Lucid, but the code that processes them is completely independent.
+
+## Purpose
+
+Yeti is for **weird experiments** with creature representations:
+
+1. **Parametric morphology** - Body plans as parameter vectors
+2. **Vector space projection** - Animals as points in continuous spaces
+3. **SVD/PCA decomposition** - Finding principal axes of variation
+4. **Design space exploration** - Semantic navigation of morphospace
+
+## Data Format
+
+Creature parameters use this structure (shared with Lucid):
+
+```json
+{
+  "name": "Species Name",
+  "emoji": "🦁",
+  "params": {
+    "color": [r, g, b],           // RGB 0-1
+    "bodyRadii": [x, y, z],       // Ellipsoid radii
+    "headPos": [x, y, z],         // Position offset
+    "legThighR": 0.15,            // Scalar radius
+    ...
+  }
+}
+```
+
+## Development Guidelines
+
+### Self-Contained HTML
+Each demo should be a single HTML file with embedded:
+- CSS styles
+- JavaScript logic
+- GLSL shaders
+- Creature data (JSON in `<script type="application/json">`)
+
+This keeps experiments isolated and portable.
+
+### SDF Rendering
+Use standard raymarching SDF techniques:
+- `sdEllipsoid`, `sdCapsule`, `sdRoundCone` primitives
+- `smin()` for smooth blending
+- Rotation matrices for positioning body parts
+
+### Parameter Organization
+Group parameters semantically:
+- **Global modifiers**: smoothness, scale, fatness
+- **Body parts**: body, rump, head, snout, ears, legs, tail
+- **Each part**: radii (shape) + position + rotation
+
+### Export Format
+JSON exports should include:
+- Species name
+- Global modifiers at time of export
+- Full parameter set
+- Timestamp (optional)
+
+## Experimentation Ideas
+
+### Vector Space Operations
+```javascript
+// Interpolate between two creatures
+function lerp(a, b, t) {
+  return Object.fromEntries(
+    Object.keys(a).map(k => [k, lerpValue(a[k], b[k], t)])
+  );
+}
+
+// Find centroid of multiple creatures
+function centroid(creatures) {
+  return creatures.reduce((acc, c) => lerp(acc, c, 1/creatures.length), creatures[0]);
+}
+```
+
+### SVD Decomposition
+```javascript
+// Stack creature params into matrix
+// Each row = one creature, each column = one parameter
+// SVD gives: principal components of morphological variation
+// First PC might be "size", second might be "legginess", etc.
+```
+
+### Random Walks
+```javascript
+// Generate novel creatures by random walk in param space
+function mutate(params, stepSize) {
+  return Object.fromEntries(
+    Object.entries(params).map(([k, v]) => [k, perturb(v, stepSize)])
+  );
+}
+```
+
+## File Organization
+
+```
+yeti/
+├── README.md          # Project overview
+├── CLAUDE.md          # This file
+├── 4legs/             # Parametric quadruped demo
+│   └── index.html     # Self-contained demo
+├── morphspace/        # Future: PCA visualization
+├── genetics/          # Future: evolutionary algorithms
+└── data/              # Future: creature JSON library
+```
+
+## What NOT To Do
+
+- Don't create complex build systems
+- Don't add npm dependencies
+- Don't share code with lucid/
+- Don't worry about production quality
+- Don't over-engineer - this is a playground
+
+## What TO Do
+
+- Keep experiments self-contained
+- Document interesting findings
+- Export promising creatures as JSON
+- Try weird mathematical operations on parameters
+- Break things and learn from it

--- a/yeti/README.md
+++ b/yeti/README.md
@@ -1,0 +1,93 @@
+# Yeti Bestiary
+
+A bestiary for Lucid/Holoplasm experiments and interop.
+
+## Philosophy
+
+Yeti is a **data-first** creature laboratory with **zero code dependencies** on `lucid/*`. It shares Lucid's data formats (JSON scene descriptions, SDF primitives) but maintains complete independence in implementation.
+
+This separation allows:
+- Rapid experimentation without breaking production code
+- Freedom to explore weird creature representations
+- A sandbox for mathematical approaches to creature design
+
+## What Lives Here
+
+This directory is for experimenting with:
+
+### Creature Representations as Data
+- Parametric quadruped models (ellipsoids, capsules, smooth unions)
+- Body plan schemas that capture morphological variation
+- JSON formats compatible with Lucid's SDF renderer
+
+### Vector Space Explorations
+- Projecting animals into continuous parameter spaces
+- Interpolating between species (elephant → dog morphs)
+- Finding the "centroid" of quadruped morphospace
+
+### SVD Decompositions
+- Decomposing creature parameter matrices
+- Finding principal axes of morphological variation
+- Low-rank approximations of body plans
+
+### Design Space Navigation
+- High-level sliders that traverse meaningful dimensions
+- "Fatness", "legginess", "ear prominence" as semantic axes
+- Constraint-aware parameter exploration
+
+## Data Format
+
+Creature definitions follow this schema:
+
+```json
+{
+  "name": "Elephant",
+  "emoji": "🐘",
+  "params": {
+    "color": [0.55, 0.52, 0.5],
+    "bodyRadii": [1.4, 1.1, 1.6],
+    "headRadii": [0.6, 0.55, 0.55],
+    "headPos": [0, 0.5, 1.8],
+    "legThighR": 0.28,
+    "legAnkleR": 0.22,
+    ...
+  }
+}
+```
+
+This format is designed for:
+- Direct consumption by WebGL SDF shaders
+- Easy serialization/deserialization
+- Human readability and manual tweaking
+- Mathematical operations (interpolation, PCA, clustering)
+
+## Demos
+
+### 4legs/
+Parametric quadruped engine with 53 parameters across 6 species. Features:
+- Real-time SDF rendering
+- Carousel-based species selection
+- Full parameter panel with semantic groupings
+- Export/import JSON parameter sets
+- Helicopter orbit and parameter wiggle modes
+
+## Relationship to Lucid
+
+| Aspect | Yeti | Lucid |
+|--------|------|-------|
+| Purpose | Experimentation | Production |
+| Dependencies | None | Complex |
+| Data format | Shared | Shared |
+| Code sharing | Zero | N/A |
+| Stability | Wild | Stable |
+
+Yeti can **export** JSON that Lucid can **import**, but the codebases are completely separate.
+
+## Future Directions
+
+- [ ] SVD-based morph slider (vary along principal components)
+- [ ] Creature clustering visualization
+- [ ] Parameter space random walk / genetic algorithm
+- [ ] Import from Lucid scene JSON
+- [ ] Export to Lucid-compatible format
+- [ ] Multi-creature scene composition


### PR DESCRIPTION
Add yeti/ directory as an independent sandbox for experimenting with
creature representations as data - vector spaces, SVD decompositions,
and design space exploration. Zero code dependencies with lucid/*,
shares only data formats.

Includes:
- README.md with project philosophy and data format docs
- CLAUDE.md with development guidelines
- 4legs/ parametric quadruped demo with 53 parameters across 6 species