### PR TITLE
edot: Save to GitHub — client-side diff + branch + pull request (MVP)

### DIFF
--- a/magpie/edot/README.md
+++ b/magpie/edot/README.md
@@ -28,6 +28,11 @@ offline, and dependency-free.
   `third_party/searching-for-logic/`).
 - **Close** (`Ctrl/⌘+W`) — closes the current document; it stays safe in the
   library.
+- **Save to GitHub** — `File ▸ Save to GitHub` commits your edits to a **new
+  branch and opens a pull request**, entirely client-side via the GitHub REST
+  API (paste a fine-grained token). Shows a **colour diff** of your changes
+  first. Text files only (`.md`/`.txt`/`.html`/`.css`). Prefilled from the
+  document's source when it was opened from a GitHub URL.
 - **Local document library** — multiple named documents stored on-device in
   **IndexedDB** (localStorage fallback), with continuous autosave. **File ▸ My
   documents** lists, opens, renames, duplicates, and deletes them. Nothing is
@@ -86,6 +91,8 @@ js/
   find-replace.js      find & replace (CSS Custom Highlight API)
   open-url.js          URL/git-host link resolution -> raw fetch + metadata
   examples.js          File ▸ Examples manifest
+  git-remote.js        GitHub REST client: read file+sha, branch, commit, PR
+  diff.js              dependency-free LCS line diff (save-back preview)
   io.js                format registry + open/save orchestration
   io-docx.js           native OOXML .docx read/write (incl. alignment via w:jc)
   io-pdf.js            native multi-page PDF export (base-14 fonts)
@@ -153,8 +160,8 @@ replace, the document library persistence across reloads, the sanitizer, and the
 toolbar wiring:
 
 ```bash
-node magpie/edot/test-edot.mjs       # functional smoke test (56 checks)
-node magpie/edot/test-e2e.mjs        # end-to-end UI driving (23 checks)
+node magpie/edot/test-edot.mjs       # functional smoke test (68 checks)
+node magpie/edot/test-e2e.mjs        # end-to-end UI driving (30 checks)
 node magpie/edot/test-mobile.mjs     # mobile: tap-to-focus, touch menu, locked shell (14 checks)
 node magpie/edot/verify-pdf.mjs      # deep PDF structural validation + sample
 ```
@@ -163,13 +170,18 @@ node magpie/edot/verify-pdf.mjs      # deep PDF structural validation + sample
 `playwright-core`. `verify-pdf.mjs` writes `/tmp/edot-sample.pdf` and checks the
 xref offsets, trailer→catalog→pages chain, and content-stream lengths.)
 
-## Roadmap: editing files in git
+## Editing files in git
 
-edot already *reads* from git hosts (Open from URL). A design study for the
-next step — **diffing and committing back to a remote repo**, entirely
-client-side (GitHub Device Flow / fine-grained PAT, `jsdiff` preview, PR-based
-writes) — is in [`docs/git-sync-methodology.md`](docs/git-sync-methodology.md).
-The `doc.source` metadata captured on URL-open is the hook it builds on.
+edot reads from git hosts (Open from URL) **and writes back**: `File ▸ Save to
+GitHub` re-exports to the source text format, fetches the current file + blob
+sha, shows a client-side colour diff (`js/diff.js`), then creates a branch and
+opens a pull request through the GitHub REST API (`js/git-remote.js`). No git
+protocol, no backend — `api.github.com` is CORS-enabled (the why, and the
+roadmap: Device-Flow auth, other hosts, binary save-back, are in
+[`docs/git-sync-methodology.md`](docs/git-sync-methodology.md)).
+
+> **Note:** the GitHub write path is verified against a mocked API in the test
+> suite; give it a real-token dry run on a throwaway repo before trusting it.
 
 ## Limits / honest scope
 

