### PR TITLE
edot: integrate token-creation help into the Save-to-GitHub dialog

### DIFF
--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -370,6 +370,13 @@ select.tbtn {
 /* ---- Save to GitHub dialog ---- */
 .dialog-ok { margin: 0.5rem 0 0; color: var(--ok); font-size: 0.85rem; }
 .dialog-ok[hidden] { display: none; }
+.gh-help { margin: 0.25rem 1rem 0; font-size: 0.82rem; }
+.gh-help summary { cursor: pointer; color: var(--focus); padding: 0.3rem 0; list-style-position: inside; }
+.gh-help summary:focus-visible { outline: 2px solid var(--focus); border-radius: var(--radius); }
+.gh-steps { margin: 0.25rem 0 0.25rem 1.2rem; padding: 0; color: var(--ink); }
+.gh-steps li { margin: 0.25rem 0; }
+.gh-steps code { background: var(--bg); padding: 0 0.3em; border-radius: 3px; }
+.gh-tip { color: var(--muted); margin: 0.4rem 0 0; }
 .gh-grid {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -110,7 +110,18 @@
       <button type="submit" class="tbtn" aria-label="Close">✕</button>
     </form>
     <div class="dialog-body">
-      <p class="dialog-note">Commits your edits to a new branch and opens a pull request — entirely from your browser via the GitHub API. Needs a fine-grained token with <strong>Contents</strong> and <strong>Pull requests</strong> read &amp; write on the repo. <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener noreferrer">Create one →</a></p>
+      <p class="dialog-note">Commits your edits to a new branch and opens a pull request — entirely from your browser via the GitHub API. Nothing leaves your device except the commit.</p>
+      <details class="gh-help">
+        <summary>Need a token? How to create one ▾</summary>
+        <ol class="gh-steps">
+          <li>Open <a href="https://github.com/settings/personal-access-tokens/new" target="_blank" rel="noopener noreferrer">GitHub ▸ Fine-grained tokens ▸ Generate new →</a></li>
+          <li><strong>Repository access</strong> → <em>Only select repositories</em> → pick your repo.</li>
+          <li><strong>Permissions ▸ Contents</strong> → <em>Read and write</em>.</li>
+          <li><strong>Permissions ▸ Pull requests</strong> → <em>Read and write</em>.</li>
+          <li><strong>Generate token</strong>, copy the <code>github_pat_…</code> value, and paste it below.</li>
+        </ol>
+        <p class="gh-tip">Scope it to the one repo and <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer">revoke it</a> when you're done. It stays in this browser only.</p>
+      </details>
       <div class="gh-grid">
         <label for="gh-repo">Repository</label>
         <input id="gh-repo" type="text" class="find-input" placeholder="owner/repo" autocomplete="off">


### PR DESCRIPTION
The "how to get a token" guidance now lives **in the Save-to-GitHub dialog**, not in chat: an expandable `<details>` with

- the direct **GitHub ▸ Fine-grained tokens ▸ Generate new** link,
- the exact scopes (Repository access · **Contents** R/W · **Pull requests** R/W),
- the `github_pat_…` copy step,
- and a **revoke** link + "scope to one repo" tip.

The concise one-line intro stays above it. HTML valid; e2e GitHub-dialog checks still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_