### PR TITLE
fix(stinkyfish): Fix demo scenes and add inlineDefaults option

### DIFF
--- a/lucid/core/wgsl-codegen.js
+++ b/lucid/core/wgsl-codegen.js
@@ -23,6 +23,7 @@ export function generateWgslFromJson(scene, options = {}) {
     helpers: [],
     helperCounter: 0,
     showCutters: options.showCutters || false,
+    inlineDefaults: options.inlineDefaults || false, // Inline param defaults instead of uniforms
     localVars: {},
     instanceIdParam: null,
     sceneParams: scene.params || {},
@@ -33,14 +34,16 @@ export function generateWgslFromJson(scene, options = {}) {
     pickingMode: options.pickingMode || false
   };
 
-  // Register ALL params as uniforms
-  const allParams = getAllParamNames(scene.params || {}, scene.rig);
-  for (const [name, paramInfo] of Object.entries(allParams)) {
-    const uniformName = `u_${name}`;
-    if (paramInfo.type === 'scalar') {
-      ctx.uniforms.add(uniformName);
-    } else if (paramInfo.type === 'color3' || paramInfo.type === 'position3' || paramInfo.type === 'radii3' || paramInfo.type === 'direction3') {
-      ctx.uniforms.add(`${uniformName}:vec3f`);
+  // Register ALL params as uniforms (unless inlining defaults)
+  if (!ctx.inlineDefaults) {
+    const allParams = getAllParamNames(scene.params || {}, scene.rig);
+    for (const [name, paramInfo] of Object.entries(allParams)) {
+      const uniformName = `u_${name}`;
+      if (paramInfo.type === 'scalar') {
+        ctx.uniforms.add(uniformName);
+      } else if (paramInfo.type === 'color3' || paramInfo.type === 'position3' || paramInfo.type === 'radii3' || paramInfo.type === 'direction3') {
+        ctx.uniforms.add(`${uniformName}:vec3f`);
+      }
     }
   }
 
@@ -926,6 +929,16 @@ function valueToWgsl(value, ctx) {
     return formatFloat(value.value);
 
   case 'var':
+    // If inlineDefaults is set, use the default value from sceneParams instead of uniform
+    if (ctx.inlineDefaults && ctx.sceneParams[value.name]) {
+      const param = ctx.sceneParams[value.name];
+      const defaultVal = param.value !== undefined ? param.value : 0;
+      if (param.type === 'color3' || param.type === 'position3' || param.type === 'radii3' || param.type === 'direction3') {
+        const arr = Array.isArray(defaultVal) ? defaultVal : [0, 0, 0];
+        return `vec3f(${arr.map(v => formatFloat(v)).join(', ')})`;
+      }
+      return formatFloat(defaultVal);
+    }
     ctx.uniforms.add(`u_${value.name}`);
     return `scene.u_${value.name}`;
 

--- a/lucid/stinkyfish/demo.html
+++ b/lucid/stinkyfish/demo.html
@@ -57,10 +57,10 @@
   <header>
     <h1>Stinkyfish WebGPU</h1>
     <select id="sceneSelect">
-      <option value="sphere">Simple Sphere</option>
+      <option value="sphere" selected>Simple Sphere</option>
       <option value="csg">CSG Demo</option>
-      <option value="wolf" selected>Wolf</option>
-      <option value="elephant">Elephant</option>
+      <option value="smoothblob">Smooth Blob</option>
+      <option value="wolf">Wolf</option>
     </select>
     <button id="recompile">Recompile</button>
     <div id="status">Loading...</div>
@@ -86,66 +86,32 @@
 
     let renderer = null;
 
-    // Built-in simple scenes for testing
+    // Built-in simple scenes for testing (raw JSON format)
     const builtinScenes = {
       sphere: {
         root: {
           type: 'sphere',
-          params: {
-            r: { type: 'const', value: 1.0 },
-            color: { type: 'array', values: [
-              { type: 'const', value: 0.8 },
-              { type: 'const', value: 0.2 },
-              { type: 'const', value: 0.2 }
-            ]}
-          }
+          params: { r: 1.0, color: [0.8, 0.2, 0.2] }
         }
       },
       csg: {
         root: {
           type: 'subtract',
           children: [
-            {
-              type: 'sphere',
-              params: {
-                r: { type: 'const', value: 1.0 },
-                color: { type: 'array', values: [
-                  { type: 'const', value: 0.2 },
-                  { type: 'const', value: 0.6 },
-                  { type: 'const', value: 0.9 }
-                ]}
-              }
-            },
-            {
-              type: 'box',
-              params: {
-                size: { type: 'array', values: [
-                  { type: 'const', value: 0.6 },
-                  { type: 'const', value: 1.5 },
-                  { type: 'const', value: 0.6 }
-                ]},
-                color: { type: 'array', values: [
-                  { type: 'const', value: 1 },
-                  { type: 'const', value: 0 },
-                  { type: 'const', value: 0 }
-                ]}
-              }
-            },
-            {
-              type: 'box',
-              params: {
-                size: { type: 'array', values: [
-                  { type: 'const', value: 1.5 },
-                  { type: 'const', value: 0.6 },
-                  { type: 'const', value: 0.6 }
-                ]},
-                color: { type: 'array', values: [
-                  { type: 'const', value: 0 },
-                  { type: 'const', value: 1 },
-                  { type: 'const', value: 0 }
-                ]}
-              }
-            }
+            { type: 'sphere', params: { r: 1.0, color: [0.2, 0.6, 0.9] } },
+            { type: 'box', params: { size: [0.6, 1.5, 0.6], color: [1, 0, 0] } },
+            { type: 'box', params: { size: [1.5, 0.6, 0.6], color: [0, 1, 0] } }
+          ]
+        }
+      },
+      smoothblob: {
+        root: {
+          type: 'smoothUnion',
+          k: 0.3,
+          children: [
+            { type: 'sphere', params: { r: 0.8, color: [0.9, 0.3, 0.1] } },
+            { type: 'sphere', params: { r: 0.6, color: [0.1, 0.8, 0.3] }, transform: { translate: [1, 0.3, 0] } },
+            { type: 'sphere', params: { r: 0.5, color: [0.2, 0.4, 0.9] }, transform: { translate: [-0.8, 0.5, 0.5] } }
           ]
         }
       }
@@ -168,8 +134,8 @@
           scene = loadJsonScene(json);
         }
 
-        // Generate WGSL
-        const wgsl = generateWgslFromJson(scene, {});
+        // Generate WGSL (inlineDefaults to avoid needing scene uniform buffer)
+        const wgsl = generateWgslFromJson(scene, { inlineDefaults: true });
         console.log(`Generated ${wgsl.length} chars of WGSL for ${name}`);
 
         // Compile


### PR DESCRIPTION
- Fix built-in scenes to use raw JSON format (not IR format)
- Add smoothblob demo scene
- Add inlineDefaults option to wgsl-codegen
- When inlineDefaults=true, param values are inlined instead of requiring a SceneUniforms buffer

This allows the demo to render complex scenes like wolf without needing to set up the scene uniform buffer.