### PR TITLE
feat(lucid): Add conic sections educational demo

### DIFF
--- a/lucid/scenes/math/conic-sections.json
+++ b/lucid/scenes/math/conic-sections.json
@@ -1,0 +1,142 @@
+{
+  "title": "Conic Sections",
+  "subtitle": "Slice a cone to reveal circles, ellipses, parabolas, and hyperbolas",
+  "version": "1.0",
+  "notes": "Educational demo inspired by science museum laser cut exhibits. Adjust the cutting plane angle to see different conic sections emerge. Circle (0°), Ellipse (~15°), Parabola (~27°), Hyperbola (>30°).",
+
+  "camera": {
+    "distance": 6,
+    "phi": 0.4,
+    "theta": 0.3,
+    "target": [0, 0, 0]
+  },
+
+  "params": {
+    "_cutting": "=== CUTTING PLANE ===",
+    "cutAngle": {
+      "value": 0,
+      "type": "scalar",
+      "min": 0,
+      "max": 60,
+      "description": "Cutting plane angle (degrees from horizontal). 0=circle, ~15=ellipse, ~27=parabola, >30=hyperbola"
+    },
+    "cutPosition": {
+      "value": 0.5,
+      "type": "scalar",
+      "min": -1.0,
+      "max": 1.5,
+      "description": "Height of cutting plane center"
+    },
+
+    "_cone": "=== CONE GEOMETRY ===",
+    "coneHeight": {
+      "value": 2.0,
+      "type": "scalar",
+      "min": 1.0,
+      "max": 3.0,
+      "description": "Height of each cone nappe"
+    },
+    "coneRadius": {
+      "value": 1.0,
+      "type": "scalar",
+      "min": 0.5,
+      "max": 1.5,
+      "description": "Base radius of cone"
+    },
+
+    "_appearance": "=== COLORS ===",
+    "coneColor": {
+      "value": [0.3, 0.6, 0.9],
+      "type": "color3",
+      "description": "Cone surface color"
+    },
+    "cutPlaneColor": {
+      "value": [1.0, 0.3, 0.3],
+      "type": "color3",
+      "description": "Cutting plane indicator color"
+    },
+    "crossSectionColor": {
+      "value": [1.0, 0.9, 0.2],
+      "type": "color3",
+      "description": "Cross-section surface color"
+    }
+  },
+
+  "defs": {
+    "singleCone": {
+      "comment": "Single cone nappe - tip at origin, opens upward",
+      "type": "cone",
+      "params": {
+        "h": { "var": "coneHeight" },
+        "r1": 0.001,
+        "r2": { "var": "coneRadius" },
+        "color": { "var": "coneColor" }
+      }
+    },
+
+    "doubleCone": {
+      "comment": "Double cone (bicone) - two nappes meeting at apex",
+      "type": "union",
+      "children": [
+        {
+          "comment": "Upper nappe - opens upward",
+          "type": "ref",
+          "id": "singleCone"
+        },
+        {
+          "comment": "Lower nappe - opens downward (mirrored)",
+          "type": "ref",
+          "id": "singleCone",
+          "transform": { "rotate": [180, 0, 0] }
+        }
+      ]
+    },
+
+    "cuttingPlaneVisual": {
+      "comment": "Visual indicator for the cutting plane - thin translucent rectangle",
+      "type": "box",
+      "params": {
+        "size": [3.0, 0.02, 3.0],
+        "color": { "var": "cutPlaneColor" }
+      }
+    }
+  },
+
+  "root": {
+    "type": "union",
+    "children": [
+      {
+        "comment": "=== CUT CONE: Intersection of double cone with half-space ===",
+        "type": "intersect",
+        "children": [
+          {
+            "type": "ref",
+            "id": "doubleCone"
+          },
+          {
+            "comment": "Half-space below the cutting plane",
+            "type": "plane",
+            "params": {
+              "normal": [0, -1, 0],
+              "h": 0,
+              "color": { "var": "crossSectionColor" }
+            },
+            "transform": {
+              "translate": [0, { "var": "cutPosition" }, 0],
+              "rotate": [{ "var": "cutAngle" }, 0, 0]
+            }
+          }
+        ]
+      },
+      {
+        "comment": "=== CUTTING PLANE INDICATOR ===",
+        "type": "ref",
+        "id": "cuttingPlaneVisual",
+        "transform": {
+          "translate": [0, { "var": "cutPosition" }, 0],
+          "rotate": [{ "var": "cutAngle" }, 0, 0]
+        }
+      }
+    ]
+  }
+}

--- a/lucid/scenes/toc.json
+++ b/lucid/scenes/toc.json
@@ -225,6 +225,19 @@
       ]
     },
     {
+      "id": "math",
+      "title": "📐 Math",
+      "description": "Interactive mathematical concepts",
+      "scenes": [
+        {
+          "path": "math/conic-sections.json",
+          "title": "Conic Sections",
+          "subtitle": "Slice a cone to reveal circles, ellipses, parabolas, hyperbolas",
+          "isAnimated": false
+        }
+      ]
+    },
+    {
       "id": "anim",
       "title": "5. Animation",
       "description": "Time-based motion",


### PR DESCRIPTION
Interactive SDF scene showing how plane cuts through a double cone
reveal different conic sections (circle, ellipse, parabola, hyperbola).

- cutAngle parameter controls cutting plane angle (0-60 degrees)
- cutPosition controls height of cutting plane
- Visual cutting plane indicator shows where the cut occurs
- Double cone (bicone) allows hyperbola visualization

Inspired by science museum laser cut exhibits.