### PR TITLE
edot: "Send to editor" — push data tables/queries into a document

### DIFF
--- a/magpie/edot/data/README.md
+++ b/magpie/edot/data/README.md
@@ -38,6 +38,7 @@ This is the point — the two halves talk to each other:
 | **sheet → table** | **Save as table** — the computed values become a SQLite table, now queryable in SQL. |
 | query → sheet | **Send to sheet** — drop a result set into a new spreadsheet. |
 | **cell → SQL** | `=SQL("SELECT …")` in any formula pulls a scalar straight from the relational layer. |
+| **table/result → document** | **→ Editor** sends a table, sheet, or query result into an open edot document (as an HTML table) — live via a BroadcastChannel, or picked up on next open via localStorage. |
 
 Sheets live *inside* the same database (a `__edot_sheets` meta table), so they
 persist and round-trip with everything else. Export/import the whole workspace

--- a/magpie/edot/data/data-workspace.js
+++ b/magpie/edot/data/data-workspace.js
@@ -73,6 +73,7 @@ export class EdotData extends HTMLElement {
     dbfile.addEventListener('change', () => { if (dbfile.files[0]) this.importDbFile(dbfile.files[0]); dbfile.value = ''; });
     this.addEventListener('views-changed', () => this.refresh());
     this.addEventListener('to-sheet', (e) => this.sheetFromResult(e.detail));
+    this.addEventListener('to-editor', (e) => this.sendToEditor(e.detail.columns, e.detail.rows, 'Query result'));
   }
 
   _btn(label, fn, cls) { const b = document.createElement('button'); b.type = 'button'; b.className = 'dbtn' + (cls ? ` ${cls}` : ''); b.textContent = label; b.addEventListener('click', fn); return b; }
@@ -119,12 +120,16 @@ export class EdotData extends HTMLElement {
     this.active = { kind: 'table', name };
     const data = this.engine.tableRows(name, { limit: 2000 });
     this._main.innerHTML = '';
+    const common = [
+      this._btn('▦ƒ Open as sheet', () => this.tableToSheet(name)),
+      this._btn('→ Editor', () => this.sendToEditor(data.columns, data.rows, name)),
+      this._btn('⬇ CSV', () => this.downloadCsv(name)),
+    ];
     this._main.appendChild(this._head(name, data.editable ? [
       this._btn('＋ Row', () => { this.engine.insertEmptyRow(name); this.openTable(name); }),
       this._btn('✕ Row', () => this._deleteActiveRow(name)),
-      this._btn('▦ƒ Open as sheet', () => this.tableToSheet(name)),
-      this._btn('⬇ CSV', () => this.downloadCsv(name)),
-    ] : [this._btn('▦ƒ Open as sheet', () => this.tableToSheet(name)), this._btn('⬇ CSV', () => this.downloadCsv(name))]));
+      ...common,
+    ] : common));
     const grid = document.createElement('edot-grid');
     this._main.appendChild(grid);
     grid.setData({ columns: data.columns, rows: data.rows, editable: data.editable });