--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -366,6 +366,38 @@ select.tbtn {
 .dialog-error[hidden] { display: none; }
 .doc-row .doc-note { display: block; font-size: 0.75rem; color: var(--muted); margin-top: 0.15rem; }
 .doc-credit { padding: 0 1rem 0.75rem; font-size: 0.72rem; color: var(--muted); }
+
+/* ---- Save to GitHub dialog ---- */
+.dialog-ok { margin: 0.5rem 0 0; color: var(--ok); font-size: 0.85rem; }
+.dialog-ok[hidden] { display: none; }
+.gh-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 0.6rem;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+.gh-grid label { font-size: 0.85rem; color: var(--muted); white-space: nowrap; }
+.gh-grid .find-input { width: 100%; }
+.gh-remember { display: flex; align-items: center; gap: 0.4rem; font-size: 0.82rem; color: var(--muted); margin-top: 0.5rem; }
+.gh-actions { display: flex; align-items: center; gap: 0.6rem; margin-top: 0.6rem; }
+.gh-diff {
+  margin-top: 0.5rem;
+  max-height: 40vh;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg);
+  font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+.gh-diff[hidden] { display: none; }
+.gh-diff .row { display: flex; white-space: pre-wrap; word-break: break-word; padding: 0 0.5em; }
+.gh-diff .row .sign { width: 1.1em; flex: 0 0 1.1em; color: var(--muted); user-select: none; }
+.gh-diff .add { background: rgba(46,160,67,0.16); }
+.gh-diff .del { background: rgba(248,81,73,0.16); }
+.gh-diff .gap { color: var(--muted); background: var(--surface); font-style: italic; padding: 0.1em 0.5em; }
 .dialog-foot { padding: 0.75rem 1rem; border-top: 1px solid var(--line); display: flex; justify-content: flex-end; }
 .tbtn.primary { background: var(--accent); color: var(--accent-fg); min-width: auto; padding: 0 1em; }
 .tbtn.primary:hover { filter: brightness(1.08); }

--- a/magpie/edot/docs/git-sync-methodology.md
+++ b/magpie/edot/docs/git-sync-methodology.md
@@ -1,8 +1,14 @@
 # edot ↔ git: methodology for diffing and saving back to remote repos
 
-A design study (not yet implemented) for letting edot **edit a file fetched
-from a git host, see a diff, and write it back** — staying true to the
-project's "static files on GitHub Pages, no backend" constraint.
+A design study for letting edot **edit a file fetched from a git host, see a
+diff, and write it back** — staying true to the project's "static files on
+GitHub Pages, no backend" constraint.
+
+> **Status:** the **MVP is implemented** — `File ▸ Save to GitHub` (PAT auth →
+> colour diff → branch + PR via the REST API; `js/git-remote.js`, `js/diff.js`).
+> Verified against a mocked API in the test suite. Remaining items below
+> (Device-Flow auth, non-GitHub hosts, binary save-back, smarter diffing) are
+> the roadmap.
 
 ## 1. What already exists (the foundation)
 

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -45,6 +45,9 @@
         <button type="button" id="mi-find" class="menu-item" role="menuitem">
           <span>Find &amp; replace…</span><span class="hint">Ctrl/⌘F</span>
         </button>
+        <button type="button" id="mi-github" class="menu-item" role="menuitem">
+          <span>Save to GitHub…</span><span class="hint">PR</span>
+        </button>
         <div class="menu-sep" role="separator"></div>
         <div id="export-list" role="group" aria-label="Save as"></div>
       </div>
@@ -98,6 +101,40 @@
       <button type="submit" class="tbtn" aria-label="Close">✕</button>
     </form>
     <ul id="examples-list" class="docs-list"></ul>
+  </dialog>
+
+  <!-- Save to GitHub (branch + pull request) -->
+  <dialog id="github-dialog" class="dialog" aria-labelledby="github-dialog-title">
+    <form method="dialog" class="dialog-head">
+      <h2 id="github-dialog-title">Save to GitHub</h2>
+      <button type="submit" class="tbtn" aria-label="Close">✕</button>
+    </form>
+    <div class="dialog-body">
+      <p class="dialog-note">Commits your edits to a new branch and opens a pull request — entirely from your browser via the GitHub API. Needs a fine-grained token with <strong>Contents</strong> and <strong>Pull requests</strong> read &amp; write on the repo. <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener noreferrer">Create one →</a></p>
+      <div class="gh-grid">
+        <label for="gh-repo">Repository</label>
+        <input id="gh-repo" type="text" class="find-input" placeholder="owner/repo" autocomplete="off">
+        <label for="gh-branch">Base branch</label>
+        <input id="gh-branch" type="text" class="find-input" placeholder="main" autocomplete="off">
+        <label for="gh-path">File path</label>
+        <input id="gh-path" type="text" class="find-input" placeholder="docs/file.md" autocomplete="off">
+        <label for="gh-token">Token</label>
+        <input id="gh-token" type="password" class="find-input" placeholder="github_pat_…" autocomplete="new-password">
+        <label for="gh-message">Commit message</label>
+        <input id="gh-message" type="text" class="find-input" autocomplete="off">
+      </div>
+      <label class="gh-remember"><input id="gh-remember" type="checkbox"> Remember token for this tab only</label>
+      <div class="gh-actions">
+        <button type="button" id="gh-preview" class="tbtn">Preview diff</button>
+        <span id="gh-diffstat" class="dialog-note"></span>
+      </div>
+      <div id="gh-diff" class="gh-diff" hidden></div>
+      <p id="gh-error" class="dialog-error" role="alert" hidden></p>
+      <p id="gh-result" class="dialog-ok" role="status" hidden></p>
+    </div>
+    <div class="dialog-foot">
+      <button type="button" id="gh-commit" class="tbtn primary">Open pull request</button>
+    </div>
   </dialog>
 
   <!-- Local document library -->

--- a/magpie/edot/js/diff.js
+++ b/magpie/edot/js/diff.js
@@ -1,0 +1,67 @@
+// diff.js — small dependency-free line diff for the save-back preview.
+// LCS-based (no CDN, no library), with a size guard that falls back to a
+// prefix/suffix coarse diff so huge files can't blow up O(n·m) memory.
+
+const MAX_CELLS = 4_000_000; // ~16 MB of Uint32 — cap before falling back
+
+export function diffLines(oldText, newText) {
+  const A = String(oldText).split('\n');
+  const B = String(newText).split('\n');
+  if (A.length * B.length > MAX_CELLS) return coarse(A, B);
+
+  const n = A.length, m = B.length;
+  // dp[i][j] = LCS length of A[i:], B[j:]
+  const dp = Array.from({ length: n + 1 }, () => new Uint32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = A[i] === B[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out = [];
+  let i = 0, j = 0;
+  while (i < n && j < m) {
+    if (A[i] === B[j]) { out.push({ type: 'ctx', text: A[i] }); i++; j++; }
+    else if (dp[i + 1][j] >= dp[i][j + 1]) { out.push({ type: 'del', text: A[i] }); i++; }
+    else { out.push({ type: 'add', text: B[j] }); j++; }
+  }
+  while (i < n) out.push({ type: 'del', text: A[i++] });
+  while (j < m) out.push({ type: 'add', text: B[j++] });
+  return out;
+}
+
+function coarse(A, B) {
+  let s = 0;
+  while (s < A.length && s < B.length && A[s] === B[s]) s++;
+  let e = 0;
+  while (e < A.length - s && e < B.length - s && A[A.length - 1 - e] === B[B.length - 1 - e]) e++;
+  const out = [];
+  for (let i = 0; i < s; i++) out.push({ type: 'ctx', text: A[i] });
+  for (let i = s; i < A.length - e; i++) out.push({ type: 'del', text: A[i] });
+  for (let j = s; j < B.length - e; j++) out.push({ type: 'add', text: B[j] });
+  for (let i = A.length - e; i < A.length; i++) out.push({ type: 'ctx', text: A[i] });
+  return out;
+}
+
+export function diffStats(diff) {
+  let add = 0, del = 0;
+  for (const d of diff) { if (d.type === 'add') add++; else if (d.type === 'del') del++; }
+  return { add, del, changed: add + del };
+}
+
+// Collapse long unchanged runs to `context` lines on each side of a change.
+export function collapse(diff, context = 3) {
+  const keep = new Array(diff.length).fill(false);
+  diff.forEach((d, i) => {
+    if (d.type !== 'ctx') {
+      for (let k = Math.max(0, i - context); k <= Math.min(diff.length - 1, i + context); k++) keep[k] = true;
+    }
+  });
+  const rows = [];
+  let gap = 0;
+  diff.forEach((d, i) => {
+    if (keep[i]) { if (gap) { rows.push({ type: 'gap', count: gap }); gap = 0; } rows.push(d); }
+    else gap++;
+  });
+  if (gap) rows.push({ type: 'gap', count: gap });
+  return rows;
+}

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -9,8 +9,12 @@ import { Library } from './library.js';
 import { FindReplace } from './find-replace.js';
 import { resolveSourceUrl, filenameFromUrl } from './open-url.js';
 import { EXAMPLES } from './examples.js';
+import { GitHubRemote, commitViaPullRequest } from './git-remote.js';
+import { diffLines, diffStats, collapse } from './diff.js';
 import * as IO from './io.js';
 import * as LO from './libreoffice-bridge.js';
+
+const GH_TOKEN_KEY = 'edot.gh.token';
 
 const LAST_DOC_KEY = 'edot.currentDoc';
 
@@ -49,6 +53,7 @@ class App {
     this._wireDialog();
     this._wireUrlDialog();
     this._wireExamplesDialog();
+    this._wireGithubDialog();
     this._wireGlobalKeys();
     this._wireDragDrop();
     this._reflectBackend();
@@ -168,6 +173,7 @@ class App {
     mi('mi-docs', () => this.openLibrary());
     mi('mi-close', () => this.closeDocument());
     mi('mi-find', () => this.findReplace.open(true));
+    mi('mi-github', () => this.openGithubDialog());
 
     this.fileInput.accept = IO.importAccept();
     this.fileInput.addEventListener('change', () => {
@@ -257,6 +263,147 @@ class App {
   }
 
   openExamplesDialog() { showModal(this.examplesDialog); }
+
+  // ---- Save to GitHub (branch + pull request) ----
+  _wireGithubDialog() {
+    this.ghDialog = document.getElementById('github-dialog');
+    this.gh = {}; // { owner, repo, path, branch, sha, newText } after a preview
+    const g = (id) => document.getElementById(id);
+    this.ghEl = {
+      repo: g('gh-repo'), branch: g('gh-branch'), path: g('gh-path'), token: g('gh-token'),
+      message: g('gh-message'), remember: g('gh-remember'), preview: g('gh-preview'),
+      commit: g('gh-commit'), diff: g('gh-diff'), diffstat: g('gh-diffstat'),
+      error: g('gh-error'), result: g('gh-result'),
+    };
+    this.ghEl.preview.addEventListener('click', () => this._githubPreview());
+    this.ghEl.commit.addEventListener('click', () => this._githubCommit());
+  }
+
+  openGithubDialog() {
+    const el = this.ghEl;
+    el.error.hidden = true; el.result.hidden = true; el.diff.hidden = true; el.diff.innerHTML = '';
+    el.diffstat.textContent = '';
+    this.gh = {};
+
+    // Prefill from the document's git source, if it came from one.
+    const s = this.doc && this.doc.source;
+    if (s && s.owner && s.repo) {
+      el.repo.value = `${s.owner}/${s.repo}`;
+      el.branch.value = s.ref && !/^[0-9a-f]{7,40}$/i.test(s.ref) ? s.ref : 'main';
+      el.path.value = s.path || '';
+    }
+    el.message.value = `Update ${el.path.value || 'document'} via edot`;
+    try { el.token.value = sessionStorage.getItem(GH_TOKEN_KEY) || ''; } catch { /* */ }
+    el.remember.checked = !!el.token.value;
+    showModal(this.ghDialog);
+    (el.repo.value ? el.token : el.repo).focus();
+  }
+
+  _ghParse() {
+    const el = this.ghEl;
+    const m = /^([^/\s]+)\/([^/\s]+?)(?:\.git)?$/.exec(el.repo.value.trim());
+    if (!m) throw new Error('Repository must be "owner/repo"');
+    const path = el.path.value.trim().replace(/^\/+/, '');
+    if (!path) throw new Error('Enter the file path to write');
+    const ext = (path.match(/\.([a-z0-9]+)$/i) || [])[1] || '';
+    if (!IO.isTextFormat(ext)) throw new Error(`Save-back supports text files only (.md, .txt, .html, .css) — not .${ext || '?'}`);
+    const token = el.token.value.trim();
+    if (!token) throw new Error('Paste a personal access token');
+    return { owner: m[1], repo: m[2], path, ext, branch: el.branch.value.trim() || 'main', token };
+  }
+
+  _rememberToken(token, on) {
+    try {
+      if (on) sessionStorage.setItem(GH_TOKEN_KEY, token);
+      else sessionStorage.removeItem(GH_TOKEN_KEY);
+    } catch { /* storage blocked */ }
+  }
+
+  async _githubPreview() {
+    const el = this.ghEl;
+    el.error.hidden = true; el.result.hidden = true;
+    let p;
+    try { p = this._ghParse(); } catch (err) { return this._ghErr(err.message); }
+    try {
+      el.diffstat.textContent = 'Fetching…';
+      const newText = await IO.exportText(this.editor.getContent(), this.titleInput.value, p.ext);
+      const remote = new GitHubRemote(p.token);
+      const file = await remote.getFile(p.owner, p.repo, p.path, p.branch);
+      const diff = diffLines(file.text, newText);
+      const stats = diffStats(diff);
+      this.gh = { ...p, sha: file.sha, newText, exists: file.exists };
+      this._renderDiff(collapse(diff));
+      el.diffstat.textContent = file.exists
+        ? `+${stats.add} −${stats.del} vs ${p.branch}`
+        : `new file · ${newText.split('\n').length} lines`;
+      this._rememberToken(p.token, el.remember.checked);
+    } catch (err) {
+      this._ghErr(this._ghMessage(err));
+    }
+  }
+
+  async _githubCommit() {
+    const el = this.ghEl;
+    el.error.hidden = true; el.result.hidden = true;
+    let p;
+    try { p = this._ghParse(); } catch (err) { return this._ghErr(err.message); }
+    try {
+      el.commit.disabled = true;
+      el.diffstat.textContent = 'Committing…';
+      const newText = this.gh.newText && this.gh.path === p.path
+        ? this.gh.newText
+        : await IO.exportText(this.editor.getContent(), this.titleInput.value, p.ext);
+      const remote = new GitHubRemote(p.token);
+      const { pr } = await commitViaPullRequest(remote, {
+        owner: p.owner, repo: p.repo, path: p.path, baseBranch: p.branch,
+        message: el.message.value.trim() || `Update ${p.path} via edot`,
+        contentText: newText,
+        title: el.message.value.trim() || `Update ${p.path}`,
+        body: 'Edited with edot (https://danbri.github.io/glitchcan-minigam/magpie/edot/edot.html).',
+      });
+      this._rememberToken(p.token, el.remember.checked);
+      el.diffstat.textContent = '';
+      el.result.innerHTML = `Pull request opened: <a href="${esc(pr.html_url)}" target="_blank" rel="noopener noreferrer">#${pr.number}</a>`;
+      el.result.hidden = false;
+      this.announce(`Pull request #${pr.number} opened`);
+    } catch (err) {
+      this._ghErr(this._ghMessage(err));
+    } finally {
+      el.commit.disabled = false;
+    }
+  }
+
+  _renderDiff(rows) {
+    const frag = document.createDocumentFragment();
+    for (const r of rows) {
+      const div = document.createElement('div');
+      if (r.type === 'gap') { div.className = 'gap'; div.textContent = `⋯ ${r.count} unchanged line${r.count === 1 ? '' : 's'}`; }
+      else {
+        div.className = 'row ' + r.type;
+        const sign = document.createElement('span');
+        sign.className = 'sign';
+        sign.textContent = r.type === 'add' ? '+' : r.type === 'del' ? '−' : ' ';
+        const txt = document.createElement('span');
+        txt.textContent = r.text;
+        div.append(sign, txt);
+      }
+      frag.appendChild(div);
+    }
+    this.ghEl.diff.innerHTML = '';
+    this.ghEl.diff.appendChild(frag);
+    this.ghEl.diff.hidden = false;
+  }
+
+  _ghErr(msg) { this.ghEl.error.textContent = msg; this.ghEl.error.hidden = false; this.ghEl.diffstat.textContent = ''; }
+
+  _ghMessage(err) {
+    if (err.status === 401) return 'Token rejected (401). Check the token and its scopes.';
+    if (err.status === 403) return 'Forbidden (403) — the token lacks permission, or rate-limited.';
+    if (err.status === 404) return 'Not found (404) — check owner/repo/branch, or the token can’t see this repo.';
+    if (err.status === 422) return `Could not create the change (422): ${err.data?.message || 'validation failed'}.`;
+    if (err instanceof TypeError) return 'Network/CORS error reaching api.github.com.';
+    return err.message || 'GitHub request failed';
+  }
 
   async openExample(ex) {
     if (ex.local) {

--- a/magpie/edot/js/git-remote.js
+++ b/magpie/edot/js/git-remote.js
@@ -1,0 +1,108 @@
+// git-remote.js — minimal GitHub REST client for reading a file and writing it
+// back as a branch + pull request. No git protocol, no packfiles: api.github.com
+// is CORS-enabled, so these calls work directly from the browser with a token
+// (see docs/git-sync-methodology.md). `fetchImpl` is injectable for testing.
+
+const API = 'https://api.github.com';
+
+export class GitHubRemote {
+  constructor(token, fetchImpl) {
+    this.token = token;
+    this.fetch = fetchImpl || ((...a) => fetch(...a));
+  }
+
+  async _req(method, path, body) {
+    const res = await this.fetch(`${API}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    let json;
+    try { json = text ? JSON.parse(text) : {}; } catch { json = { message: text }; }
+    if (!res.ok) {
+      const err = new Error(json.message || `GitHub API ${res.status}`);
+      err.status = res.status; err.data = json;
+      throw err;
+    }
+    return json;
+  }
+
+  me() { return this._req('GET', '/user'); }
+  getRepo(owner, repo) { return this._req('GET', `/repos/${owner}/${repo}`); }
+
+  // File text + blob sha. Returns { sha:null } if the file does not exist yet.
+  async getFile(owner, repo, path, ref) {
+    const q = ref ? `?ref=${encodeURIComponent(ref)}` : '';
+    try {
+      const j = await this._req('GET', `/repos/${owner}/${repo}/contents/${encPath(path)}${q}`);
+      return { sha: j.sha, text: j.encoding === 'base64' ? b64ToUtf8(j.content) : (j.content || ''), exists: true };
+    } catch (err) {
+      if (err.status === 404) return { sha: null, text: '', exists: false };
+      throw err;
+    }
+  }
+
+  getRef(owner, repo, branch) {
+    return this._req('GET', `/repos/${owner}/${repo}/git/ref/heads/${encodeURIComponent(branch)}`);
+  }
+
+  async createBranch(owner, repo, fromBranch, newBranch) {
+    const base = await this.getRef(owner, repo, fromBranch);
+    return this._req('POST', `/repos/${owner}/${repo}/git/refs`, {
+      ref: `refs/heads/${newBranch}`, sha: base.object.sha,
+    });
+  }
+
+  putFile(owner, repo, path, { branch, message, contentText, sha }) {
+    return this._req('PUT', `/repos/${owner}/${repo}/contents/${encPath(path)}`, {
+      message, content: utf8ToB64(contentText), branch, ...(sha ? { sha } : {}),
+    });
+  }
+
+  openPullRequest(owner, repo, { head, base, title, body }) {
+    return this._req('POST', `/repos/${owner}/${repo}/pulls`, { head, base, title, body });
+  }
+}
+
+/**
+ * High-level safe write: create a branch off `baseBranch`, commit the new
+ * content to it, and open a PR. Returns the created pull request.
+ */
+export async function commitViaPullRequest(remote, {
+  owner, repo, path, baseBranch, message, contentText, title, body,
+}) {
+  const branch = `edot-patch-${Date.now().toString(36)}`;
+  const existing = await remote.getFile(owner, repo, path, baseBranch); // sha (or null)
+  await remote.createBranch(owner, repo, baseBranch, branch);
+  await remote.putFile(owner, repo, path, { branch, message, contentText, sha: existing.sha });
+  const pr = await remote.openPullRequest(owner, repo, {
+    head: branch, base: baseBranch, title: title || message, body: body || '',
+  });
+  return { branch, pr };
+}
+
+// ---- encoding helpers (unicode-safe) ----
+function encPath(path) {
+  return String(path).replace(/^\/+/, '').split('/').map(encodeURIComponent).join('/');
+}
+
+export function utf8ToB64(str) {
+  const bytes = new TextEncoder().encode(str);
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  return btoa(bin);
+}
+
+export function b64ToUtf8(b64) {
+  const bin = atob(String(b64).replace(/\s/g, ''));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}

--- a/magpie/edot/js/io.js
+++ b/magpie/edot/js/io.js
@@ -137,6 +137,21 @@ function mimeFor(ext) {
   }[ext] || 'application/octet-stream';
 }
 
+// Text formats that can be re-exported to a string (for git save-back / diff).
+export const TEXT_FORMATS = new Set(['txt', 'md', 'markdown', 'html', 'htm', 'css']);
+export function isTextFormat(ext) { return TEXT_FORMATS.has((ext || '').toLowerCase()); }
+
+/**
+ * Re-export document HTML to the given *text* format as a string. Used by the
+ * git save-back path to produce the file content to commit and diff.
+ */
+export async function exportText(html, title, ext) {
+  const e = ext === 'markdown' ? 'md' : ext === 'htm' ? 'html' : ext;
+  if (!isTextFormat(ext)) throw new Error(`.${ext} is a binary format — text save-back only`);
+  const blob = await exportDocument(html, title, e);
+  return blob.text();
+}
+
 /** Trigger a browser download for a Blob. */
 export function downloadBlob(blob, filename) {
   const url = URL.createObjectURL(blob);

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -112,6 +112,40 @@ try {
   ok('url dialog shows a validation error', await page.isVisible('#url-error'));
   await page.keyboard.press('Escape');
 
+  // Save to GitHub dialog, driven against a mocked api.github.com.
+  await page.evaluate(() => {
+    const orig = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      if (String(url).startsWith('https://api.github.com')) {
+        const m = opts.method || 'GET';
+        const j = (o) => new Response(JSON.stringify(o), { status: 200, headers: { 'content-type': 'application/json' } });
+        if (/\/contents\//.test(url) && m === 'GET') return j({ sha: 'S', encoding: 'base64', content: btoa('# old heading\n') });
+        if (/\/git\/ref\/heads\//.test(url)) return j({ object: { sha: 'B' } });
+        if (/\/git\/refs$/.test(url)) return j({});
+        if (/\/contents\//.test(url) && m === 'PUT') return j({ commit: { sha: 'C' } });
+        if (/\/pulls$/.test(url)) return j({ number: 7, html_url: 'https://github.com/o/r/pull/7' });
+        return j({});
+      }
+      return orig(url, opts);
+    };
+  });
+  await page.evaluate(() => { document.getElementById('editor').innerHTML = '<h1>New heading</h1><p>edited body</p>'; window.__edot.editor.onChange(); });
+  await page.click('#menu-button'); await page.click('#mi-github'); await page.waitForTimeout(150);
+  ok('github dialog opens', await page.isVisible('#gh-repo'));
+  await page.fill('#gh-repo', 'o/r'); await page.fill('#gh-branch', 'main');
+  await page.fill('#gh-path', 'docs/x.md'); await page.fill('#gh-token', 'tok');
+  await page.click('#gh-preview'); await page.waitForTimeout(250);
+  ok('github preview renders a diff', (await page.$$('#gh-diff .row')).length > 0);
+  ok('github diffstat shows counts', /[+−]\d/.test(await page.textContent('#gh-diffstat')));
+  await page.click('#gh-commit'); await page.waitForTimeout(300);
+  ok('github commit opens a PR link', /#7/.test(await page.textContent('#gh-result')));
+
+  // Non-text path is rejected with a clear error.
+  await page.fill('#gh-path', 'image.docx');
+  await page.click('#gh-preview'); await page.waitForTimeout(120);
+  ok('github rejects binary save-back', await page.isVisible('#gh-error'));
+  await page.keyboard.press('Escape');
+
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
 } finally { await b.close(); server.close(); }

--- a/magpie/edot/test-edot.mjs
+++ b/magpie/edot/test-edot.mjs
@@ -316,6 +316,65 @@ try {
     teardown.after.bars === teardown.before.bars &&
     teardown.after.toasts === teardown.before.toasts);
 
+  // 9j. Diff engine: detects edits/additions and collapses context to gaps.
+  const diff = await page.evaluate(async () => {
+    const { diffLines, diffStats, collapse } = await import('./js/diff.js');
+    const d = diffLines('a\nb\nc\nd', 'a\nB\nc\nd\ne');
+    const s = diffStats(d);
+    const big = collapse(diffLines(
+      Array.from({ length: 50 }, (_, i) => 'L' + i).join('\n'),
+      Array.from({ length: 50 }, (_, i) => (i === 25 ? 'CHANGED' : 'L' + i)).join('\n')), 2);
+    return { add: s.add, del: s.del, hasGap: big.some((r) => r.type === 'gap') };
+  });
+  ok('diff counts edits + additions', diff.add === 2 && diff.del === 1);
+  ok('diff collapses unchanged runs into gaps', diff.hasGap);
+
+  // 9k. git-remote: unicode base64 + mocked commit-via-PR sequence/payloads.
+  const git = await page.evaluate(async () => {
+    const { GitHubRemote, commitViaPullRequest, utf8ToB64, b64ToUtf8 } = await import('./js/git-remote.js');
+    const round = b64ToUtf8(utf8ToB64('héllo — wörld\n€ 𝄞')) === 'héllo — wörld\n€ 𝄞';
+    const calls = [];
+    const fake = async (url, opts) => {
+      const body = opts.body ? JSON.parse(opts.body) : null;
+      calls.push({ url, method: opts.method, body, auth: opts.headers.Authorization });
+      const j = (o) => ({ ok: true, status: 200, text: async () => JSON.stringify(o) });
+      if (/\/contents\//.test(url) && opts.method === 'GET') return j({ sha: 'OLDSHA', encoding: 'base64', content: btoa('old') });
+      if (/\/git\/ref\/heads\//.test(url)) return j({ object: { sha: 'BASESHA' } });
+      if (/\/git\/refs$/.test(url)) return j({});
+      if (/\/contents\//.test(url) && opts.method === 'PUT') return j({ commit: { sha: 'C' } });
+      if (/\/pulls$/.test(url)) return j({ number: 42, html_url: 'https://github.com/o/r/pull/42' });
+      return j({});
+    };
+    const { branch, pr } = await commitViaPullRequest(new GitHubRemote('TKN', fake),
+      { owner: 'o', repo: 'r', path: 'docs/a.md', baseBranch: 'main', message: 'msg', contentText: 'new text', title: 't', body: 'b' });
+    const put = calls.find((c) => c.method === 'PUT');
+    const ref = calls.find((c) => c.method === 'POST' && /git\/refs$/.test(c.url));
+    const pull = calls.find((c) => /pulls$/.test(c.url));
+    return {
+      round, prNumber: pr.number, branch,
+      putContent: put && atob(put.body.content), putSha: put && put.body.sha, putBranch: put && put.body.branch,
+      refOk: ref && ref.body.ref === `refs/heads/${branch}`,
+      prHead: pull && pull.body.head, prBase: pull && pull.body.base, auth: put && put.auth,
+    };
+  });
+  ok('git base64 round-trips unicode (incl. astral)', git.round);
+  ok('git PUT commits decoded content', git.putContent === 'new text');
+  ok('git PUT uses existing sha + new branch', git.putSha === 'OLDSHA' && git.putBranch === git.branch);
+  ok('git creates branch ref off base', git.refOk);
+  ok('git PR head=branch, base=main', git.prHead === git.branch && git.prBase === 'main');
+  ok('git authorizes with bearer token', git.auth === 'Bearer TKN');
+  ok('git returns the PR number', git.prNumber === 42);
+
+  // 9l. exportText: source-format string; binary formats blocked.
+  const ex = await page.evaluate(async () => {
+    const IO = await import('./js/io.js');
+    const md = await IO.exportText('<h1>T</h1><p><strong>b</strong></p>', 'Doc', 'md');
+    let blocked = false; try { await IO.exportText('<p>x</p>', 'D', 'docx'); } catch { blocked = true; }
+    return { md, blocked, isText: IO.isTextFormat('md') && !IO.isTextFormat('docx') };
+  });
+  ok('exportText returns source-format markdown', /^# T/m.test(ex.md) && /\*\*b\*\*/.test(ex.md));
+  ok('exportText blocks binary formats', ex.blocked && ex.isText);
+
   // 10. LibreOffice bridge reports not-configured gracefully.
   const loState = await page.evaluate(async () => {
     const LO = await import('./js/libreoffice-bridge.js');


### PR DESCRIPTION
Implements the git **save-back MVP** from `docs/git-sync-methodology.md` — entirely client-side (no backend, no git protocol; `api.github.com` is CORS-enabled).

### What it does
`File ▸ Save to GitHub`: re-exports your edits to the source text format, fetches the current file + blob sha, shows a **colour diff**, then creates a **branch and opens a pull request** via the GitHub REST API. Paste a fine-grained token; it's prefilled from the document's source when opened from a GitHub URL.

### Modules
- **`js/git-remote.js`** — REST client (injectable `fetch` for tests): `getFile` (text + sha; 404 → new file), `createBranch`, `putFile` (unicode-safe base64), `openPullRequest`; `commitViaPullRequest()` orchestrates branch → commit → PR.
- **`js/diff.js`** — dependency-free LCS line diff with an O(n·m) size guard + prefix/suffix coarse fallback; `diffStats`; `collapse()` to context hunks.
- **`io.js`** — `exportText()` / `isTextFormat()` re-export to the source format (`.md`/`.txt`/`.html`/`.css`); binary blocked.

### Safety
PR-based (never touches the base branch directly); text-only; sha-conditional writes on a fresh branch; token optionally kept in `sessionStorage` (this tab only); clear 401/403/404/422/CORS error mapping.

### Testing
- Smoke **68** — diff engine, **mocked commit-via-PR** sequence/payloads (unicode base64, bearer auth, sha/branch/PR head·base), `exportText`.
- e2e **30** — full dialog flow against a mocked `api.github.com`: preview diff, PR link, binary rejection.
- mobile **14**. HTML valid. Screenshot: colour diff + "Open pull request".

> **Honest note:** verified against a mock — the real-GitHub round-trip hasn't been run from here. Give it a real-token dry run on a throwaway repo before trusting it.

Redeploys to `https://danbri.github.io/glitchcan-minigam/magpie/edot/edot.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_