### PR TITLE
edot: gentle "return to this tab" indicator (title + favicon + page flash)

### DIFF
--- a/magpie/edot/README.md
+++ b/magpie/edot/README.md
@@ -28,6 +28,11 @@ offline, and dependency-free.
   `third_party/searching-for-logic/`).
 - **Close** (`Ctrl/⌘+W`) — closes the current document; it stays safe in the
   library.
+- **Return indicator** — when you flip to another tab/window from an open
+  dialog (e.g. off to GitHub to make a token, or to the Data workspace), the
+  edot tab gently blinks its **title + favicon** so it's easy to find your way
+  back, and soft-flashes the page on return. Auto-stops after a few minutes
+  (`js/attention.js`).
 - **Save to GitHub** — `File ▸ Save to GitHub` commits your edits to a **new
   branch and opens a pull request**, entirely client-side via the GitHub REST
   API (paste a fine-grained token). Shows a **colour diff** of your changes

--- a/magpie/edot/js/attention.js
+++ b/magpie/edot/js/attention.js
@@ -1,0 +1,101 @@
+// attention.js — "come back to this tab" indicator. When armed and the page is
+// hidden (user switched to another window/tab — e.g. to create a GitHub token),
+// it gently blinks the document title and swaps the favicon so the edot tab
+// stands out in the tab strip. On return it stops, restores everything, and
+// does a soft full-page flash to confirm. Auto-disarms after a timeout so it
+// never nags forever. Respects prefers-reduced-motion.
+
+const ATTENTION_ICON =
+  'data:image/svg+xml,' + encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+    '<circle cx="16" cy="16" r="14" fill="#d2935a"/>' +
+    '<text x="16" y="23" font-size="20" text-anchor="middle" fill="#1a1a1a">↩</text></svg>');
+
+export class Attention {
+  constructor({ timeoutMs = 5 * 60000, message = 'Back to edot' } = {}) {
+    this.timeoutMs = timeoutMs;
+    this.message = message;
+    this._armed = false;
+    this._blinking = false;
+    this._onVis = () => this._visibility();
+  }
+
+  // Begin watching. If already hidden, start blinking immediately.
+  // `once`: disarm automatically the first time the user returns (good for a
+  // fire-and-forget jump). Otherwise stays armed across round-trips until
+  // disarm() or the timeout (good while a dialog waits for a pasted token).
+  arm(message, { once = false } = {}) {
+    if (message) this.message = message;
+    this._once = once;
+    clearTimeout(this._timer);
+    this._timer = setTimeout(() => this.disarm(), this.timeoutMs);
+    if (!this._armed) {
+      this._armed = true;
+      document.addEventListener('visibilitychange', this._onVis);
+      window.addEventListener('blur', this._onVis);
+      window.addEventListener('focus', this._onVis);
+    }
+    if (document.hidden) this._startBlink();
+  }
+
+  disarm() {
+    if (!this._armed) return;
+    this._armed = false;
+    clearTimeout(this._timer);
+    document.removeEventListener('visibilitychange', this._onVis);
+    window.removeEventListener('blur', this._onVis);
+    window.removeEventListener('focus', this._onVis);
+    this._stopBlink();
+  }
+
+  _visibility() {
+    if (document.hidden) this._startBlink();
+    else if (this._blinking) { this._stopBlink(); this._flash(); if (this._once) this.disarm(); }
+  }
+
+  _startBlink() {
+    if (this._blinking || !this._armed) return;
+    this._blinking = true;
+    this._origTitle = document.title;
+    this._setIcon(ATTENTION_ICON);
+    let on = false;
+    this._blinkTimer = setInterval(() => {
+      on = !on;
+      document.title = on ? `🔔 ${this.message}` : this._origTitle;
+    }, 1100);
+  }
+
+  _stopBlink() {
+    if (!this._blinking) return;
+    this._blinking = false;
+    clearInterval(this._blinkTimer);
+    if (this._origTitle != null) document.title = this._origTitle;
+    this._setIcon(null);
+  }
+
+  _setIcon(href) {
+    let link = document.querySelector('link[rel~="icon"]');
+    if (!href) {
+      if (this._origIcon !== undefined) {
+        if (link) { if (this._origIcon === null) link.remove(); else link.href = this._origIcon; }
+        this._origIcon = undefined;
+      }
+      return;
+    }
+    if (!link) { link = document.createElement('link'); link.rel = 'icon'; document.head.appendChild(link); this._origIcon = null; }
+    else if (this._origIcon === undefined) this._origIcon = link.href;
+    link.href = href;
+  }
+
+  // Soft full-page tint that fades out — confirms "you're back here".
+  _flash() {
+    if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const o = document.createElement('div');
+    o.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:9999;background:#d2935a;opacity:0;transition:opacity .28s ease';
+    document.body.appendChild(o);
+    requestAnimationFrame(() => {
+      o.style.opacity = '0.13';
+      setTimeout(() => { o.style.opacity = '0'; setTimeout(() => o.remove(), 320); }, 240);
+    });
+  }
+}

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -7,6 +7,7 @@ import { Toolbar } from './toolbar.js';
 import { Announcer } from './a11y.js';
 import { Library } from './library.js';
 import { FindReplace } from './find-replace.js';