@@ -152,6 +157,7 @@ export class EdotData extends HTMLElement {
     this._main.innerHTML = '';
     this._main.appendChild(this._head(name, [
       this._btn('▤ Save as table', () => this.sheetToTable(name)),
+      this._btn('→ Editor', () => { const t = this._activeSheet.toTable({ headerRow: true }); this.sendToEditor(t.columns, t.rows, name); }),
     ], 'Spreadsheet — type values or =formulas (try =SUM(A1:A3) or =SQL("SELECT count(*) FROM …"))'));
     const sheet = document.createElement('edot-sheet');
     this._main.appendChild(sheet);
@@ -254,6 +260,24 @@ export class EdotData extends HTMLElement {
     if (q) { q.setSql(CHINOOK_DEMO); q.run(); }
   }
 
+  // ---- send to the edot editor (cross-tab) ----
+  sendToEditor(columns, rows, title) {
+    const html = toHtmlTable(columns, rows);
+    const payload = { type: 'insert', title, html, at: Date.now() };
+    try { localStorage.setItem('edot.handoff', JSON.stringify(payload)); } catch { /* quota */ }
+    let live = false;
+    try { const bc = new BroadcastChannel('edot'); bc.postMessage(payload); bc.close(); live = true; } catch { /* */ }
+    this._toast(live ? 'Sent to the editor — switch to (or open) the editor tab to see it.' : 'Saved for the editor.');
+  }
+
+  _toast(msg) {
+    let t = this.querySelector('.dw-toast');
+    if (!t) { t = document.createElement('div'); t.className = 'dw-toast'; this.appendChild(t); }
+    t.textContent = msg; t.classList.add('show');
+    clearTimeout(this._toastTimer);
+    this._toastTimer = setTimeout(() => t.classList.remove('show'), 3200);
+  }
+
   // ---- export/import db ----
   exportDb() { download(new Blob([this.engine.exportDb()], { type: 'application/octet-stream' }), 'edot-data.sqlite'); }
   async importDbFile(file) { await this.engine.importDb(await file.arrayBuffer()); this.refresh(); this.openQuery(); }
@@ -274,6 +298,12 @@ export class EdotData extends HTMLElement {
 
 function dedupe(cols) {
   const seen = new Map(); return cols.map((c) => { let n = c; while (seen.has(n)) n = `${c}_${seen.get(c) + 1}`; seen.set(c, (seen.get(c) || 1) + 1); seen.set(n, 1); return n; });
+}
+function toHtmlTable(columns, rows) {
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+  let h = '<table><tr>' + columns.map((c) => `<th>${esc(c)}</th>`).join('') + '</tr>';
+  for (const r of rows) h += '<tr>' + r.map((v) => `<td>${esc(v)}</td>`).join('') + '</tr>';
+  return h + '</table>';
 }
 function spacer() { const s = document.createElement('span'); s.className = 'dw-spacer'; return s; }
 function download(blob, filename) {

--- a/magpie/edot/data/data.css
+++ b/magpie/edot/data/data.css
@@ -101,3 +101,12 @@ table.grid input.cell-input {
 .q-bar { display: flex; gap: 0.4rem; align-items: center; margin-bottom: 0.4rem; }
 
 .hint { color: var(--d-muted); font-size: 0.8rem; }
+
+/* ---- cross-tab "sent to editor" toast ---- */
+.dw-toast {
+  position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%);
+  background: var(--d-ink); color: var(--d-bg); padding: 0.6em 1em; border-radius: 6px;
+  font-size: 0.85rem; max-width: 90vw; opacity: 0; pointer-events: none; transition: opacity 0.25s; z-index: 50;
+}
+.dw-toast.show { opacity: 0.96; }
+@media (prefers-reduced-motion: reduce) { .dw-toast { transition: none; } }

--- a/magpie/edot/data/query-component.js
+++ b/magpie/edot/data/query-component.js
@@ -22,8 +22,9 @@ export class EdotQuery extends HTMLElement {
     const run = btn('▶ Run', 'primary');
     const saveView = btn('Save as view');
     const toSheet = btn('Send to sheet');
+    const toEditor = btn('→ Editor');
     const status = document.createElement('span'); status.className = 'dw-status';
-    bar.append(run, saveView, toSheet, status);
+    bar.append(run, saveView, toSheet, toEditor, status);
     const grid = document.createElement('edot-grid');
     this.append(ed, bar, grid);
     this._editor = ed; this._grid = grid; this._status = status;
@@ -32,6 +33,7 @@ export class EdotQuery extends HTMLElement {
     ed.addEventListener('keydown', (e) => { if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); this.run(); } });
     saveView.addEventListener('click', () => this._saveView());
     toSheet.addEventListener('click', () => this._toSheet());
+    toEditor.addEventListener('click', () => { if (!this._last) this.run(); if (this._last) this.dispatchEvent(new CustomEvent('to-editor', { bubbles: true, detail: this._last })); });
   }
 
   run() {

--- a/magpie/edot/data/test-data.mjs
+++ b/magpie/edot/data/test-data.mjs
@@ -105,6 +105,14 @@ try {
   ok('Chinook sidebar shows the tables', await page.evaluate(() =>
     !![...document.querySelectorAll('.dw-item .nm')].find((e) => e.textContent === 'Track')));
 
+  // 4c. Send to editor writes an HTML-table handoff for the editor to pick up.
+  const handoff = await page.evaluate(() => {
+    const d = document.querySelector('edot-data');
+    d.sendToEditor(['x', 'y'], [[1, 2], [3, 4]], 'My table');
+    return JSON.parse(localStorage.getItem('edot.handoff'));
+  });
+  ok('sendToEditor writes an HTML-table handoff', handoff && handoff.type === 'insert' && handoff.title === 'My table' && /<table>.*<td>1<\/td>/.test(handoff.html));
+
   // 5. Persistence: DB exports to bytes.
   ok('database exports to bytes', await page.evaluate(() => document.querySelector('edot-data').engine.exportDb().length > 0));
 

--- a/magpie/edot/js/editor.js
+++ b/magpie/edot/js/editor.js
@@ -55,6 +55,21 @@ export class Editor {
     if (this._onSelectionChange) document.removeEventListener('selectionchange', this._onSelectionChange);
   }
 
+  // Insert sanitized HTML at the caret (if it's inside the editor) or append
+  // to the end. Used to drop tables/query results in from the data workspace.
+  insertHtml(html) {
+    const clean = sanitizeHtml(html);
+    const sel = window.getSelection();
+    if (sel && sel.rangeCount && this.el.contains(sel.anchorNode)) {
+      this.el.focus();
+      document.execCommand('insertHTML', false, clean);
+    } else {
+      this.el.insertAdjacentHTML('beforeend', clean);
+    }
+    this._updateEmpty();
+    this.onChange();
+  }
+
   // Focus and drop the caret at the very end. Used when a tap lands on the
   // page margin or empty area — on mobile this is what actually raises the
   // on-screen keyboard, since it runs inside the tap gesture.

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -57,7 +57,34 @@ class App {
     this._wireGlobalKeys();
     this._wireDragDrop();
     this._reflectBackend();
+    this._wireDataHandoff();
     this._boot();
+  }
+
+  // Receive tables / query results sent from the data workspace. A live editor
+  // tab gets them over a BroadcastChannel; a cold start picks them up from
+  // localStorage on boot (see _consumeHandoff).
+  _wireDataHandoff() {
+    try {
+      this._bc = new BroadcastChannel('edot');
+      this._on(this._bc, 'message', (e) => {
+        if (e && e.data && e.data.type === 'insert' && e.data.html) {
+          this._insertHandoff(e.data);
+          try { localStorage.removeItem('edot.handoff'); } catch { /* */ }
+        }
+      });
+    } catch { /* no BroadcastChannel */ }
+  }
+
+  _consumeHandoff() {
+    let h = null;
+    try { h = JSON.parse(localStorage.getItem('edot.handoff') || 'null'); localStorage.removeItem('edot.handoff'); } catch { /* */ }
+    if (h && h.html && (!h.at || Date.now() - h.at < 30 * 60000)) this._insertHandoff(h);
+  }
+
+  _insertHandoff({ title, html }) {
+    this.editor.insertHtml((title ? `<h3>${esc(title)}</h3>` : '') + html);
+    this.announce('Inserted from the data workspace');
   }
 
   // Register a global listener and remember how to remove it (for destroy()).
@@ -72,6 +99,7 @@ class App {
     this._cleanup.forEach((off) => { try { off(); } catch { /* ignore */ } });
     this._cleanup = [];
     clearTimeout(this._saveTimer);
+    try { this._bc?.close(); } catch { /* */ }
     this.findReplace?.destroy?.();
     this.announcer?.destroy?.();
     this.editor?.destroy?.();
@@ -93,6 +121,7 @@ class App {
     if (!doc) doc = await this.library.createDoc('Welcome to edot', WELCOME);
 
     this._loadDoc(doc, { announce: false });
+    this._consumeHandoff();
     this.announce('Document ready');
   }
 

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -150,6 +150,18 @@ try {
   ok('github rejects binary save-back', await page.isVisible('#gh-error'));
   await page.keyboard.press('Escape');
 
+  // Data workspace handoff: a table sent from the data app lands in the doc.
+  await page.evaluate(() => localStorage.setItem('edot.handoff', JSON.stringify({
+    type: 'insert', title: 'Imported data', at: Date.now(),
+    html: '<table><tr><th>a</th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>',
+  })));
+  await page.reload();
+  await page.waitForFunction(() => !!window.__edot && !!window.__edot.doc);
+  await page.waitForTimeout(200);
+  ok('data handoff inserts a table into the doc', await page.evaluate(() =>
+    /<table>/.test(document.getElementById('editor').innerHTML) && /Imported data/.test(document.getElementById('editor').textContent)));
+  ok('handoff is consumed (cleared)', await page.evaluate(() => !localStorage.getItem('edot.handoff')));
+
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
 } finally { await b.close(); server.close(); }


### PR DESCRIPTION
Closes the loop between the **data layer** and the **word processor**.

In the data workspace, a **table**, **sheet**, or **query result** now has a **→ Editor** button that sends it into an edot document as an HTML table:
- **live** to an already-open editor tab via a same-origin **BroadcastChannel**, or
- picked up from **localStorage** the next time the editor opens (cold start).

The editor gains `Editor.insertHtml` (sanitized; inserts at the caret, else appends). The app consumes the handoff on boot and over the channel, and closes the channel on `destroy()`.

**Tests:** edot e2e **+2** (handoff inserts a table and is cleared), data **+1** (`sendToEditor` writes an HTML-table handoff). All suites green. Screenshot shows a Chinook "top artists" table inserted into a document with the "Inserted from the data workspace" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_