### PR TITLE
edot: DOCX tables & images on import (+ table round-trip)

### DIFF
--- a/magpie/edot/README.md
+++ b/magpie/edot/README.md
@@ -24,7 +24,9 @@ offline, and dependency-free.
   documents** lists, opens, renames, duplicates, and deletes them. Nothing is
   ever uploaded.
 - **Real file I/O, offline & dependency-free:**
-  - **Word `.docx`** — native OOXML read *and* write.
+  - **Word `.docx`** — native OOXML read *and* write, including **tables**,
+    **embedded images** (imported as data-URLs), headings, lists, alignment,
+    and hyperlinks.
   - **PDF** — native multi-page export (A4, base-14 fonts, wrapped text flow,
     inline bold/italic/links, lists, quotes, code, page breaks). No backend.
   - **HTML + RDFa** — standalone self-styled documents that declare common
@@ -140,9 +142,9 @@ replace, the document library persistence across reloads, the sanitizer, and the
 toolbar wiring:
 
 ```bash
-node magpie/edot/test-edot.mjs       # functional smoke test (39 checks)
+node magpie/edot/test-edot.mjs       # functional smoke test (45 checks)
 node magpie/edot/test-e2e.mjs        # end-to-end UI driving (16 checks)
-node magpie/edot/test-mobile.mjs     # mobile: tap-to-focus, touch menu, locked shell
+node magpie/edot/test-mobile.mjs     # mobile: tap-to-focus, touch menu, locked shell (14 checks)
 node magpie/edot/verify-pdf.mjs      # deep PDF structural validation + sample
 ```
 
@@ -152,10 +154,16 @@ xref offsets, trailer→catalog→pages chain, and content-stream lengths.)
 
 ## Limits / honest scope
 
-- The native `.docx` writer covers paragraphs, Heading 1–3, bold/italic/
-  underline/strike runs, ordered & unordered lists, block quotes, code, and
-  hyperlinks. **Tables, images, footnotes, and complex styles need the
+- The native `.docx` path covers paragraphs, Heading 1–3, bold/italic/
+  underline/strike runs, ordered & unordered lists, block quotes, code,
+  hyperlinks, alignment, **tables**, and **images**. Import brings tables and
+  embedded images in (images become data-URLs); export writes tables back.
+  **Image *export* to .docx, footnotes, and complex styles still need the
   LibreOffice WASM backend.**
+- **PDF export** currently renders text, lists, quotes and code; tables are
+  flattened to text and images are omitted (both are on the roadmap).
+- Tables and images that can't be represented in **Markdown/plain text** are
+  exported as a GFM table / `![alt](src)` where possible, else dropped.
 - PDF export uses the base-14 fonts and WinAnsi/Latin-1 text; characters outside
   that range (e.g. CJK, emoji) are exported as `?`. Inline styling is per-run
   (bold/italic/links); it does not embed images or tables.

--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -236,6 +236,23 @@ select.tbtn {
   color: var(--muted);
 }
 .page a { color: var(--focus); }
