### PR TITLE
edot: clarify token help — Contents/PRs are under Repository permissions

### DIFF
--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -119,8 +119,8 @@
         <ol class="gh-steps">
           <li>Open <a href="https://github.com/settings/personal-access-tokens/new" target="_blank" rel="noopener noreferrer">GitHub ▸ Fine-grained tokens ▸ Generate new →</a></li>
           <li><strong>Repository access</strong> → <em>Only select repositories</em> → pick your repo.</li>
-          <li><strong>Permissions ▸ Contents</strong> → <em>Read and write</em>.</li>
-          <li><strong>Permissions ▸ Pull requests</strong> → <em>Read and write</em>.</li>
+          <li>Scroll to <strong>Repository permissions</strong> (NOT “Account permissions”) → <strong>Contents</strong> → <em>Read and write</em>.</li>
+          <li>Still under <strong>Repository permissions</strong> → <strong>Pull requests</strong> → <em>Read and write</em>.</li>
           <li><strong>Generate token</strong> and <strong>copy</strong> it — when you switch back to this tab, edot fills it in from your clipboard automatically (or paste it below).</li>
         </ol>
         <p class="gh-tip">Scope it to the one repo and <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer">revoke it</a> when you're done. It stays in this browser only.</p>


### PR DESCRIPTION
The token-help steps said "Permissions ▸ Contents", which let users (per the screenshots) land in the **Account permissions** list — where Contents / Pull requests don't exist. Steps now explicitly say **Repository permissions (NOT "Account permissions")**. The link itself was already correct (GitHub has no deep-link to a permissions subsection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_