### PR TITLE
edot: readable toolbar (long-press labels + labelled mode) + mobile data UI

### DIFF
--- a/magpie/edot/README.md
+++ b/magpie/edot/README.md
@@ -61,6 +61,9 @@ offline, and dependency-free.
   export. Distinguishes edot from a plain word processor.
 - **High-fidelity I/O (optional)** — `.odt`, `.doc`, `.rtf` import and ODT/RTF
   export via a pluggable **LibreOffice WASM** backend (see below).
+- **Readable toolbar** — **long-press** any toolbar button for a big label
+  bubble, or tap **Aa** to grow the toolbar into a larger, **text-labelled**
+  layout (persisted) — for when the icons alone are hard to read.
 - **Accessibility first** — ARIA toolbar with roving tabindex, screen-reader
   live announcements, full keyboard operation, native `<dialog>` modal, skip
   link, honours `prefers-color-scheme` and `prefers-reduced-motion`.

--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -184,6 +184,37 @@ body {
 .tbtn.underline { text-decoration: underline; }
 .tbtn.strike { text-decoration: line-through; }
 
+.tbtn .tglyph { display: inline-flex; align-items: center; justify-content: center; font-size: 1.06rem; line-height: 1; }
+.tbtn .tlabel { display: none; }
+
+/* "Labels" mode: a bigger, text-labelled toolbar for easier reading.
+   Toggle with the Aa button (persisted); long-press any control for a big
+   readable label bubble even when off. */
+.toolbar.labels .tbtn:not(select) {
+  flex-direction: column;
+  height: auto;
+  min-height: 2.9rem;
+  gap: 0.08rem;
+  padding: 0.3em 0.45em;
+}
+.toolbar.labels .tbtn .tglyph { font-size: 1.2rem; }
+.toolbar.labels .tbtn .tlabel {
+  display: block; font-size: 0.62rem; line-height: 1.05; color: var(--ink);
+  max-width: 5rem; overflow: hidden; text-overflow: ellipsis;
+}
+
+.tbtip {
+  position: fixed; transform: translateX(-50%);
+  background: var(--ink); color: var(--bg);
+  padding: 0.45em 0.8em; border-radius: 7px;
+  font-size: 1rem; font-weight: 600; white-space: nowrap;
+  z-index: 200; pointer-events: none; opacity: 0; transition: opacity 0.12s;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+}
+.tbtip.show { opacity: 0.97; }
+@media (prefers-reduced-motion: reduce) { .tbtip { transition: none; } }
+@media (pointer: coarse) { .tbtn .tglyph { font-size: 1.2rem; } }
+
 select.tbtn {
   min-width: 7rem;
   text-align: left;

--- a/magpie/edot/data/README.md
+++ b/magpie/edot/data/README.md
@@ -61,6 +61,10 @@ data/
 All four are real custom elements (`customElements.define`) using light DOM +
 the shared `data.css`, so they can be embedded individually.
 
+**Mobile:** the object list (tables/views/sheets) collapses into a slide-in
+**☰ drawer** with a scrim, the toolbar stays sticky, and tap targets grow on
+coarse pointers — sharing the editor's design tokens for a consistent feel.
+
 ## Testing
 
 ```bash

--- a/magpie/edot/data/data-workspace.js
+++ b/magpie/edot/data/data-workspace.js
@@ -51,7 +51,9 @@ export class EdotData extends HTMLElement {
     const tb = document.createElement('div'); tb.className = 'dw-toolbar';
     const file = document.createElement('input'); file.type = 'file'; file.accept = '.csv,text/csv'; file.style.display = 'none';
     const dbfile = document.createElement('input'); dbfile.type = 'file'; dbfile.accept = '.sqlite,.db,application/octet-stream'; dbfile.style.display = 'none';
+    const menu = this._btn('☰', () => root.classList.toggle('side-open')); menu.classList.add('dw-menu-btn'); menu.setAttribute('aria-label', 'Show objects');
     tb.append(
+      menu,
       this._btn('⬆ Import CSV', () => file.click(), 'primary'),
       this._btn('🎵 Sample (Chinook)', () => this.loadChinook()),
       this._btn('＋ Sheet', () => this.newSheet()),
@@ -67,7 +69,9 @@ export class EdotData extends HTMLElement {
     const main = document.createElement('div'); main.className = 'dw-main';
     root.append(tb, side, main);
     this.innerHTML = ''; this.appendChild(root);
-    this._side = side; this._main = main;
+    this._side = side; this._main = main; this._root = root;
+    // Tap the scrim (or pick an item) closes the mobile drawer.
+    root.addEventListener('click', (e) => { if (e.target === root) root.classList.remove('side-open'); });
 
     file.addEventListener('change', () => { if (file.files[0]) this.importCsv(file.files[0]); file.value = ''; });
     dbfile.addEventListener('change', () => { if (dbfile.files[0]) this.importDbFile(dbfile.files[0]); dbfile.value = ''; });
@@ -101,7 +105,7 @@ export class EdotData extends HTMLElement {
       const del = document.createElement('span'); del.textContent = '✕'; del.title = 'Delete'; del.className = 'hint';
       del.addEventListener('click', (e) => { e.stopPropagation(); this._delete(title, name); });
       it.append(ic, nm, del);
-      it.addEventListener('click', () => onOpen(name));
+      it.addEventListener('click', () => { onOpen(name); this._root.classList.remove('side-open'); });
       this._side.appendChild(it);
     }
   }

--- a/magpie/edot/data/data.css
+++ b/magpie/edot/data/data.css
@@ -29,7 +29,7 @@ edot-data, edot-grid, edot-sheet, edot-query { display: block; }
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 .dw-toolbar {
-  grid-column: 1 / 3;
+  grid-column: 1 / -1;
   display: flex; flex-wrap: wrap; gap: 0.3rem; align-items: center;
   padding: 0.4rem 0.6rem; background: var(--d-surface); border-bottom: 1px solid var(--d-line);
 }
@@ -101,6 +101,39 @@ table.grid input.cell-input {
 .q-bar { display: flex; gap: 0.4rem; align-items: center; margin-bottom: 0.4rem; }
 
 .hint { color: var(--d-muted); font-size: 0.8rem; }
+
+/* Touch + convergence with the editor: bigger tap targets, no zoom delay. */
+.dbtn, .dw-item, .q-editor, .find-input, input, select, button { touch-action: manipulation; }
+.dw-main { overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
+
+@media (pointer: coarse) {
+  .dbtn { padding: 0.55em 0.85em; font-size: 0.9rem; }
+  .dw-item { padding: 0.55em 0.5em; }
+  table.grid th, table.grid td { padding: 0.4em 0.55em; height: 2em; }
+}
+
+/* The ☰ objects button only shows on mobile, where the sidebar is a drawer. */
+.dw-menu-btn { display: none; }
+
+/* Mobile: the object list (tables/views/sheets) becomes a slide-in drawer with
+   a scrim — discoverable via the ☰ button — so the main area stays full-width. */
+@media (max-width: 44rem) {
+  .dw { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
+  .dw-main { grid-column: 1; }
+  .dw-menu-btn { display: inline-flex; }
+  .dw-side {
+    position: fixed; top: 0; bottom: 0; left: 0; z-index: 40;
+    width: min(80vw, 18rem); max-height: none;
+    transform: translateX(-100%); transition: transform 0.2s ease;
+    box-shadow: 2px 0 18px rgba(0,0,0,0.3);
+  }
+  .dw.side-open .dw-side { transform: none; }
+  .dw.side-open::after { content: ''; position: fixed; inset: 0; background: rgba(0,0,0,0.38); z-index: 39; }
+  .dw-toolbar { gap: 0.25rem; position: sticky; top: 0; z-index: 5; }
+  .sheet-bar { flex-wrap: wrap; }
+  .sheet-bar input.formula { min-width: 8rem; }
+}
+@media (prefers-reduced-motion: reduce) { .dw-side { transition: none; } }
 
 /* ---- cross-tab "sent to editor" toast ---- */
 .dw-toast {

--- a/magpie/edot/data/test-data.mjs
+++ b/magpie/edot/data/test-data.mjs
@@ -113,6 +113,15 @@ try {
   });
   ok('sendToEditor writes an HTML-table handoff', handoff && handoff.type === 'insert' && handoff.title === 'My table' && /<table>.*<td>1<\/td>/.test(handoff.html));
 
+  // 4d. Mobile object-drawer toggle.
+  ok('mobile drawer toggles via ☰', await page.evaluate(() => {
+    const d = document.querySelector('edot-data');
+    d.querySelector('.dw-menu-btn').click();
+    const open = d._root.classList.contains('side-open');
+    d._root.classList.remove('side-open');
+    return open;
+  }));
+
   // 5. Persistence: DB exports to bytes.
   ok('database exports to bytes', await page.evaluate(() => document.querySelector('edot-data').engine.exportDb().length > 0));
 

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -103,6 +103,7 @@ class App {
     clearTimeout(this._saveTimer);
     try { this._bc?.close(); } catch { /* */ }
     this.attention?.disarm();
+    this.toolbar?.destroy?.();
     this.findReplace?.destroy?.();
     this.announcer?.destroy?.();
     this.editor?.destroy?.();

--- a/magpie/edot/js/toolbar.js
+++ b/magpie/edot/js/toolbar.js
@@ -68,6 +68,7 @@ export class Toolbar {
       for (const id of section.items) group.appendChild(this._button(id));
       this.root.appendChild(group);
     }
+    this.root.appendChild(this._labelsToggle());
     // first control is the only initial tab stop
     this.controls.forEach((el, i) => el.setAttribute('tabindex', i === 0 ? '0' : '-1'));
   }
@@ -105,11 +106,14 @@ export class Toolbar {
     const icon = ICONS[id] || { glyph: id };
     const cmd = COMMANDS[id];
     const label = (cmd && cmd.label) || icon.label || id;
+    const tip = label + (cmd && cmd.key ? ` · ${shortcutText(cmd)}` : '');
 
     btn.className = 'tbtn' + (icon.cls ? ` ${icon.cls}` : '');
-    btn.textContent = icon.glyph;
-    btn.setAttribute('aria-label', label + (cmd && cmd.key ? ` (${shortcutText(cmd)})` : ''));
-    btn.title = btn.getAttribute('aria-label');
+    const g = document.createElement('span'); g.className = 'tglyph'; g.textContent = icon.glyph;
+    const l = document.createElement('span'); l.className = 'tlabel'; l.textContent = label;
+    btn.append(g, l);
+    btn.setAttribute('aria-label', tip);
+    btn.title = tip;
     btn.dataset.cmd = id;
 
     if (cmd && cmd.state) {
@@ -124,6 +128,7 @@ export class Toolbar {
 
     btn.addEventListener('click', (e) => {
       e.preventDefault();
+      if (btn._peek) { btn._peek = false; return; } // a long-press peeked the label; don't act
       if (id === 'link') { createLink(this.announce); }
       else if (id === 'semantic') { createSemantic(this.announce); }
       else if (id in ALIGN) { setAlign(ALIGN[id]); }
@@ -134,10 +139,71 @@ export class Toolbar {
     });
     // Keep selection while pressing toolbar (don't steal focus on mousedown).
     btn.addEventListener('mousedown', (e) => e.preventDefault());
+    this._wireLongPress(btn, tip);
 
     this.controls.push(btn);
     return btn;
   }
+
+  // Press-and-hold any control to reveal a big, readable label bubble (the icon
+  // alone is hard to read). The hold suppresses the action so it's a safe peek.
+  _wireLongPress(el, text) {
+    let timer = null;
+    const start = () => { el._peek = false; timer = setTimeout(() => { timer = null; el._peek = true; this._showTip(el, text); }, 420); };
+    const cancel = () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      this._hideTip();
+      // Self-heal: if a peek didn't get consumed by a click, clear it next tick.
+      if (el._peek) setTimeout(() => { el._peek = false; }, 0);
+    };
+    el.addEventListener('pointerdown', start);
+    el.addEventListener('pointerup', cancel);
+    el.addEventListener('pointerleave', cancel);
+    el.addEventListener('pointercancel', cancel);
+  }
+
+  _showTip(el, text) {
+    if (!this._tip) { this._tip = document.createElement('div'); this._tip.className = 'tbtip'; document.body.appendChild(this._tip); }
+    this._tip.textContent = text;
+    const r = el.getBoundingClientRect();
+    this._tip.style.left = `${Math.round(r.left + r.width / 2)}px`;
+    this._tip.style.top = `${Math.round(r.bottom + 8)}px`;
+    this._tip.classList.add('show');
+  }
+  _hideTip() { if (this._tip) this._tip.classList.remove('show'); }
+
+  _labelsOn() { try { return localStorage.getItem('edot.toolbarLabels') === '1'; } catch { return false; } }
+
+  // A toggle that "grows" the toolbar into a larger, text-labelled layout —
+  // for anyone who finds the icons hard to read. Persisted.
+  _labelsToggle() {
+    const wrap = document.createElement('div'); wrap.className = 'group';
+    const btn = document.createElement('button'); btn.type = 'button'; btn.className = 'tbtn labels-toggle';
+    const g = document.createElement('span'); g.className = 'tglyph'; g.textContent = 'Aa';
+    const l = document.createElement('span'); l.className = 'tlabel'; l.textContent = 'Labels';
+    btn.append(g, l);
+    btn.setAttribute('aria-label', 'Show button labels');
+    btn.title = 'Show button labels';
+    const apply = (on) => {
+      this.root.classList.toggle('labels', on);
+      btn.setAttribute('aria-pressed', String(on));
+      try { localStorage.setItem('edot.toolbarLabels', on ? '1' : '0'); } catch { /* */ }
+    };
+    apply(this._labelsOn());
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (btn._peek) { btn._peek = false; return; }
+      apply(!this.root.classList.contains('labels'));
+      this.editor.focus();
+    });
+    btn.addEventListener('mousedown', (e) => e.preventDefault());
+    this._wireLongPress(btn, 'Show button labels — bigger, with text');
+    this.controls.push(btn);
+    wrap.appendChild(btn);
+    return wrap;
+  }
+
+  destroy() { if (this._tip) { this._tip.remove(); this._tip = null; } }
 
   _wireRovingFocus() {
     this.root.addEventListener('keydown', (e) => {

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -162,6 +162,25 @@ try {
     /<table>/.test(document.getElementById('editor').innerHTML) && /Imported data/.test(document.getElementById('editor').textContent)));
   ok('handoff is consumed (cleared)', await page.evaluate(() => !localStorage.getItem('edot.handoff')));
 
+  // Toolbar readability: long-press reveals a big label; Labels mode adds text.
+  await page.evaluate(() => {
+    const btn = document.querySelector('button[data-cmd="bold"]');
+    btn.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+  });
+  await page.waitForTimeout(550);
+  ok('long-press shows a readable label bubble', await page.evaluate(() => {
+    const t = document.querySelector('.tbtip.show');
+    return !!t && /Bold/.test(t.textContent);
+  }));
+  await page.evaluate(() => document.querySelector('button[data-cmd="bold"]').dispatchEvent(new PointerEvent('pointerup', { bubbles: true })));
+  await page.click('.labels-toggle');
+  ok('Labels mode shows text under icons', await page.evaluate(() => {
+    const tl = document.querySelector('button[data-cmd="bold"] .tlabel');
+    return document.getElementById('toolbar').classList.contains('labels') && tl && getComputedStyle(tl).display !== 'none' && /Bold/.test(tl.textContent);
+  }));
+  ok('Labels preference persists', await page.evaluate(() => localStorage.getItem('edot.toolbarLabels') === '1'));
+  await page.click('.labels-toggle'); // back off
+
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
 } finally { await b.close(); server.close(); }


### PR DESCRIPTION
Addresses the UX feedback: editor icons hard to read, and the data UI needing mobile work + convergence with the editor.

### Editor toolbar readability
- **Long-press** any toolbar control → a big, high-contrast **label bubble** ("Bold · Ctrl/⌘B"). A safe *peek* that doesn't fire the action; per-button suppression so it never swallows a real tap. Works on touch and mouse-hold.
- **"Aa" toggle** grows the toolbar into a larger, **text-labelled** layout (icon + word beneath), **persisted**. Bigger glyphs and coarse-pointer sizing throughout.

### Data workspace — mobile + convergence
- The tables/views/sheets sidebar becomes a discoverable slide-in **☰ drawer** (tap-to-dismiss scrim) on ≤44rem, so the grid/sheet/query gets full width; picking an item closes it.
- Sticky toolbar, bigger touch targets on coarse pointers, `touch-action: manipulation`, contained overscroll. Shares the editor's palette/fonts for a consistent feel.

This pushes actions into **discoverable contextual UI**: long-press reveals what an icon does in place, and the drawer surfaces objects on demand.

### Testing
- e2e **+3** (long-press bubble, Labels mode adds text, preference persists), data **+1** (drawer toggle). Toolbar gains `destroy()`; wired into `App.destroy`. Smoke **77** / data **17** / e2e green; HTML valid. Screenshots verify the labelled toolbar, the hold-tooltip, and the mobile object drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_