+.page img { max-width: 100%; height: auto; }
+.page figure { margin: 0 0 0.8em; text-align: center; }
+.page figcaption { font-size: 0.85em; color: var(--muted); margin-top: 0.3em; }
+.page table {
+  border-collapse: collapse;
+  margin: 0 0 0.8em;
+  max-width: 100%;
+  font-size: 0.95em;
+}
+.page td, .page th {
+  border: 1px solid var(--line);
+  padding: 0.3em 0.55em;
+  vertical-align: top;
+  text-align: left;
+}
+.page th { background: var(--toolbar-bg); font-weight: 700; }
+.page caption { caption-side: top; font-size: 0.85em; color: var(--muted); margin-bottom: 0.3em; }
 .page pre {
   background: var(--bg);
   padding: 0.8em;

--- a/magpie/edot/js/document-model.js
+++ b/magpie/edot/js/document-model.js
@@ -10,11 +10,18 @@ const ALLOWED = new Set([
   'B', 'STRONG', 'I', 'EM', 'U', 'S', 'STRIKE', 'SUB', 'SUP',
   'UL', 'OL', 'LI', 'BLOCKQUOTE', 'PRE', 'CODE',
   'A', 'HR', 'SPAN',
+  // Tables, images and figures (imported from .docx / pasted from the web).
+  'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR', 'TD', 'TH', 'CAPTION',
+  'COLGROUP', 'COL', 'IMG', 'FIGURE', 'FIGCAPTION',
 ]);
 
 const ALLOWED_ATTR = {
   A: ['href', 'title'],
   SPAN: [],   // span kept only as a transparent wrapper; attrs stripped
+  IMG: ['src', 'alt', 'width', 'height'],
+  TD: ['colspan', 'rowspan'],
+  TH: ['colspan', 'rowspan', 'scope'],
+  COL: ['span', 'width'],
 };
 
 // RDFa Lite + Core attributes are preserved on *any* allowed element so
@@ -67,6 +74,11 @@ function sanitizeNode(node, doc) {
           // Defang any URL-bearing attribute carrying javascript:.
           if ((name === 'href' || name === 'src' || name === 'resource' || name === 'about') &&
               /^\s*javascript:/i.test(attr.value)) {
+            child.removeAttribute(attr.name);
+          }
+          // img/src: permit only image data URLs, http(s), and relative paths.
+          if (name === 'src' && /^\s*data:/i.test(attr.value) &&
+              !/^\s*data:image\//i.test(attr.value)) {
             child.removeAttribute(attr.name);
           }
         } else {

--- a/magpie/edot/js/io-docx.js
+++ b/magpie/edot/js/io-docx.js
@@ -104,9 +104,41 @@ function blockToXml(el, rels, ctx = {}) {
       .map((li) => paraXml(inlineRuns(li, {}, rels), { list: kind, align: jcOf(li) }))
       .join('');
   }
+  if (tag === 'TABLE') return tableXml(el, rels);
   if (tag === 'HR') return paraXml('', {});
   // Fallback: treat as paragraph.
   return paraXml(inlineRuns(el, {}, rels), { align });
+}
+
+// <table> -> w:tbl with single borders. Each cell holds at least one w:p.
+function tableXml(table, rels) {
+  const rows = Array.from(table.rows);
+  let cols = 0;
+  if (rows[0]) Array.from(rows[0].cells).forEach((c) => { cols += c.colSpan || 1; });
+  cols = cols || 1;
+  const grid = `<w:tblGrid>${Array.from({ length: cols }, () =>
+    `<w:gridCol w:w="${Math.floor(9000 / cols)}"/>`).join('')}</w:tblGrid>`;
+  const borders = '<w:tblBorders>' +
+    ['top', 'left', 'bottom', 'right', 'insideH', 'insideV']
+      .map((s) => `<w:${s} w:val="single" w:sz="4" w:color="999999"/>`).join('') +
+    '</w:tblBorders>';
+  let xml = `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/>${borders}</w:tblPr>${grid}`;
+  for (const tr of rows) {
+    xml += '<w:tr>';
+    for (const cell of Array.from(tr.cells)) {
+      const span = cell.colSpan || 1;
+      const spanXml = span > 1 ? `<w:gridSpan w:val="${span}"/>` : '';
+      const blocks = Array.from(cell.children).filter((c) =>
+        /^(P|H[1-6]|UL|OL|BLOCKQUOTE|PRE|TABLE)$/.test(c.tagName));
+      let content = blocks.length
+        ? blocks.map((b) => blockToXml(b, rels)).join('')
+        : paraXml(inlineRuns(cell, cell.tagName === 'TH' ? { b: true } : {}, rels));
+      if (!/<w:p[ />]/.test(content)) content += '<w:p/>'; // a tc needs >=1 w:p
+      xml += `<w:tc><w:tcPr>${spanXml}</w:tcPr>${content}</w:tc>`;
+    }
+    xml += '</w:tr>';
+  }
+  return xml + '</w:tbl>';
 }
 
 function makeRels() {
@@ -171,7 +203,8 @@ export async function docxToHtml(arrayBuffer) {
   const xml = new DOMParser().parseFromString(utf8.decode(docXml), 'application/xml');
   const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
   const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
-  const paras = xml.getElementsByTagNameNS(W, 'p');
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const VML = 'urn:schemas-microsoft-com:vml';
   const out = [];
   let listBuffer = null; // { tag, items: [] }
 
@@ -179,18 +212,58 @@ export async function docxToHtml(arrayBuffer) {
     if (listBuffer) { out.push(`<${listBuffer.tag}>${listBuffer.items.join('')}</${listBuffer.tag}>`); listBuffer = null; }
   };
 
+  const bytesToBase64 = (bytes) => {
+    let bin = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+      bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return btoa(bin);
+  };
+
+  // Embedded images: relationship id -> data-URL <img>.
+  const imgFor = (id) => {
+    if (!id) return '';
+    const target = relMap[id];
+    if (!target) return '';
+    const rel = target.replace(/^\//, '');
+    const bytes = entries['word/' + rel] || entries[rel];
+    if (!bytes) return '';
+    const ext = (rel.split('.').pop() || '').toLowerCase();
+    const mime = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+      bmp: 'image/bmp', webp: 'image/webp', svg: 'image/svg+xml' }[ext];
+    if (!mime) return ''; // skip EMF/WMF and other non-browser image formats
+    return `<img src="data:${mime};base64,${bytesToBase64(bytes)}" alt="">`;
+  };
+
+  const runImages = (run) => {
+    let html = '';
+    Array.from(run.getElementsByTagNameNS(A, 'blip')).forEach((blip) => {
+      html += imgFor(blip.getAttributeNS(R, 'embed') || blip.getAttributeNS(R, 'link'));
+    });
+    Array.from(run.getElementsByTagNameNS(VML, 'imagedata')).forEach((im) => {
+      html += imgFor(im.getAttributeNS(R, 'id'));
+    });
+    return html;
+  };
+
+  // Build a run's HTML by walking its children in order (text, <br>, tab,
+  // image) — no text sentinel, so line breaks survive cleanly.
   const runHtml = (run) => {
     const rPr = run.getElementsByTagNameNS(W, 'rPr')[0];
-    let text = '';
-    Array.from(run.getElementsByTagNameNS(W, 't')).forEach((t) => { text += t.textContent; });
-    if (run.getElementsByTagNameNS(W, 'br').length) text += ' BR ';
-    let html = xmlEscapeText(text).replace(/ BR /g, '<br>');
-    if (!rPr) return html;
-    if (rPr.getElementsByTagNameNS(W, 'b').length) html = `<strong>${html}</strong>`;
-    if (rPr.getElementsByTagNameNS(W, 'i').length) html = `<em>${html}</em>`;
-    if (rPr.getElementsByTagNameNS(W, 'u').length) html = `<u>${html}</u>`;
-    if (rPr.getElementsByTagNameNS(W, 'strike').length) html = `<s>${html}</s>`;
-    return html;
+    let html = '';
+    Array.from(run.childNodes).forEach((n) => {
+      if (n.localName === 't') html += xmlEscapeText(n.textContent);
+      else if (n.localName === 'br' || n.localName === 'cr') html += '<br>';
+      else if (n.localName === 'tab') html += ' ';
+    });
+    if (rPr) {
+      if (rPr.getElementsByTagNameNS(W, 'b').length) html = `<strong>${html}</strong>`;
+      if (rPr.getElementsByTagNameNS(W, 'i').length) html = `<em>${html}</em>`;
+      if (rPr.getElementsByTagNameNS(W, 'u').length) html = `<u>${html}</u>`;
+      if (rPr.getElementsByTagNameNS(W, 'strike').length) html = `<s>${html}</s>`;
+    }
+    return html + runImages(run);
   };
 
   const inlineHtml = (p) => {
@@ -217,7 +290,28 @@ export async function docxToHtml(arrayBuffer) {
     return css ? ` style="text-align: ${css}"` : '';
   };
 
-  for (const p of paras) {
+  // w:tbl -> <table> (recursive for nested tables; honours gridSpan).
+  const renderTable = (tbl) => {
+    const rows = Array.from(tbl.childNodes).filter((n) => n.localName === 'tr');
+    let html = '<table>';
+    for (const tr of rows) {
+      html += '<tr>';
+      const cells = Array.from(tr.childNodes).filter((n) => n.localName === 'tc');
+      for (const tc of cells) {
+        const tcPr = Array.from(tc.childNodes).find((n) => n.localName === 'tcPr');
+        const gridSpan = tcPr && tcPr.getElementsByTagNameNS(W, 'gridSpan')[0];
+        const span = gridSpan ? parseInt(gridSpan.getAttributeNS(W, 'val'), 10) : 1;
+        const parts = Array.from(tc.childNodes)
+          .filter((n) => n.localName === 'p' || n.localName === 'tbl')
+          .map((n) => (n.localName === 'tbl' ? renderTable(n) : (inlineHtml(n) || '')));
+        html += `<td${span > 1 ? ` colspan="${span}"` : ''}>${parts.join('<br>')}</td>`;
+      }
+      html += '</tr>';
+    }
+    return html + '</table>';
+  };
+
+  const handleParagraph = (p) => {
     const pPr = p.getElementsByTagNameNS(W, 'pPr')[0];
     const styleEl = pPr && pPr.getElementsByTagNameNS(W, 'pStyle')[0];
     const style = styleEl ? styleEl.getAttributeNS(W, 'val') : '';
@@ -231,7 +325,7 @@ export async function docxToHtml(arrayBuffer) {
       const tag = numId === '2' ? 'ol' : 'ul';
       if (!listBuffer || listBuffer.tag !== tag) { flushList(); listBuffer = { tag, items: [] }; }
       listBuffer.items.push(`<li${al}>${inner || '<br>'}</li>`);
-      continue;
+      return;
     }
     flushList();
 
@@ -240,6 +334,15 @@ export async function docxToHtml(arrayBuffer) {
     if (hMatch) out.push(`<h${h}${al}>${inner || '<br>'}</h${h}>`);
     else if (/^Code$/i.test(style)) out.push(`<pre><code>${p.textContent ? xmlEscapeText(p.textContent) : ''}</code></pre>`);
     else out.push(`<p${al}>${inner || '<br>'}</p>`);
+  };
+
+  // Walk the body in document order so tables keep their place and aren't
+  // flattened into the surrounding paragraph stream.
+  const bodyEl = xml.getElementsByTagNameNS(W, 'body')[0];
+  const topNodes = bodyEl ? Array.from(bodyEl.childNodes).filter((n) => n.nodeType === Node.ELEMENT_NODE) : [];
+  for (const el of topNodes) {
+    if (el.localName === 'p') handleParagraph(el);
+    else if (el.localName === 'tbl') { flushList(); out.push(renderTable(el)); }
   }
   flushList();
 

--- a/magpie/edot/js/io-html.js
+++ b/magpie/edot/js/io-html.js
@@ -24,6 +24,12 @@ const DOC_CSS = `
   pre { background: #f4f4f2; padding: 0.8em; border-radius: 6px; overflow: auto; }
   code { font-family: ui-monospace, Menlo, Consolas, monospace; }
   a { color: #1a73e8; }
+  img { max-width: 100%; height: auto; }
+  figure { margin: 0 0 1em; text-align: center; }
+  figcaption { font-size: 0.85em; color: #555; }
+  table { border-collapse: collapse; margin: 0 0 1em; max-width: 100%; }
+  td, th { border: 1px solid #d9d6cf; padding: 0.3em 0.55em; vertical-align: top; text-align: left; }
+  th { background: #f4f4f2; }
   [property], [typeof] { } /* semantic spans render inline, unstyled by default */`;
 
 /**

--- a/magpie/edot/js/io-markdown.js
+++ b/magpie/edot/js/io-markdown.js
@@ -13,6 +13,8 @@ function inline(text) {
   let s = escapeHtml(text);
   // code spans first so their contents aren't re-processed
   s = s.replace(/`([^`]+)`/g, (_, c) => `<code>${c}</code>`);
+  // Images before links (image syntax embeds the link form).
+  s = s.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_, alt, src) => `<img src="${src}" alt="${alt}">`);
   s = s.replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
     (_, t, href, title) => `<a href="${href}"${title ? ` title="${title}"` : ''}>${t}</a>`);
   s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
@@ -103,6 +105,7 @@ export function htmlToMarkdown(html) {
         case 'S': case 'STRIKE': s += `~~${inner}~~`; break;
         case 'CODE': s += `\`${inner}\``; break;
         case 'A': s += `[${inner}](${n.getAttribute('href') || ''})`; break;
+        case 'IMG': s += `![${n.getAttribute('alt') || ''}](${n.getAttribute('src') || ''})`; break;
         case 'BR': s += '  \n'; break;
         default: s += inner;
       }
@@ -134,6 +137,8 @@ export function htmlToMarkdown(html) {
       blocks.push(items.join('\n'));
     } else if (tag === 'HR') {
       blocks.push('---');
+    } else if (tag === 'TABLE') {
+      blocks.push(tableToMarkdown(node, inlineMd));
     } else {
       const t = inlineMd(node).trim();
       if (t) blocks.push(t);
@@ -141,4 +146,15 @@ export function htmlToMarkdown(html) {
   });
 
   return blocks.join('\n\n').replace(/\n{3,}/g, '\n\n').trim() + '\n';
+}
+
+// GFM table. First row becomes the header; cell pipes/newlines are escaped.
+function tableToMarkdown(table, inlineMd) {
+  const rows = Array.from(table.rows);
+  if (!rows.length) return '';
+  const cell = (c) => inlineMd(c).replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim();
+  const toLine = (tr) => `| ${Array.from(tr.cells).map(cell).join(' | ')} |`;
+  const cols = rows[0].cells.length || 1;
+  const sep = `| ${Array.from({ length: cols }, () => '---').join(' | ')} |`;
+  return [toLine(rows[0]), sep, ...rows.slice(1).map(toLine)].join('\n');
 }

--- a/magpie/edot/test-edot.mjs
+++ b/magpie/edot/test-edot.mjs
@@ -205,6 +205,65 @@ try {
   ok('find locates all matches', fr.count === 3);
   ok('replace all replaces every match', !/foo/.test(fr.html) && (fr.html.match(/X/g) || []).length === 3);
 
+  // 9d. DOCX with a table + embedded image: build a real fixture, import it.
+  const docxRich = await page.evaluate(async () => {
+    const { zipSync } = await import('./js/zip.js');
+    const { docxToHtml } = await import('./js/io-docx.js');
+    // 1x1 transparent PNG
+    const pngB64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+    const bin = atob(pngB64);
+    const png = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) png[i] = bin.charCodeAt(i);
+    const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+      'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+      'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"';
+    const doc = `<?xml version="1.0"?>
+<w:document ${NS}><w:body>
+<w:p><w:r><w:t>Before table</w:t></w:r></w:p>
+<w:tbl>
+  <w:tr><w:tc><w:p><w:r><w:t>A1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>B1</w:t></w:r></w:p></w:tc></w:tr>
+  <w:tr><w:tc><w:p><w:r><w:t>A2</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>B2</w:t></w:r></w:p></w:tc></w:tr>
+</w:tbl>
+<w:p><w:r><w:drawing><a:graphic><a:graphicData><a:blip r:embed="rId10"/></a:graphicData></a:graphic></w:drawing></w:r></w:p>
+</w:body></w:document>`;
+    const files = {
+      '[Content_Types].xml': '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>',
+      '_rels/.rels': '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>',
+      'word/document.xml': doc,
+      'word/_rels/document.xml.rels': '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/></Relationships>',
+      'word/media/image1.png': png,
+    };
+    const blob = await zipSync(files);
+    return docxToHtml(await blob.arrayBuffer());
+  });
+  ok('docx import renders a table', /<table>(?:<tbody>)?<tr><td>A1<\/td><td>B1<\/td><\/tr><tr><td>A2<\/td><td>B2<\/td><\/tr>(?:<\/tbody>)?<\/table>/.test(docxRich));
+  ok('docx import embeds the image as data-URL', /<img src="data:image\/png;base64,iVBOR/.test(docxRich));
+  ok('docx import keeps document order (text, table, image)',
+    docxRich.indexOf('Before table') < docxRich.indexOf('<table>') && docxRich.indexOf('<table>') < docxRich.indexOf('<img'));
+
+  // 9e. Table round-trips: HTML -> DOCX -> HTML, and HTML -> Markdown.
+  const tableTrip = await page.evaluate(async () => {
+    const { htmlToDocx, docxToHtml } = await import('./js/io-docx.js');
+    const { htmlToMarkdown } = await import('./js/io-markdown.js');
+    const src = '<table><tr><th>H1</th><th>H2</th></tr><tr><td>a</td><td>b</td></tr></table>';
+    const docx = await htmlToDocx(src, 'T');
+    const back = await docxToHtml(await docx.arrayBuffer());
+    const md = htmlToMarkdown(src);
+    return { back, md };
+  });
+  ok('docx export+import preserves a table', /<table>.*<td>a<\/td><td>b<\/td>.*<\/table>/s.test(tableTrip.back));
+  ok('markdown export emits a GFM table', /\| H1 \| H2 \|/.test(tableTrip.md) && /\| --- \| --- \|/.test(tableTrip.md) && /\| a \| b \|/.test(tableTrip.md));
+
+  // 9f. Sanitizer keeps tables/images but still strips danger.
+  const sanTbl = await page.evaluate(async () => {
+    const { sanitizeHtml } = await import('./js/document-model.js');
+    return sanitizeHtml('<table onclick="x()"><tr><td colspan="2" style="color:red">c</td></tr></table>' +
+      '<img src="data:image/png;base64,AAAA" onerror="x()"><img src="data:text/html,evil">');
+  });
+  ok('sanitizer keeps table + colspan', /<table>(?:<tbody>)?<tr><td colspan="2">c<\/td><\/tr>(?:<\/tbody>)?<\/table>/.test(sanTbl));
+  ok('sanitizer keeps data:image but drops handlers + data:text/html',
+    /<img src="data:image\/png;base64,AAAA">/.test(sanTbl) && !/onclick|onerror|data:text\/html/.test(sanTbl));
+
   // 10. LibreOffice bridge reports not-configured gracefully.
   const loState = await page.evaluate(async () => {
     const LO = await import('./js/libreoffice-bridge.js');


### PR DESCRIPTION
Reported on real device: a loaded `.docx` showed its text but **dropped tables** (flattened to paragraphs) and **figures**. This adds both.

### Import (`io-docx.js`)
- Walk the document **body in order** so `w:tbl` keeps its position instead of being flattened into the paragraph stream.
- **Tables** → `<table>` (recursive for nested tables; honours `gridSpan`/colspan).
- **Embedded images** (DrawingML `a:blip` and legacy VML `imagedata`) → data-URL `<img>` pulled from `word/media`.
- `<br>` now handled structurally — which also removed **4 stray NUL bytes** a previous heredoc had baked into the old `BR` sentinel (the file even read as binary to `grep`).

### Export
- `htmlToDocx` writes `<table>` back as `w:tbl` (borders + `gridSpan`).
- Markdown export emits **GFM tables** and `[alt](src)`; Markdown import gained image syntax.
- HTML export ships table/image CSS.

### Sanitizer
- Allow `table`/`img`/`figure` tags (+ `colspan`/`rowspan`, `img src`/`alt`); permit only `data:image/*` data-URLs (block `data:text/html`); keep stripping event handlers.

### Testing
- Smoke **45/45** — builds a real `.docx` fixture (2×2 table + 1×1 PNG), asserts table/image import + document order, table round-trips through DOCX and Markdown, and the sanitizer keeps tables/images while dropping danger.
- e2e 16, mobile 14 still green. Screenshot confirms a bordered table renders in the editor.

### Known gaps (documented)
PDF export flattens tables / omits images; image *export* to `.docx` still needs the LibreOffice backend.

Redeploys to `https://danbri.github.io/glitchcan-minigam/magpie/edot/edot.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_