### PR TITLE
edot: mobile-first fixes (tap-to-focus, touch menu, locked app shell)

### DIFF
--- a/magpie/edot/README.md
+++ b/magpie/edot/README.md
@@ -142,6 +142,7 @@ toolbar wiring:
 ```bash
 node magpie/edot/test-edot.mjs       # functional smoke test (39 checks)
 node magpie/edot/test-e2e.mjs        # end-to-end UI driving (16 checks)
+node magpie/edot/test-mobile.mjs     # mobile: tap-to-focus, touch menu, locked shell
 node magpie/edot/verify-pdf.mjs      # deep PDF structural validation + sample
 ```
 

--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -34,6 +34,15 @@
 
 * { box-sizing: border-box; }
 
+/* Native-app feel on touch: no double-tap zoom delay, no long-press callout
+   on the chrome, and no rubber-band/overscroll leaking to the browser. */
+html {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+  -webkit-text-size-adjust: 100%;
+}
+
 html, body {
   margin: 0;
   height: 100%;
@@ -45,7 +54,24 @@ html, body {
 body {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100dvh;            /* dynamic viewport: accounts for mobile chrome */
+  height: 100vh;             /* fallback for browsers without dvh */
+  height: 100dvh;
+  overflow: hidden;          /* only .app-main scrolls */
+  overscroll-behavior: none;
+  /* respect notches / rounded corners */
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);
+}
+
+/* Interactive controls: kill the 300ms tap delay and double-tap zoom, and
+   suppress the iOS long-press selection/callout on UI chrome. */
+.tbtn, .menu-item, button, select, input, label, .find-bar, .doc-row {
+  touch-action: manipulation;
+}
+.app-header, .toolbar, .statusbar, .menu-panel, .find-bar, .dialog-head, .dialog-foot {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 /* Skip link for keyboard/screen-reader users */
@@ -164,10 +190,16 @@ select.tbtn {
 /* ---- Main / page ---- */
 .app-main {
   flex: 1 1 auto;
-  overflow: auto;
-  padding: 1rem 0.75rem 4rem;
+  min-height: 0;                    /* let the flex child shrink & scroll */
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;     /* don't chain scroll to the document */
+  -webkit-overflow-scrolling: touch;
+  padding: 1rem 0.75rem calc(4rem + env(safe-area-inset-bottom));
   display: flex;
   justify-content: center;
+  /* Tapping the margin around the page should still land on the editor. */
+  cursor: text;
 }
 
 .page {
@@ -175,6 +207,10 @@ select.tbtn {
   width: 100%;
   max-width: var(--page-max);
   min-height: 60vh;
+  cursor: text;
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
   padding: clamp(1rem, 4vw, 4rem);
   border: 1px solid var(--line);
   border-radius: var(--radius);
@@ -220,7 +256,7 @@ select.tbtn {
   display: flex;
   gap: 1rem;
   align-items: center;
-  padding: 0.3rem 0.75rem;
+  padding: 0.3rem 0.75rem calc(0.3rem + env(safe-area-inset-bottom));
   background: var(--surface);
   border-top: 1px solid var(--line);
   font-size: 0.8rem;
@@ -264,6 +300,25 @@ select.tbtn {
 .menu-item:hover, .menu-item:focus-visible { background: var(--toolbar-bg); outline: none; }
 .menu-item .hint { margin-left: auto; color: var(--muted); font-size: 0.8em; }
 .menu-sep { height: 1px; background: var(--line); margin: 0.3rem 0; }
+
+/* On phones, the File menu drops as a roomy, finger-sized panel pinned to the
+   left edge so it never overflows off-screen. */
+@media (max-width: 30rem) {
+  .menu-panel {
+    position: fixed;
+    left: 0.5rem;
+    right: 0.5rem;
+    top: auto;
+    min-width: 0;
+    max-height: 70dvh;
+    overflow: auto;
+  }
+  .menu-item { padding: 0.85em 0.7em; font-size: 1.05rem; }
+  .menu-item .hint { display: none; }
+}
+@media (pointer: coarse) {
+  .menu-item { padding: 0.75em 0.7em; }
+}
 
 /* ---- Document library dialog ---- */
 .dialog {

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -2,9 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="edot — a small, modular, accessible browser word processor with native DOCX/Markdown/HTML I/O and an optional LibreOffice WASM bridge.">
   <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#efece6" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#2c2c2c" media="(prefers-color-scheme: dark)">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>edot — accessible word processor</title>
   <link rel="stylesheet" href="css/edot.css">
 </head>

--- a/magpie/edot/js/editor.js
+++ b/magpie/edot/js/editor.js
@@ -50,6 +50,20 @@ export class Editor {
 
   focus() { this.el.focus(); }
 
+  // Focus and drop the caret at the very end. Used when a tap lands on the
+  // page margin or empty area — on mobile this is what actually raises the
+  // on-screen keyboard, since it runs inside the tap gesture.
+  focusEnd() {
+    this.el.focus();
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(this.el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+
   // Called by toolbar after a command runs, and internally on input.
   onChange() {
     this._updateEmpty();

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -76,6 +76,17 @@ class App {
   }
 
   _wireEditor() {
+    // Tap anywhere in the page area (margins / empty space) to start typing.
+    // Mobile browsers won't raise the keyboard unless focus happens inside the
+    // tap gesture, and a tap on the grey margin or empty doc otherwise does
+    // nothing — so force-focus the editor when the tap didn't land in it.
+    const main = document.querySelector('.app-main');
+    main.addEventListener('click', () => {
+      if (document.activeElement !== this.editorEl && !this.editorEl.contains(document.activeElement)) {
+        this.editor.focusEnd();
+      }
+    });
+
     this.editor.onSelectionCallback(() => this.toolbar.refresh());
     this.editor.onChangeCallback(() => {
       this._refreshStats();

--- a/magpie/edot/test-mobile.mjs
+++ b/magpie/edot/test-mobile.mjs
@@ -1,0 +1,66 @@
+// test-mobile.mjs — mobile-first behaviour: tap-to-focus (keyboard),
+// touch-driven File menu, and a locked app shell (no document overscroll).
+import { chromium } from 'playwright-core';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' };
+const server = http.createServer(async (req, res) => { try { const rel = decodeURIComponent(req.url.split('?')[0]).replace(/^\//, '') || 'edot.html'; const buf = await readFile(path.join(DIR, rel)); res.writeHead(200, { 'Content-Type': MIME[path.extname(rel)] || 'application/octet-stream' }); res.end(buf); } catch { res.writeHead(404); res.end(); } });
+await new Promise((r) => server.listen(0, r)); const port = server.address().port;
+const b = await chromium.launch({ headless: true, executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome', args: ['--no-sandbox'] });
+let fail = 0; const ok = (n, c) => { console.log(`${c ? '✅' : '❌'} ${n}`); if (!c) fail++; };
+try {
+  // iPhone-ish: small viewport, touch, mobile UA.
+  const ctx = await b.newContext({ viewport: { width: 390, height: 720 }, hasTouch: true, isMobile: true, deviceScaleFactor: 2 });
+  const page = await ctx.newPage();
+  const errs = []; page.on('pageerror', (e) => errs.push(String(e)));
+  await page.goto(`http://127.0.0.1:${port}/edot.html`);
+  await page.waitForFunction(() => !!window.__edot && !!window.__edot.doc);
+
+  // Start a clean doc, then TAP the empty page area -> editor must take focus.
+  await page.click('#menu-button'); await page.tap('#mi-new'); await page.waitForTimeout(200);
+  // tap low in the page (empty region / margin), not on text
+  const box = await page.locator('#editor').boundingBox();
+  await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height - 20);
+  await page.waitForTimeout(150);
+  ok('tap empty area focuses the editor', await page.evaluate(() => document.activeElement && document.activeElement.id === 'editor'));
+
+  // Now typing should land in the editor.
+  await page.keyboard.type('typed on mobile');
+  await page.waitForTimeout(150);
+  ok('typing after tap reaches the editor', /typed on mobile/.test(await page.textContent('#editor')));
+
+  // File menu opens on tap and an item is reachable.
+  await page.tap('#menu-button'); await page.waitForTimeout(150);
+  ok('File menu opens on tap', await page.isVisible('#menu-panel'));
+  ok('menu button reports expanded', await page.getAttribute('#menu-button', 'aria-expanded') === 'true');
+  ok('a Save-as item is visible', await page.isVisible('text=Save as PDF'));
+  // tapping an item acts (open library dialog) and closes the menu
+  await page.tap('#mi-docs'); await page.waitForTimeout(200);
+  ok('menu item action fired (library dialog open)', await page.evaluate(() => document.getElementById('docs-dialog').open === true));
+  await page.evaluate(() => document.getElementById('docs-dialog').close());
+
+  // App shell is locked: body/html don't scroll, overscroll contained.
+  const shell = await page.evaluate(() => {
+    const cs = (el) => getComputedStyle(el);
+    return {
+      htmlOverflow: cs(document.documentElement).overflow,
+      bodyOverflow: cs(document.body).overflow,
+      htmlOverscroll: cs(document.documentElement).overscrollBehavior || cs(document.documentElement).overscrollBehaviorY,
+      mainOverscroll: cs(document.querySelector('.app-main')).overscrollBehavior || cs(document.querySelector('.app-main')).overscrollBehaviorY,
+      bodyScrollable: document.body.scrollHeight > document.body.clientHeight + 1,
+    };
+  });
+  ok('html overflow hidden', shell.htmlOverflow === 'hidden');
+  ok('body overflow hidden', shell.bodyOverflow === 'hidden');
+  ok('document overscroll is none', /none/.test(shell.htmlOverscroll));
+  ok('scroll region contains overscroll', /contain/.test(shell.mainOverscroll));
+  ok('body itself does not scroll', shell.bodyScrollable === false);
+
+  ok('no page errors', errs.length === 0);
+  if (errs.length) console.log(errs);
+} finally { await b.close(); server.close(); }
+console.log(fail ? `\n${fail} MOBILE FAILURE(S)` : '\nMOBILE OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Fixes three real mobile defects reported on device.

1. **Tapping the empty page area didn't raise the keyboard.** Added `Editor.focusEnd()` and an `.app-main` tap handler that force-focuses the editor (caret to end) when a tap lands on the margin/empty doc — run inside the tap gesture, which is what mobile browsers require to show the on-screen keyboard. Typing then lands correctly.

2. **File menu was awkward/unreachable on phones.** On ≤30rem it now drops as a full-width, finger-sized panel pinned to the screen edges (no off-screen overflow), with larger touch targets. Menu/buttons get `touch-action: manipulation` (kills the 300ms delay and double-tap zoom).

3. **Touch scroll/overscroll leaked to the browser ("breaking the 4th wall").** Locked the shell: `html`/`body` `height:100dvh` + `overflow:hidden` + `overscroll-behavior:none`; only `.app-main` scrolls (`overscroll-behavior:contain`). Added `viewport-fit=cover` + safe-area insets, `theme-color`, mobile-web-app metas, and `-webkit-touch-callout`/`user-select:none` on the chrome (the editor stays selectable).

### Testing
- New `test-mobile.mjs` emulates an iPhone (touch + mobile UA): **12/12** — tap-to-focus + typing, touch-driven File menu and item actions, and a confirmed non-scrolling shell with contained overscroll.
- Existing `test-edot.mjs` (39) and `test-e2e.mjs` (16) still green. HTML validates clean.

**Caveat:** verified with Chromium mobile emulation, not real iOS Safari — keyboard-raising and `100dvh` can differ on actual devices.

Once merged, redeploys to `https://danbri.github.io/glitchcan-minigam/magpie/edot/edot.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_