### PR TITLE
edot: surface GitHub's exact 403/404 reason in save-back errors

### DIFF
--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -419,9 +419,10 @@ class App {
   _ghErr(msg) { this.ghEl.error.textContent = msg; this.ghEl.error.hidden = false; this.ghEl.diffstat.textContent = ''; }
 
   _ghMessage(err) {
-    if (err.status === 401) return 'Token rejected (401). Check the token and its scopes.';
-    if (err.status === 403) return 'Forbidden (403) — the token lacks permission, or rate-limited.';
-    if (err.status === 404) return 'Not found (404) — check owner/repo/branch, or the token can’t see this repo.';
+    const gh = err.data && err.data.message ? ` — “${err.data.message}”` : '';
+    if (err.status === 401) return `Token rejected (401)${gh}. Check the token value.`;
+    if (err.status === 403) return `Forbidden (403): the token needs Repository permissions → Contents and Pull requests = “Read and write” on this repo${gh}`;
+    if (err.status === 404) return `Not found (404): check owner/repo/branch, or grant the token access to this repo${gh}`;
     if (err.status === 422) return `Could not create the change (422): ${err.data?.message || 'validation failed'}.`;
     if (err instanceof TypeError) return 'Network/CORS error reaching api.github.com.';
     return err.message || 'GitHub request failed';


### PR DESCRIPTION
A 403 on save-back almost always means the fine-grained token is missing **Repository permissions → Contents / Pull requests = "Read and write"** (the *Account* permissions list doesn't grant repo write). The dialog error now says exactly that and appends GitHub's own message (e.g. *"Resource not accessible by personal access token"*) so the cause is unambiguous. Also surfaces the API message on 401/404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_