+import { Attention } from './attention.js';
 import { resolveSourceUrl, filenameFromUrl } from './open-url.js';
 import { EXAMPLES } from './examples.js';
 import { GitHubRemote, commitViaPullRequest } from './git-remote.js';
@@ -31,6 +32,7 @@ class App {
 
     this.announcer = new Announcer();
     this.announce = (m, o) => this.announcer.toast(m, o);
+    this.attention = new Attention({ message: 'Back to edot' });
 
     this.editorEl = document.getElementById('editor');
     this.editor = new Editor(this.editorEl);
@@ -100,6 +102,7 @@ class App {
     this._cleanup = [];
     clearTimeout(this._saveTimer);
     try { this._bc?.close(); } catch { /* */ }
+    this.attention?.disarm();
     this.findReplace?.destroy?.();
     this.announcer?.destroy?.();
     this.editor?.destroy?.();
@@ -203,7 +206,7 @@ class App {
     mi('mi-close', () => this.closeDocument());
     mi('mi-find', () => this.findReplace.open(true));
     mi('mi-github', () => this.openGithubDialog());
-    mi('mi-data', () => { const w = window.open('data/data.html', '_blank', 'noopener'); if (!w) location.href = 'data/data.html'; });
+    mi('mi-data', () => { const w = window.open('data/data.html', '_blank', 'noopener'); if (!w) location.href = 'data/data.html'; else this.attention.arm('Back to edot', { once: true }); });
 
     this.fileInput.accept = IO.importAccept();
     this.fileInput.addEventListener('change', () => {
@@ -307,6 +310,9 @@ class App {
     };
     this.ghEl.preview.addEventListener('click', () => this._githubPreview());
     this.ghEl.commit.addEventListener('click', () => this._githubCommit());
+    // While the dialog is open and you flip to GitHub to make a token, nudge
+    // the edot tab so it's easy to find your way back; stop when it closes.
+    this.ghDialog.addEventListener('close', () => this.attention.disarm());
     // Returning from the GitHub token page (token freshly copied) refocuses
     // this tab — grab it from the clipboard if the field is still empty.
     this._on(window, 'focus', () => { if (this.ghDialog.open) this._harvestToken(); });
@@ -349,6 +355,7 @@ class App {
     showModal(this.ghDialog);
     (el.repo.value ? el.token : el.repo).focus();
     this._harvestToken(); // pick up a freshly-copied token from the clipboard
+    this.attention.arm('Paste your GitHub token'); // nudge the tab on return
   }
 
   _ghParse() {

--- a/magpie/edot/test-edot.mjs
+++ b/magpie/edot/test-edot.mjs
@@ -406,6 +406,26 @@ try {
   });
   ok('docx Symbol-font run imports ∀ (not a square)', /∀x is happy/.test(symDoc));
 
+  // 9n. Attention: nudge title + favicon while the tab is hidden, restore on return.
+  const att = await page.evaluate(async () => {
+    const { Attention } = await import('./js/attention.js');
+    const orig = document.title;
+    let hidden = false;
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+    const a = new Attention({ timeoutMs: 60000 });
+    a.arm('Come back', { once: true });
+    hidden = true; document.dispatchEvent(new Event('visibilitychange'));
+    const iconAway = (document.querySelector('link[rel~="icon"]') || {}).href || '';
+    await new Promise((r) => setTimeout(r, 1250));
+    const titleAway = document.title;
+    hidden = false; document.dispatchEvent(new Event('visibilitychange'));
+    await new Promise((r) => setTimeout(r, 30));
+    return { orig, iconAway, titleAway, titleBack: document.title, blinking: a._blinking, armed: a._armed };
+  });
+  ok('attention swaps favicon while away', /svg/.test(att.iconAway));
+  ok('attention nudges the title while away', /Come back|🔔/.test(att.titleAway));
+  ok('attention restores title + disarms on return (once)', att.titleBack === att.orig && !att.blinking && !att.armed);
+
   // 10. LibreOffice bridge reports not-configured gracefully.
   const loState = await page.evaluate(async () => {
     const LO = await import('./js/libreoffice-bridge.js');


### PR DESCRIPTION
When you flip to another tab/window from edot with a dialog open — e.g. off to GitHub to create a token, or to the Data workspace — the edot tab now **gently blinks its document title** (🔔 *Paste your GitHub token* / *Back to edot*) and **swaps the favicon** to a ↩ marker so it stands out in the tab strip. On return it restores everything and **softly flashes the page** to confirm. **Auto-stops after a few minutes**, and respects `prefers-reduced-motion`.

`js/attention.js` (reusable `Attention` class):
- **sticky** mode keeps nudging across round-trips while the GitHub dialog is open (disarms on dialog `close`);
- **once** mode disarms on the first return (the Data-workspace jump).

Wired into the app; disarmed on `destroy()`.

**Test:** smoke **+3** (favicon swap while hidden, title nudge, restore + disarm on return, via a mocked `document.hidden`). All suites green; HTML valid.

> Context: this complements the clipboard token-harvest — now the tab *tells you where to come back to*, and fills the token in when you do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_