### PR TITLE
edot suite: system-wide sign-in chip (alpha) + Tier-1 encrypted backup (GitHub/S3/WebDAV/Solid)

### DIFF
--- a/magpie/edot/backup/README.md
+++ b/magpie/edot/backup/README.md
@@ -1,0 +1,128 @@
+# edot — encrypted backup & restore (Tier 1) · **ALPHA**
+
+Client-side, passphrase-encrypted backup and restore of your local edot data
+(IndexedDB) to a pluggable storage backend: **GitHub · S3 · WebDAV · Solid**.
+
+> ⚠️ **ALPHA — experimental.** Verify your backups before relying on them.
+> Encryption is end-to-end with **your passphrase only**. There is **no
+> recovery** in Tier 1: **lose the passphrase = lose the data.**
+
+This implements **Tier 1** of [`../ENCRYPTED-BACKUP.md`](../ENCRYPTED-BACKUP.md)
+(passphrase envelope encryption). Tier 2 (the OIDC-gated key service that makes
+decryption *conditional on a login*) needs a backend and is **out of scope**
+here — the code leaves clearly-marked hooks for it (see *Tier-2 hooks* below).
+
+Open `backup.html` (served over https or localhost — Web Crypto needs a secure
+context). No build step, no runtime CDN dependencies: Web Crypto + `fetch` only.
+
+## How it works (the envelope)
+
+```
+snapshot  = serialise(chosen IndexedDB databases)     // snapshot.js
+DEK       = random AES-GCM-256                          // data key
+ciphertext= AES-GCM(DEK, iv, snapshot)                 // GCM tag = integrity
+KEK       = PBKDF2(passphrase, salt, 210k, SHA-256)    // crypto.js
+wrappedDEK= AES-GCM(KEK, iv, DEK)                       // passphrase wraps the key
+envelope  = magic + JSON header + ciphertext           // self-describing, versioned
+```
+
+The header is `{ v, kdf, salt, iv, wrappedDEK, cipherIv, sha256OfPlaintext,
+createdAt }`. `sha256OfPlaintext` is the OPENDOC fingerprint gesture — a restore
+re-hashes the recovered bytes and refuses a mismatch. A wrong passphrase fails
+at DEK-unwrap; a tampered ciphertext fails the GCM tag — both surface as clear
+errors, never silent corruption.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `js/crypto.js` | Tier-1 envelope: PBKDF2 KEK, AES-GCM DEK wrap, versioned header, SHA-256 fingerprint. The `deriveKek()` seam is where Tier-2 folds in `S_user`. |
+| `js/snapshot.js` | Collect/restore IndexedDB databases into one blob + manifest. DB/store list is configurable (`DEFAULT_DATABASES`). |
+| `js/stores/github.js` | GitHub Contents API adapter (base64 file under `edot-backups/`). |
+| `js/stores/s3.js` | S3-compatible adapter via **presigned URLs** (CORS-friendly). |
+| `js/stores/webdav.js` | WebDAV adapter (PUT/GET/PROPFIND/DELETE, Basic auth). |
+| `js/stores/solid.js` | Solid Pod adapter (LDP container; bearer-token shim, DPoP seam). |
+| `js/stores/index.js` | Backend registry (`github`/`s3`/`webdav`/`solid`). |
+| `js/backup-config.js` | Per-backend config placeholders + CORS notes. |
+| `js/backup-ui.js` | `<edot-backup>` web component (light DOM, accessible, mobile-first). |
+| `css/backup.css` | Component styles (reuses `../css/edot.css` variables, dark-mode aware). |
+| `backup.html` | Page; exposes `window.__backup` headless-test hook. |
+| `test-backup.mjs` | Headless Chromium test (mocked `fetch`, ✅/❌, non-zero exit). |
+
+Every adapter shares one opaque-blob interface and an **injectable `fetch`**
+(mirroring `../js/git-remote.js`), so the suite is fully testable offline:
+
+```js
+put(id, bytes, cfg)            // → {}
+get(id, cfg)                   // → Uint8Array
+list(cfg)                      // → [{ id, size, modified }]
+remove(id, cfg)               // → {}
+```
+
+## Per-backend setup & CORS caveats
+
+### GitHub  — *fully working*
+- `cfg = { repo: 'owner/name', token, dir = 'edot-backups', branch? }`
+- Token: a fine-grained PAT with **Contents: read/write** on a **private** repo.
+- **CORS: none needed** — `api.github.com` is CORS-enabled. Repo history gives
+  you free versioning of every backup.
+
+### S3-compatible  — *working via presigned URLs; raw SigV4 intentionally shimmed*
+- Primary path: `cfg.presign(method, key) -> url` (PUT/GET/DELETE/LIST signed
+  **server-side**), plus `cfg.listUrl` (a presigned `ListObjectsV2` URL). For
+  quick tests you may instead pass direct `cfg.urls = { put, get, del, list }`.
+- **Raw AWS SigV4 from the browser is NOT implemented** on purpose: it would
+  ship your secret key to the page. Keep signing on a tiny backend.
+- **CORS:** the bucket needs a CORS policy allowing your origin and
+  `PUT/GET/DELETE`. ListObjectsV2 returns XML, which we parse without a lib.
+
+### WebDAV  — *fully working*
+- `cfg = { baseUrl, user?, password? }` (Basic auth). Listing uses `PROPFIND`
+  `Depth: 1` and parses the multistatus XML namespace-agnostically.
+- **CORS:** most WebDAV servers (Nextcloud, Apache `mod_dav`) must be configured
+  to send CORS headers for your origin **and** allow the `PROPFIND` method in
+  `Access-Control-Allow-Methods` — otherwise the browser blocks listing.
+
+### Solid  — *working with a bearer token (Tier-1 shim); Solid-OIDC + DPoP is TODO*
+- `cfg = { container, token? }` — `container` is a Pod container URL ending `/`.
+  PUT/GET/DELETE a resource; list via a Turtle `GET` of the container
+  (`ldp:contains`).
+- **Auth:** Tier 1 sends `Authorization: Bearer <token>`. **Production Solid is
+  Solid-OIDC + DPoP** (DPoP-bound access tokens with a per-request proof JWT);
+  bearer-only tokens are rejected by DPoP-enforcing servers. The adapter accepts
+  an injectable `cfg.dpopHeaders(method, url)` provider so the auth module can
+  supply proofs later without forking the file. **(SOLID-OIDC TODO.)**
+- **CORS:** most Community/Enterprise Solid Servers already send permissive CORS.
+
+## Tier-2 hooks left for the OIDC-gated key service
+
+Tier 2 (`../ENCRYPTED-BACKUP.md` §Tier 2) makes decryption *conditional on a
+valid OIDC login* by mixing a service-released secret `S_user` into the KEK:
+`KEK = HKDF( concat( PBKDF2(passphrase, salt), S_user ) )`. The seams:
+
+1. **`crypto.js` → `deriveKek()`** — the single place key derivation happens.
+   Search **`TIER2-HOOK`**. Fold `S_user` (fetched from the auth-gated service
+   after an OIDC token check) into an HKDF here; nothing else in `crypto.js`
+   changes.
+2. **`crypto.js` header `kdf` field** — versioned (`'pbkdf2'` today). A Tier-2
+   envelope would record `'pbkdf2+hkdf'`; `decryptSnapshot` already rejects
+   unknown KDFs gracefully so old/new clients coexist.
+3. **`stores/solid.js` → `dpopHeaders` seam** (**`SOLID-OIDC TODO`**) — where
+   `magpie/edot/auth/` (`OidcClient` / `AuthSession`) injects Solid-OIDC + DPoP
+   proofs. This is the storage adapter that the auth module will tie into.
+
+Argon2id is noted in the design as a stronger KDF; it needs a vendored WASM
+module, so PBKDF2 (built-in) is the Tier-1 choice, with the `kdf` field reserved
+to recognise an `'argon2id'` envelope in future.
+
+## Test
+
+```sh
+node magpie/edot/backup/test-backup.mjs
+```
+
+Covers: crypto round-trip + wrong-passphrase + tamper + fingerprint; snapshot
+seed→wipe→restore (incl. binary values); all four adapters against a mocked
+`fetch` (verifying method/URL shapes — GitHub Contents PUT, WebDAV PROPFIND,
+Solid container GET); the full snapshot→encrypt→GitHub→decrypt path; and the UI
+(ALPHA badge present, no page errors). All network is mocked — no credentials.

--- a/magpie/edot/backup/backup.html
+++ b/magpie/edot/backup/backup.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="description" content="edot encrypted backup — client-side, passphrase-encrypted backup &amp; restore of your local data to GitHub, S3, WebDAV, or a Solid Pod. ALPHA.">
+  <meta name="color-scheme" content="light dark">
+  <title>edot — encrypted backup (ALPHA)</title>
+  <!-- Shared edot variables/components (dark mode, focus rings, etc.) -->
+  <link rel="stylesheet" href="../css/edot.css">
+  <link rel="stylesheet" href="css/backup.css">
+  <style>
+    html, body { height: auto; overflow: auto; }
+    body { display: block; }
+    .app-header { display: flex; align-items: center; gap: 0.6rem; padding: 0.5rem 0.9rem; }
+    .app-header h1 { font-size: 1.05rem; margin: 0; }
+    .app-header .logo { color: var(--accent); }
+    .app-header .spacer { flex: 1; }
+    .app-header a { color: var(--focus); font-size: 0.85rem; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to backup</a>
+  <header class="app-header">
+    <h1><span class="logo">🔐 edot backup</span></h1>
+    <span class="spacer"></span>
+    <a href="../edot.html">← back to editor</a>
+  </header>
+
+  <main id="main">
+    <edot-backup></edot-backup>
+  </main>
+
+  <script type="module">
+    import { EdotBackup } from './js/backup-ui.js';
+    import * as crypto from './js/crypto.js';
+    import * as snapshot from './js/snapshot.js';
+    import { STORES, getStore, listStores } from './js/stores/index.js';
+
+    // Headless-test hook: exposes the crypto core, snapshot fns, adapters, and a
+    // handle to the live component so test-backup.mjs can drive everything
+    // (incl. injecting a mocked fetch via component._fetchImpl).
+    window.__backup = {
+      crypto, snapshot,
+      stores: STORES, getStore, listStores,
+      component: () => document.querySelector('edot-backup'),
+    };
+  </script>
+</body>
+</html>

--- a/magpie/edot/backup/css/backup.css
+++ b/magpie/edot/backup/css/backup.css
@@ -1,0 +1,93 @@
+/* backup.css — styles for <edot-backup>. Reuses edot.css custom properties
+   (--bg/--surface/--ink/--accent/…); light DOM so they cascade in. Mobile-first,
+   em/rem units, dark-mode aware via the inherited variables. */
+
+.bk {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: 1rem 0.9rem calc(2rem + env(safe-area-inset-bottom));
+  background: var(--surface, #fff);
+  color: var(--ink, #1c1c1c);
+}
+
+.bk-head { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+.bk-head h2 { font-size: 1.15rem; margin: 0; }
+
+/* ALPHA badge — deliberately loud. */
+.bk-badge {
+  font-size: 0.7rem; font-weight: 800; letter-spacing: 0.08em;
+  background: var(--danger, #b00020); color: #fff;
+  padding: 0.15em 0.5em; border-radius: 999px; text-transform: uppercase;
+}
+
+.bk-warn {
+  margin: 0.5rem 0 1rem;
+  padding: 0.55em 0.75em;
+  border: 1px solid var(--danger, #b00020);
+  border-radius: var(--radius, 6px);
+  background: color-mix(in srgb, var(--danger, #b00020) 8%, transparent);
+  font-size: 0.85rem; line-height: 1.45;
+}
+
+.bk-row { display: grid; grid-template-columns: 1fr; gap: 0.25rem; margin: 0.5rem 0; }
+@media (min-width: 32rem) {
+  .bk-row { grid-template-columns: 9rem 1fr; align-items: center; gap: 0.5rem 0.75rem; }
+}
+.bk-row label { font-size: 0.85rem; color: var(--muted, #5a5a5a); }
+
+.bk-input {
+  font: inherit; font-size: 0.95rem;
+  padding: 0.5em 0.6em;
+  border: 1px solid var(--line, #d9d6cf);
+  border-radius: var(--radius, 6px);
+  background: var(--bg, #f4f4f2); color: var(--ink, #1c1c1c);
+  width: 100%; min-width: 0;
+}
+.bk-input:focus { outline: 2px solid var(--focus, #1a73e8); outline-offset: -1px; }
+
+.bk-fields {
+  border: 1px solid var(--line, #d9d6cf);
+  border-radius: var(--radius, 6px);
+  padding: 0.5rem 0.75rem 0.75rem;
+  margin: 0.75rem 0 0.4rem;
+}
+.bk-fields legend { font-size: 0.8rem; color: var(--muted, #5a5a5a); padding: 0 0.4em; }
+
+.bk-cors { font-size: 0.78rem; color: var(--muted, #5a5a5a); margin: 0 0 0.75rem; line-height: 1.4; }
+
+.bk-actions { display: flex; gap: 0.6rem; flex-wrap: wrap; margin: 0.75rem 0 0.5rem; }
+
+.bk-btn {
+  font: inherit; font-size: 0.95rem; cursor: pointer;
+  min-height: 2.6rem; padding: 0 1em;
+  border: 1px solid var(--line, #d9d6cf);
+  border-radius: var(--radius, 6px);
+  background: var(--surface, #fff); color: var(--ink, #1c1c1c);
+  touch-action: manipulation;
+}
+.bk-btn:hover { border-color: var(--focus, #1a73e8); }
+.bk-btn:focus-visible { outline: 3px solid var(--focus, #1a73e8); outline-offset: 1px; }
+.bk-btn.primary { background: var(--accent, #8b4513); color: var(--accent-fg, #fff); border-color: transparent; }
+.bk-btn.primary:hover { filter: brightness(1.08); }
+.bk-btn.small { min-height: 2.1rem; padding: 0 0.7em; font-size: 0.85rem; }
+.bk-btn.danger { color: var(--danger, #b00020); }
+.bk-btn.danger:hover { background: var(--danger, #b00020); color: #fff; border-color: var(--danger, #b00020); }
+
+.bk-status { font-size: 0.9rem; margin: 0.5rem 0; min-height: 1.3em; }
+.bk-status[data-kind="error"] { color: var(--danger, #b00020); }
+.bk-status[data-kind="ok"] { color: var(--ok, #155724); }
+
+.bk-fp { font-size: 0.82rem; color: var(--muted, #5a5a5a); margin: 0.25rem 0; word-break: break-all; }
+.bk-fp code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+
+.bk-subh { font-size: 1rem; margin: 1.2rem 0 0.4rem; }
+
+.bk-list { list-style: none; margin: 0; padding: 0; }
+.bk-item {
+  display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+  padding: 0.5rem; border: 1px solid var(--line, #d9d6cf);
+  border-radius: var(--radius, 6px); margin-bottom: 0.4rem;
+}
+.bk-item-id { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85rem; flex: 1 1 10rem; min-width: 0; overflow-wrap: anywhere; }
+.bk-item-meta { font-size: 0.78rem; color: var(--muted, #5a5a5a); }
+.bk-empty { color: var(--muted, #5a5a5a); font-size: 0.9rem; padding: 0.5rem 0; }

--- a/magpie/edot/backup/js/backup-config.js
+++ b/magpie/edot/backup/js/backup-config.js
@@ -1,0 +1,56 @@
+// backup-config.js — per-backend config placeholders for the backup UI.
+//
+// These are *defaults / shapes only*. Secrets (tokens, passwords) are NEVER
+// committed here — the UI collects them at runtime and keeps them in memory
+// (optionally localStorage if the user opts in). Treat every value below as a
+// placeholder a user overrides in the form.
+
+// Default object path/prefix used by all backends.
+export const DEFAULT_PREFIX = 'edot-backups';
+
+export const BACKENDS = {
+  github: {
+    label: 'GitHub repo',
+    // repo: 'owner/name'  — a PRIVATE repo is strongly recommended.
+    // token: a fine-grained PAT with Contents read/write on that repo.
+    // dir: folder for the encrypted files (history = free versioning).
+    fields: { repo: '', token: '', dir: DEFAULT_PREFIX, branch: '' },
+    // CORS: api.github.com is CORS-enabled — works from the browser as-is.
+    cors: 'GitHub API is CORS-enabled; no extra config needed.',
+  },
+
+  s3: {
+    label: 'S3-compatible (presigned)',
+    // Primary path: presigned URLs (a tiny backend signs PUT/GET/LIST/DELETE).
+    // For quick tests you may instead provide direct `urls`.
+    fields: { endpoint: '', bucket: '', region: '', prefix: DEFAULT_PREFIX, listUrl: '' },
+    // CORS: the bucket must allow your origin + methods. Raw SigV4 from a
+    // browser is discouraged (exposes the secret key) — prefer presigned URLs.
+    cors: 'Bucket needs a CORS policy allowing your origin and PUT/GET/DELETE. '
+        + 'Use presigned URLs (server-side signing) — do not ship AWS secrets to the browser.',
+  },
+
+  webdav: {
+    label: 'WebDAV',
+    // baseUrl: collection URL, e.g. https://host/remote.php/dav/files/me/edot-backups/
+    fields: { baseUrl: '', user: '', password: '' },
+    cors: 'WebDAV server must send CORS headers for your origin and allow the '
+        + 'PROPFIND method (Nextcloud/Apache mod_dav need explicit config).',
+  },
+
+  solid: {
+    label: 'Solid Pod',
+    // container: Pod container URL ending in '/', e.g. https://you.solidpod/edot-backups/
+    // token: a bearer access token (TIER-1 SHIM). Production = Solid-OIDC + DPoP
+    //        via magpie/edot/auth/ (SOLID-OIDC TODO).
+    fields: { container: '', token: '' },
+    cors: 'The Pod server must allow your origin (most CSS/ESS servers do). '
+        + 'Tier-1 uses a bearer token; production needs Solid-OIDC + DPoP.',
+  },
+};
+
+/** Shallow clone of a backend's default field set (for fresh form state). */
+export function defaultFields(backendId) {
+  const b = BACKENDS[backendId];
+  return b ? { ...b.fields } : {};
+}

--- a/magpie/edot/backup/js/backup-ui.js
+++ b/magpie/edot/backup/js/backup-ui.js
@@ -1,0 +1,175 @@
+// backup-ui.js — <edot-backup> web component: the Tier-1 encrypted backup UI.
+//
+// Light DOM (so the shared edot.css + backup.css apply), no globals, mobile-first
+// and accessible. It wires together:
+//   snapshot.js  (collect/restore IndexedDB)  →
+//   crypto.js    (passphrase envelope encrypt/decrypt)  →
+//   stores/*     (put/get/list/remove over an opaque blob).
+//
+// The feature is ALPHA: a visible badge + a one-line warning are rendered up
+// front. Passphrase loss = data loss; there is no recovery in Tier 1.
+
+import { encryptSnapshot, decryptSnapshot, readEnvelopeHeader } from './crypto.js';
+import { createSnapshot, restoreSnapshot, readSnapshotManifest } from './snapshot.js';
+import { getStore, listStores } from './stores/index.js';
+import { BACKENDS, defaultFields } from './backup-config.js';
+
+const FIELD_LABELS = {
+  repo: 'Repo (owner/name)', token: 'Token', dir: 'Folder', branch: 'Branch (optional)',
+  endpoint: 'Endpoint', bucket: 'Bucket', region: 'Region', prefix: 'Prefix', listUrl: 'List URL',
+  baseUrl: 'Base URL', user: 'User', password: 'Password',
+  container: 'Pod container URL',
+};
+const SECRET_FIELDS = new Set(['token', 'password']);
+
+export class EdotBackup extends HTMLElement {
+  connectedCallback() {
+    if (this._built) return;
+    this._built = true;
+    this.backend = 'github';
+    this.cfg = defaultFields(this.backend);
+    this.render();
+  }
+
+  render() {
+    this.innerHTML = `
+      <section class="bk" aria-labelledby="bk-h">
+        <header class="bk-head">
+          <h2 id="bk-h">🔐 Encrypted backup</h2>
+          <span class="bk-badge" role="status">ALPHA</span>
+        </header>
+        <p class="bk-warn" role="note">
+          Experimental — <strong>verify your backups</strong>. Encryption is end-to-end with your
+          passphrase; <strong>passphrase loss = data loss</strong> (no recovery in Tier&nbsp;1).
+        </p>
+
+        <div class="bk-row">
+          <label for="bk-backend">Storage backend</label>
+          <select id="bk-backend" class="bk-input">
+            ${listStores().map((s) => `<option value="${s.id}">${esc(s.label)}</option>`).join('')}
+          </select>
+        </div>
+
+        <fieldset class="bk-fields" id="bk-fields">
+          <legend>Backend settings</legend>
+        </fieldset>
+        <p class="bk-cors" id="bk-cors"></p>
+
+        <div class="bk-row">
+          <label for="bk-pass">Passphrase</label>
+          <input id="bk-pass" class="bk-input" type="password" autocomplete="new-password"
+                 inputmode="text" placeholder="a strong passphrase you can remember">
+        </div>
+
+        <div class="bk-actions">
+          <button id="bk-backup" class="bk-btn primary" type="button">Back up now</button>
+          <button id="bk-refresh" class="bk-btn" type="button">Refresh list</button>
+        </div>
+
+        <p class="bk-status" id="bk-status" role="status" aria-live="polite"></p>
+        <p class="bk-fp" id="bk-fp" hidden>SHA-256: <code id="bk-fp-hex"></code></p>
+
+        <h3 class="bk-subh">Snapshots</h3>
+        <ul class="bk-list" id="bk-list" aria-label="Existing snapshots"></ul>
+      </section>`;
+
+    this.$ = (s) => this.querySelector(s);
+    this.$('#bk-backend').value = this.backend;
+    this.$('#bk-backend').addEventListener('change', (e) => { this.backend = e.target.value; this.cfg = defaultFields(this.backend); this.renderFields(); });
+    this.$('#bk-backup').addEventListener('click', () => this.doBackup());
+    this.$('#bk-refresh').addEventListener('click', () => this.refreshList());
+    this.renderFields();
+  }
+
+  renderFields() {
+    const fs = this.$('#bk-fields');
+    const meta = BACKENDS[this.backend];
+    fs.innerHTML = '<legend>Backend settings</legend>' + Object.keys(meta.fields).map((k) => {
+      const v = this.cfg[k] ?? '';
+      const type = SECRET_FIELDS.has(k) ? 'password' : 'text';
+      const ac = SECRET_FIELDS.has(k) ? 'off' : 'on';
+      return `<div class="bk-row">
+        <label for="bk-f-${k}">${esc(FIELD_LABELS[k] || k)}</label>
+        <input id="bk-f-${k}" class="bk-input" data-field="${k}" type="${type}"
+               autocomplete="${ac}" value="${esc(String(v))}">
+      </div>`;
+    }).join('');
+    fs.querySelectorAll('input[data-field]').forEach((inp) => {
+      inp.addEventListener('input', (e) => { this.cfg[e.target.dataset.field] = e.target.value; });
+    });
+    this.$('#bk-cors').textContent = 'CORS: ' + meta.cors;
+  }
+
+  // Build a store cfg from the form, plus a fetchImpl so callers (and tests) can
+  // inject a mock without touching the adapters.
+  storeCfg(extra = {}) {
+    const cfg = { ...this.cfg, ...extra };
+    if (this._fetchImpl) cfg.fetchImpl = this._fetchImpl;
+    return cfg;
+  }
+
+  status(msg, kind = '') { const el = this.$('#bk-status'); el.textContent = msg; el.dataset.kind = kind; }
+
+  async doBackup() {
+    const pass = this.$('#bk-pass').value;
+    if (!pass) return this.status('Enter a passphrase first.', 'error');
+    try {
+      this.status('Collecting data…');
+      const { bytes, manifest } = await createSnapshot({ indexedDB: this._indexedDB });
+      this.status(`Encrypting ${manifest.totalRecords} record(s)…`);
+      const envelope = await encryptSnapshot(bytes, pass);
+      const bid = `${stamp()}`;
+      this.status('Uploading…');
+      await getStore(this.backend).put(bid, envelope, this.storeCfg());
+      const fpEl = this.$('#bk-fp'); fpEl.hidden = false; this.$('#bk-fp-hex').textContent = manifest.sha256;
+      this.status(`Backed up as ${bid} (${manifest.totalRecords} records).`, 'ok');
+      await this.refreshList();
+    } catch (e) { this.status(`Backup failed: ${e.message}`, 'error'); }
+  }
+
+  async refreshList() {
+    const ul = this.$('#bk-list');
+    try {
+      const items = await getStore(this.backend).list(this.storeCfg());
+      if (!items.length) { ul.innerHTML = '<li class="bk-empty">No snapshots yet.</li>'; return; }
+      ul.innerHTML = items.map((it) => `
+        <li class="bk-item">
+          <span class="bk-item-id">${esc(it.id)}</span>
+          <span class="bk-item-meta">${it.size != null ? fmtSize(it.size) : ''}</span>
+          <button class="bk-btn small" data-act="restore" data-id="${esc(it.id)}" type="button">Restore</button>
+          <button class="bk-btn small danger" data-act="remove" data-id="${esc(it.id)}" type="button">Delete</button>
+        </li>`).join('');
+      ul.querySelectorAll('button[data-act]').forEach((b) => b.addEventListener('click', (e) => {
+        const { act, id } = e.target.dataset;
+        if (act === 'restore') this.doRestore(id); else this.doRemove(id);
+      }));
+    } catch (e) { ul.innerHTML = `<li class="bk-empty">Could not list: ${esc(e.message)}</li>`; }
+  }
+
+  async doRestore(bid) {
+    const pass = this.$('#bk-pass').value;
+    if (!pass) return this.status('Enter the passphrase used for this backup.', 'error');
+    try {
+      this.status(`Downloading ${bid}…`);
+      const envelope = await getStore(this.backend).get(bid, this.storeCfg());
+      this.status('Decrypting…');
+      const plain = await decryptSnapshot(envelope, pass);
+      const manifest = await readSnapshotManifest(plain);
+      this.status(`Restoring ${manifest.totalRecords} record(s)…`);
+      await restoreSnapshot(plain, { indexedDB: this._indexedDB });
+      this.status(`Restored ${bid} (${manifest.totalRecords} records). Reload apps to see changes.`, 'ok');
+    } catch (e) { this.status(`Restore failed: ${e.message}`, 'error'); }
+  }
+
+  async doRemove(bid) {
+    try { await getStore(this.backend).remove(bid, this.storeCfg()); this.status(`Deleted ${bid}.`, 'ok'); await this.refreshList(); }
+    catch (e) { this.status(`Delete failed: ${e.message}`, 'error'); }
+  }
+}
+
+// ---- helpers ----
+function esc(s) { return String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+function stamp() { return new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19); }
+function fmtSize(n) { if (n < 1024) return `${n} B`; if (n < 1048576) return `${(n / 1024).toFixed(1)} KB`; return `${(n / 1048576).toFixed(1)} MB`; }
+
+if (!customElements.get('edot-backup')) customElements.define('edot-backup', EdotBackup);

--- a/magpie/edot/backup/js/crypto.js
+++ b/magpie/edot/backup/js/crypto.js
@@ -1,0 +1,228 @@
+// crypto.js — Tier-1 passphrase envelope encryption for edot backups.
+//
+// Implements the "common core" of ENCRYPTED-BACKUP.md, Tier 1:
+//
+//   1. A random AES-GCM-256 DEK (data key) encrypts the snapshot bytes; the GCM
+//      tag carries integrity (a flipped ciphertext byte fails to decrypt).
+//   2. A KEK (key-encryption key) is derived from the user's passphrase via
+//      PBKDF2(SHA-256, random salt, >=200k iterations). The DEK is *wrapped*
+//      (encrypted) under the KEK with AES-GCM, so the passphrase never touches
+//      the bulk ciphertext directly.
+//   3. A versioned, self-describing header travels with the ciphertext:
+//        { v, kdf, salt, iv, wrappedDEK, cipherIv, sha256OfPlaintext, createdAt }
+//      We also record SHA-256(plaintext) — the OPENDOC fingerprint gesture — so
+//      a restore can prove it recovered exactly what was backed up.
+//
+// Everything is Web Crypto (crypto.subtle). No vendored crypto lib, no CDN.
+//
+// --- Tier-2 UPGRADE PATH (out of scope here; see ENCRYPTED-BACKUP.md §Tier 2) ---
+// To make decryption *conditional on an OIDC login*, the KEK must mix in a
+// secret released only by an auth-gated key service:
+//     KEK = HKDF( concat( PBKDF2(passphrase, salt), S_user ) )
+// `deriveKek()` is the single seam where that S_user would be folded in. The
+// `kdf` header field is versioned precisely so Tier-2 envelopes ('pbkdf2+hkdf')
+// can coexist with Tier-1 ones ('pbkdf2'). Search "TIER2-HOOK" below.
+//
+// Argon2id is mentioned in the design as a stronger KDF option; it needs a
+// vendored WASM module, so PBKDF2 (built into Web Crypto) is the Tier-1 choice.
+// The `kdf` field lets a future 'argon2id' envelope be recognised and rejected
+// gracefully by older clients instead of mis-decoded.
+
+const ENVELOPE_VERSION = 1;
+const ENVELOPE_MAGIC = 'EDOTBK01';        // 8 ASCII bytes; cheap sanity/version guard
+export const PBKDF2_ITERATIONS = 210000;  // >= 200k per spec (OWASP 2023 floor for SHA-256)
+const SALT_BYTES = 16;
+const IV_BYTES = 12;                       // 96-bit nonce, the AES-GCM standard
+
+const subtle = (globalThis.crypto && globalThis.crypto.subtle) || null;
+function requireSubtle() {
+  if (!subtle) throw new Error('Web Crypto (crypto.subtle) unavailable — needs a secure context (https/localhost).');
+  return subtle;
+}
+
+// ---- public API -------------------------------------------------------------
+
+/**
+ * Encrypt snapshot bytes into a self-contained envelope (header + ciphertext).
+ * @param {Uint8Array|ArrayBuffer} bytes  plaintext snapshot
+ * @param {string} passphrase
+ * @returns {Promise<Uint8Array>} envelope bytes (magic + JSON header + ciphertext)
+ */
+export async function encryptSnapshot(bytes, passphrase) {
+  const s = requireSubtle();
+  const plain = asU8(bytes);
+  if (!passphrase) throw new Error('A passphrase is required to encrypt a backup.');
+
+  const sha256OfPlaintext = await sha256Hex(plain);
+
+  // Fresh random material for every backup: salt (KDF), DEK, and two IVs.
+  const salt = randomBytes(SALT_BYTES);
+  const cipherIv = randomBytes(IV_BYTES);
+  const wrapIv = randomBytes(IV_BYTES);
+
+  const dek = await s.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+  const kek = await deriveKek(passphrase, salt);
+
+  // Bulk encrypt under the DEK; the GCM tag is appended to the ciphertext.
+  const ciphertext = new Uint8Array(
+    await s.encrypt({ name: 'AES-GCM', iv: cipherIv }, dek, plain));
+
+  // Wrap (encrypt) the raw DEK under the KEK so only the passphrase unlocks it.
+  const rawDek = new Uint8Array(await s.exportKey('raw', dek));
+  const wrappedDEK = new Uint8Array(
+    await s.encrypt({ name: 'AES-GCM', iv: wrapIv }, kek, rawDek));
+
+  const header = {
+    magic: ENVELOPE_MAGIC,
+    v: ENVELOPE_VERSION,
+    kdf: { name: 'pbkdf2', hash: 'SHA-256', iterations: PBKDF2_ITERATIONS },
+    cipher: 'AES-GCM-256',
+    salt: b64(salt),
+    iv: b64(wrapIv),          // IV used to wrap the DEK
+    wrappedDEK: b64(wrappedDEK),
+    cipherIv: b64(cipherIv),  // IV used for the bulk snapshot ciphertext
+    sha256OfPlaintext,
+    createdAt: new Date().toISOString(),
+  };
+  return packEnvelope(header, ciphertext);
+}
+
+/**
+ * Decrypt an envelope back to the original snapshot bytes.
+ * Throws clearly on a wrong passphrase (DEK unwrap fails), on tampering (GCM
+ * auth failure), or on a fingerprint mismatch.
+ * @param {Uint8Array|ArrayBuffer} envelopeBytes
+ * @param {string} passphrase
+ * @returns {Promise<Uint8Array>} plaintext snapshot
+ */
+export async function decryptSnapshot(envelopeBytes, passphrase) {
+  const s = requireSubtle();
+  if (!passphrase) throw new Error('A passphrase is required to decrypt a backup.');
+  const { header, ciphertext } = unpackEnvelope(asU8(envelopeBytes));
+
+  if (header.magic !== ENVELOPE_MAGIC) throw new Error('Not an edot backup envelope (bad magic).');
+  if (header.v !== ENVELOPE_VERSION) throw new Error(`Unsupported envelope version ${header.v}.`);
+  if (header.kdf && header.kdf.name !== 'pbkdf2') {
+    // TIER2-HOOK: a 'pbkdf2+hkdf' (auth-gated) or 'argon2id' envelope lands here.
+    throw new Error(`This backup uses an unsupported KDF (${header.kdf.name}); a newer client is required.`);
+  }
+
+  const salt = unb64(header.salt);
+  const kek = await deriveKek(passphrase, salt, header.kdf && header.kdf.iterations);
+
+  // Unwrap the DEK. A wrong passphrase yields a wrong KEK and the GCM tag check
+  // fails here — surfaced as a clear, non-leaky error.
+  let rawDek;
+  try {
+    rawDek = new Uint8Array(await s.decrypt(
+      { name: 'AES-GCM', iv: unb64(header.iv) }, kek, unb64(header.wrappedDEK)));
+  } catch {
+    throw new Error('Wrong passphrase, or the backup header was tampered with.');
+  }
+  const dek = await s.importKey('raw', rawDek, { name: 'AES-GCM' }, false, ['decrypt']);
+
+  let plain;
+  try {
+    plain = new Uint8Array(await s.decrypt(
+      { name: 'AES-GCM', iv: unb64(header.cipherIv) }, dek, ciphertext));
+  } catch {
+    throw new Error('Backup is corrupt or was tampered with (authentication failed).');
+  }
+
+  // Verify the recorded OPENDOC fingerprint — defence in depth beyond the tag.
+  if (header.sha256OfPlaintext) {
+    const got = await sha256Hex(plain);
+    if (got !== header.sha256OfPlaintext) {
+      throw new Error('Restored bytes do not match the recorded SHA-256 fingerprint.');
+    }
+  }
+  return plain;
+}
+
+/** Parse just the header of an envelope (no passphrase needed) — for listings. */
+export function readEnvelopeHeader(envelopeBytes) {
+  return unpackEnvelope(asU8(envelopeBytes)).header;
+}
+
+/** SHA-256 of bytes as a lowercase hex string (the OPENDOC fingerprint form). */
+export async function sha256Hex(bytes) {
+  const buf = await requireSubtle().digest('SHA-256', asU8(bytes));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ---- KEK derivation (the Tier-1 vs Tier-2 seam) -----------------------------
+
+/**
+ * Derive the AES-GCM KEK from a passphrase + salt via PBKDF2.
+ *
+ * TIER2-HOOK: this is the *only* place the key-derivation differs by tier. To
+ * gate decryption on an OIDC login (Tier 2), fetch S_user from the auth-gated
+ * key service (see magpie/edot/auth/) and replace the returned key with:
+ *     HKDF( concat( pbkdf2Bits, S_user ) )  ->  importKey AES-GCM
+ * The passphrase still never leaves the device; the service only releases
+ * S_user after verifying the OIDC id_token. Nothing else in this file changes.
+ */
+async function deriveKek(passphrase, salt, iterations = PBKDF2_ITERATIONS) {
+  const s = requireSubtle();
+  const baseKey = await s.importKey(
+    'raw', new TextEncoder().encode(passphrase), { name: 'PBKDF2' }, false, ['deriveKey']);
+  return s.deriveKey(
+    { name: 'PBKDF2', salt: asU8(salt), iterations, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+// ---- envelope framing -------------------------------------------------------
+// Layout: [8-byte magic][4-byte big-endian header length][JSON header][ciphertext]
+
+function packEnvelope(header, ciphertext) {
+  const headerJson = new TextEncoder().encode(JSON.stringify(header));
+  const out = new Uint8Array(8 + 4 + headerJson.length + ciphertext.length);
+  out.set(new TextEncoder().encode(ENVELOPE_MAGIC), 0);
+  new DataView(out.buffer).setUint32(8, headerJson.length, false);
+  out.set(headerJson, 12);
+  out.set(ciphertext, 12 + headerJson.length);
+  return out;
+}
+
+function unpackEnvelope(bytes) {
+  if (bytes.length < 12) throw new Error('Truncated backup envelope.');
+  const magic = new TextDecoder().decode(bytes.subarray(0, 8));
+  if (magic !== ENVELOPE_MAGIC) throw new Error('Not an edot backup envelope (bad magic).');
+  const headerLen = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(8, false);
+  const headerEnd = 12 + headerLen;
+  if (headerEnd > bytes.length) throw new Error('Corrupt backup envelope (bad header length).');
+  let header;
+  try { header = JSON.parse(new TextDecoder().decode(bytes.subarray(12, headerEnd))); }
+  catch { throw new Error('Corrupt backup envelope (unparseable header).'); }
+  return { header, ciphertext: bytes.subarray(headerEnd) };
+}
+
+// ---- small byte / base64 helpers (unicode-safe, chunked for big blobs) ------
+
+export function asU8(x) {
+  if (x instanceof Uint8Array) return x;
+  if (x instanceof ArrayBuffer) return new Uint8Array(x);
+  if (ArrayBuffer.isView(x)) return new Uint8Array(x.buffer, x.byteOffset, x.byteLength);
+  throw new Error('Expected bytes (Uint8Array/ArrayBuffer).');
+}
+
+function randomBytes(n) { return globalThis.crypto.getRandomValues(new Uint8Array(n)); }
+
+export function b64(bytes) {
+  const u8 = asU8(bytes);
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < u8.length; i += chunk) bin += String.fromCharCode.apply(null, u8.subarray(i, i + chunk));
+  return btoa(bin);
+}
+
+export function unb64(str) {
+  const bin = atob(String(str).replace(/\s/g, ''));
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/magpie/edot/backup/js/snapshot.js
+++ b/magpie/edot/backup/js/snapshot.js
@@ -1,0 +1,253 @@
+// snapshot.js — collect the suite's IndexedDB databases into one serialisable
+// blob, and restore them back. The blob is plaintext here; crypto.js encrypts
+// it into an envelope before it ever leaves the device.
+//
+// IndexedDB has no native "dump the whole database" call, so we walk it: open
+// each database, enumerate its object stores, read every record (with its key
+// when the store has no keyPath), and pack it all — plus a manifest — into one
+// JSON document. Restore replays it: open/upgrade each database to hold the
+// listed stores, clear them, and put the records back.
+//
+// Patterns mirror data-engine.js (promise-wrapped IDB open/get/put). Binary
+// values (e.g. the edot-data SQLite Uint8Array blob) are tagged and base64'd so
+// they survive JSON; everything else is round-tripped as-is via structured data.
+//
+// The DB/store list is *configurable* (DEFAULT_DATABASES) so new edot apps can
+// opt in without editing this file.
+
+import { sha256Hex, b64, unb64, asU8 } from './crypto.js';
+
+// Sane defaults: every IndexedDB database the edot suite is known to use, with
+// the object stores inside each. Discovered from the codebase (June 2026):
+//   edot-data → kv (the SQLite blob), edot-calendar → calendars/events,
+//   edot-maps → places, plus the editor's library/find/grid/sheet/query stores.
+// `stores: '*'` means "enumerate whatever stores the DB actually has".
+export const DEFAULT_DATABASES = [
+  { name: 'edot-data', stores: '*' },       // SQLite blob store ('kv')
+  { name: 'edot-calendar', stores: '*' },   // calendars + events
+  { name: 'edot-maps', stores: '*' },       // saved map places
+  { name: 'edot-find', stores: '*' },
+  { name: 'edot-grid', stores: '*' },
+  { name: 'edot-sheet', stores: '*' },
+  { name: 'edot-query', stores: '*' },
+  // Intentionally NOT included by default: 'edot-auth' / 'edot-login' hold OIDC
+  // tokens/session secrets — backing those up is a separate, careful decision.
+];
+
+const SNAPSHOT_VERSION = 1;
+const BINARY_TAG = '__edot_b64__';   // marker object for byte values inside JSON
+
+/**
+ * Build one serialisable snapshot blob across the chosen databases.
+ * @param {{databases?: Array, indexedDB?: IDBFactory}} [opts]
+ * @returns {Promise<{bytes: Uint8Array, manifest: object}>}
+ */
+export async function createSnapshot(opts = {}) {
+  const idb = opts.indexedDB || globalThis.indexedDB;
+  const wanted = opts.databases || DEFAULT_DATABASES;
+
+  const dbDump = {};
+  const manifestDbs = [];
+  for (const spec of wanted) {
+    const present = await dbExists(idb, spec.name);
+    if (!present) continue;                 // graceful: skip DBs not on this device
+    const db = await openExisting(idb, spec.name);
+    try {
+      const storeNames = resolveStores(db, spec.stores);
+      const stores = {};
+      const manifestStores = [];
+      for (const sn of storeNames) {
+        const records = await readStore(db, sn);
+        stores[sn] = { keyPath: storeKeyPath(db, sn), records };
+        manifestStores.push({ store: sn, count: records.length });
+      }
+      dbDump[spec.name] = { version: db.version, stores };
+      manifestDbs.push({ db: spec.name, version: db.version, stores: manifestStores });
+    } finally { db.close(); }
+  }
+
+  const payload = { v: SNAPSHOT_VERSION, databases: dbDump };
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  const manifest = {
+    v: SNAPSHOT_VERSION,
+    createdAt: new Date().toISOString(),
+    databases: manifestDbs,
+    totalRecords: manifestDbs.reduce((n, d) => n + d.stores.reduce((m, s) => m + s.count, 0), 0),
+    sha256: await sha256Hex(bytes),
+  };
+  return { bytes, manifest };
+}
+
+/** Inspect a snapshot blob's manifest without restoring it. */
+export async function readSnapshotManifest(bytes) {
+  const payload = JSON.parse(new TextDecoder().decode(asU8(bytes)));
+  const databases = Object.entries(payload.databases || {}).map(([db, d]) => ({
+    db,
+    version: d.version,
+    stores: Object.entries(d.stores).map(([store, s]) => ({ store, count: s.records.length })),
+  }));
+  return {
+    v: payload.v,
+    databases,
+    totalRecords: databases.reduce((n, d) => n + d.stores.reduce((m, s) => m + s.count, 0), 0),
+    sha256: await sha256Hex(asU8(bytes)),
+  };
+}
+
+/**
+ * Restore a snapshot blob back into IndexedDB. Each listed store is created if
+ * missing, cleared, then re-populated. Returns the manifest of what was written.
+ * @param {Uint8Array|ArrayBuffer} bytes
+ * @param {{indexedDB?: IDBFactory}} [opts]
+ */
+export async function restoreSnapshot(bytes, opts = {}) {
+  const idb = opts.indexedDB || globalThis.indexedDB;
+  const payload = JSON.parse(new TextDecoder().decode(asU8(bytes)));
+  if (!payload || !payload.databases) throw new Error('Not a valid edot snapshot.');
+
+  const restored = [];
+  for (const [dbName, dump] of Object.entries(payload.databases)) {
+    const storeNames = Object.keys(dump.stores);
+    // Bump the version if we must add stores the current DB lacks. Opening with
+    // a version >= existing triggers onupgradeneeded where stores are created.
+    const targetVersion = await neededVersion(idb, dbName, dump.version, storeNames);
+    const db = await openForRestore(idb, dbName, targetVersion, dump.stores);
+    try {
+      const wroteStores = [];
+      for (const [sn, sdump] of Object.entries(dump.stores)) {
+        const n = await writeStore(db, sn, sdump.records);
+        wroteStores.push({ store: sn, count: n });
+      }
+      restored.push({ db: dbName, version: db.version, stores: wroteStores });
+    } finally { db.close(); }
+  }
+  return { databases: restored, totalRecords: restored.reduce((n, d) => n + d.stores.reduce((m, s) => m + s.count, 0), 0) };
+}
+
+// ---- IndexedDB plumbing (promise-wrapped, mirrors data-engine.js) -----------
+
+function dbExists(idb, name) {
+  // databases() is widely supported; fall back to "open and check version".
+  if (typeof idb.databases === 'function') {
+    return idb.databases().then((list) => list.some((d) => d.name === name)).catch(() => true);
+  }
+  return Promise.resolve(true);
+}
+
+function openExisting(idb, name) {
+  return new Promise((resolve, reject) => {
+    const r = idb.open(name);                     // no version: opens current
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+    r.onblocked = () => reject(new Error(`IndexedDB "${name}" is blocked by another tab.`));
+  });
+}
+
+function resolveStores(db, spec) {
+  const all = Array.from(db.objectStoreNames);
+  if (!spec || spec === '*') return all;
+  return (Array.isArray(spec) ? spec : [spec]).filter((s) => all.includes(s));
+}
+
+function storeKeyPath(db, sn) {
+  const tx = db.transaction(sn, 'readonly');
+  const kp = tx.objectStore(sn).keyPath;
+  return kp == null ? null : kp;   // null => out-of-line keys; we store them explicitly
+}
+
+function readStore(db, sn) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(sn, 'readonly');
+    const store = tx.objectStore(sn);
+    const out = [];
+    const inlineKey = store.keyPath != null;     // inline keys live inside the value
+    const cur = store.openCursor();
+    cur.onsuccess = () => {
+      const c = cur.result;
+      if (!c) return;            // done; resolution happens in tx.oncomplete
+      out.push(inlineKey ? { value: encodeValue(c.value) }
+                         : { key: encodeValue(c.key), value: encodeValue(c.value) });
+      c.continue();
+    };
+    cur.onerror = () => reject(cur.error);
+    tx.oncomplete = () => resolve(out);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function writeStore(db, sn, records) {
+  return new Promise((resolve, reject) => {
+    if (!db.objectStoreNames.contains(sn)) {
+      return reject(new Error(`Store "${sn}" missing after upgrade — cannot restore.`));
+    }
+    const tx = db.transaction(sn, 'readwrite');
+    const store = tx.objectStore(sn);
+    store.clear();
+    for (const rec of records) {
+      if ('key' in rec) store.put(decodeValue(rec.value), decodeValue(rec.key));
+      else store.put(decodeValue(rec.value));    // inline key inside the value
+    }
+    tx.oncomplete = () => resolve(records.length);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error || new Error(`Restore of "${sn}" aborted.`));
+  });
+}
+
+// Decide the version to open with for restore: at least the snapshot's, bumped
+// by one if the live DB is missing any store we need to write.
+async function neededVersion(idb, name, snapVersion, storeNames) {
+  let liveVersion = 0; let liveStores = [];
+  try {
+    const db = await openExisting(idb, name);
+    liveVersion = db.version; liveStores = Array.from(db.objectStoreNames); db.close();
+  } catch { /* DB doesn't exist yet */ }
+  const missing = storeNames.some((s) => !liveStores.includes(s));
+  let v = Math.max(liveVersion, snapVersion || 1, 1);
+  if (missing && v <= liveVersion) v = liveVersion + 1;   // force an upgrade tx
+  return v;
+}
+
+function openForRestore(idb, name, version, storesDump) {
+  return new Promise((resolve, reject) => {
+    const r = idb.open(name, version);
+    r.onupgradeneeded = () => {
+      const db = r.result;
+      for (const [sn, sdump] of Object.entries(storesDump)) {
+        if (!db.objectStoreNames.contains(sn)) {
+          // Recreate with the original keyPath so inline keys keep working.
+          db.createObjectStore(sn, sdump.keyPath != null ? { keyPath: sdump.keyPath } : undefined);
+        }
+      }
+    };
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+    r.onblocked = () => reject(new Error(`IndexedDB "${name}" is blocked by another tab.`));
+  });
+}
+
+// ---- value (de)serialisation ------------------------------------------------
+// JSON can't carry typed arrays. Tag byte values so the SQLite Uint8Array blob
+// and friends survive the round-trip. Strings/numbers/plain objects pass through.
+
+function encodeValue(v) {
+  if (v instanceof Uint8Array) return { [BINARY_TAG]: b64(v) };
+  if (v instanceof ArrayBuffer) return { [BINARY_TAG]: b64(new Uint8Array(v)) };
+  if (Array.isArray(v)) return v.map(encodeValue);
+  if (v && typeof v === 'object' && !(v instanceof Date)) {
+    const out = {};
+    for (const k of Object.keys(v)) out[k] = encodeValue(v[k]);
+    return out;
+  }
+  return v;
+}
+
+function decodeValue(v) {
+  if (v && typeof v === 'object') {
+    if (typeof v[BINARY_TAG] === 'string') return unb64(v[BINARY_TAG]);
+    if (Array.isArray(v)) return v.map(decodeValue);
+    const out = {};
+    for (const k of Object.keys(v)) out[k] = decodeValue(v[k]);
+    return out;
+  }
+  return v;
+}

--- a/magpie/edot/backup/js/stores/github.js
+++ b/magpie/edot/backup/js/stores/github.js
@@ -1,0 +1,109 @@
+// stores/github.js — store an encrypted backup as a file in a GitHub repo.
+//
+// Mirrors magpie/edot/js/git-remote.js: api.github.com is CORS-enabled, so the
+// Contents API works directly from the browser with a token. We store opaque
+// ciphertext as a base64-encoded file under `edot-backups/<id>.enc`, GET it
+// back (decoding base64), list the directory, and DELETE it.
+//
+// `fetchImpl` is injectable for testing — every network call goes through it.
+//
+// Common adapter interface (shared by all stores/*.js):
+//   put(id, bytes, cfg)            -> {}
+//   get(id, cfg)                   -> Uint8Array
+//   list(cfg)                      -> [{ id, size, modified }]
+//   remove(id, cfg)               -> {}
+// cfg shape for GitHub: { repo: 'owner/name', token, dir?, branch?, fetchImpl? }
+
+const API = 'https://api.github.com';
+const DEFAULT_DIR = 'edot-backups';
+const EXT = '.enc';
+
+export const id = 'github';
+export const label = 'GitHub repo';
+
+function client(cfg) {
+  const f = cfg.fetchImpl || ((...a) => fetch(...a));
+  const [owner, repo] = String(cfg.repo || '').split('/');
+  if (!owner || !repo) throw new Error('GitHub: cfg.repo must be "owner/name".');
+  const dir = (cfg.dir || DEFAULT_DIR).replace(/^\/+|\/+$/g, '');
+
+  const req = async (method, path, body) => {
+    const res = await f(`${API}${path}`, {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(cfg.token ? { Authorization: `Bearer ${cfg.token}` } : {}),
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    let json; try { json = text ? JSON.parse(text) : {}; } catch { json = { message: text }; }
+    if (!res.ok) { const e = new Error(json.message || `GitHub ${res.status}`); e.status = res.status; throw e; }
+    return json;
+  };
+  const enc = (p) => p.split('/').map(encodeURIComponent).join('/');
+  const filePath = (bid) => `${dir}/${safeId(bid)}${EXT}`;
+  return { req, owner, repo, dir, enc, filePath, branch: cfg.branch };
+}
+
+export async function put(bid, bytes, cfg) {
+  const c = client(cfg);
+  const path = c.filePath(bid);
+  // Contents PUT needs the prior blob sha to overwrite; null if it's new.
+  let sha = null;
+  try { sha = (await c.req('GET', `/repos/${c.owner}/${c.repo}/contents/${c.enc(path)}`)).sha; }
+  catch (e) { if (e.status !== 404) throw e; }
+  return c.req('PUT', `/repos/${c.owner}/${c.repo}/contents/${c.enc(path)}`, {
+    message: `edot backup ${safeId(bid)}`,
+    content: bytesToB64(bytes),
+    ...(c.branch ? { branch: c.branch } : {}),
+    ...(sha ? { sha } : {}),
+  });
+}
+
+export async function get(bid, cfg) {
+  const c = client(cfg);
+  const q = c.branch ? `?ref=${encodeURIComponent(c.branch)}` : '';
+  const j = await c.req('GET', `/repos/${c.owner}/${c.repo}/contents/${c.enc(c.filePath(bid))}${q}`);
+  if (j.encoding !== 'base64') throw new Error('GitHub: unexpected file encoding.');
+  return b64ToBytes(j.content);
+}
+
+export async function list(cfg) {
+  const c = client(cfg);
+  const q = c.branch ? `?ref=${encodeURIComponent(c.branch)}` : '';
+  let items;
+  try { items = await c.req('GET', `/repos/${c.owner}/${c.repo}/contents/${c.enc(c.dir)}${q}`); }
+  catch (e) { if (e.status === 404) return []; throw e; }   // empty dir = no backups yet
+  return (Array.isArray(items) ? items : [])
+    .filter((it) => it.type === 'file' && it.name.endsWith(EXT))
+    .map((it) => ({ id: it.name.slice(0, -EXT.length), size: it.size, modified: null, sha: it.sha }));
+}
+
+export async function remove(bid, cfg) {
+  const c = client(cfg);
+  const path = c.filePath(bid);
+  const cur = await c.req('GET', `/repos/${c.owner}/${c.repo}/contents/${c.enc(path)}`);
+  return c.req('DELETE', `/repos/${c.owner}/${c.repo}/contents/${c.enc(path)}`, {
+    message: `edot backup remove ${safeId(bid)}`, sha: cur.sha,
+    ...(c.branch ? { branch: c.branch } : {}),
+  });
+}
+
+// ---- helpers ----
+function safeId(bid) { return String(bid).replace(/[^A-Za-z0-9._-]/g, '_'); }
+
+export function bytesToB64(bytes) {
+  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let bin = ''; const chunk = 0x8000;
+  for (let i = 0; i < u8.length; i += chunk) bin += String.fromCharCode.apply(null, u8.subarray(i, i + chunk));
+  return btoa(bin);
+}
+export function b64ToBytes(b64) {
+  const bin = atob(String(b64).replace(/\s/g, ''));
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/magpie/edot/backup/js/stores/index.js
+++ b/magpie/edot/backup/js/stores/index.js
@@ -1,0 +1,24 @@
+// stores/index.js — registry mapping a backend id to its adapter module.
+//
+// Every adapter exposes the same opaque-blob interface:
+//   put(id, bytes, cfg) · get(id, cfg) -> Uint8Array · list(cfg) -> [{id,size,modified}] · remove(id, cfg)
+// plus `id` and `label` strings. cfg is backend-specific (see backup-config.js).
+
+import * as github from './github.js';
+import * as s3 from './s3.js';
+import * as webdav from './webdav.js';
+import * as solid from './solid.js';
+
+export const STORES = { github, s3, webdav, solid };
+
+/** Resolve an adapter by id ('github' | 's3' | 'webdav' | 'solid'). */
+export function getStore(backendId) {
+  const a = STORES[backendId];
+  if (!a) throw new Error(`Unknown backup backend: ${backendId}`);
+  return a;
+}
+
+/** [{ id, label }] for populating a backend picker. */
+export function listStores() {
+  return Object.values(STORES).map((a) => ({ id: a.id, label: a.label }));
+}

--- a/magpie/edot/backup/js/stores/s3.js
+++ b/magpie/edot/backup/js/stores/s3.js
@@ -1,0 +1,100 @@
+// stores/s3.js — store an encrypted backup in S3-compatible object storage.
+//
+// Browser reality: raw AWS SigV4 from a page is awkward (you'd ship the secret
+// key to the browser, and the bucket needs permissive CORS). So the PRIMARY,
+// CORS-friendly path here is **presigned URLs**: the user (or a tiny backend)
+// presigns short-lived PUT/GET/DELETE URLs and the browser just follows them.
+// The blob is opaque ciphertext, so a plain HTTP PUT/GET is all we need.
+//
+// Two cfg styles are supported:
+//   A) Presign callback (recommended):
+//        cfg.presign(method, id) -> Promise<url>   // you implement signing server-side
+//      and cfg.listUrl / cfg.list() for listing (S3 ListObjectsV2 is XML).
+//   B) Direct per-id URLs for quick tests / fully-public-write buckets:
+//        cfg.urls = { put(id), get(id), del(id), list }  (each -> url string)
+//
+// SigV4 is intentionally NOT implemented in-browser (secret exposure). The
+// `presign` seam keeps signing server-side and testable. Documented in README.
+//
+// cfg: { presign?, urls?, listUrl?, prefix?, region?, bucket?, fetchImpl? }
+
+export const id = 's3';
+export const label = 'S3-compatible (presigned)';
+
+const EXT = '.enc';
+
+function f(cfg) { return cfg.fetchImpl || ((...a) => fetch(...a)); }
+function key(cfg, bid) { return `${(cfg.prefix || 'edot-backups').replace(/\/+$/, '')}/${safeId(bid)}${EXT}`; }
+
+// Resolve a URL for one operation from whichever cfg style is provided.
+async function urlFor(cfg, method, bid) {
+  if (typeof cfg.presign === 'function') return cfg.presign(method, key(cfg, bid));
+  if (cfg.urls) {
+    if (method === 'PUT' && cfg.urls.put) return typeof cfg.urls.put === 'function' ? cfg.urls.put(bid) : cfg.urls.put;
+    if (method === 'GET' && cfg.urls.get) return typeof cfg.urls.get === 'function' ? cfg.urls.get(bid) : cfg.urls.get;
+    if (method === 'DELETE' && cfg.urls.del) return typeof cfg.urls.del === 'function' ? cfg.urls.del(bid) : cfg.urls.del;
+  }
+  throw new Error(`S3: no way to obtain a presigned ${method} URL (set cfg.presign or cfg.urls).`);
+}
+
+export async function put(bid, bytes, cfg) {
+  const url = await urlFor(cfg, 'PUT', bid);
+  const res = await f(cfg)(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: toBody(bytes),
+  });
+  if (!res.ok) throw new Error(`S3 PUT failed (${res.status}).`);
+  return {};
+}
+
+export async function get(bid, cfg) {
+  const url = await urlFor(cfg, 'GET', bid);
+  const res = await f(cfg)(url, { method: 'GET' });
+  if (!res.ok) throw new Error(`S3 GET failed (${res.status}).`);
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function remove(bid, cfg) {
+  const url = await urlFor(cfg, 'DELETE', bid);
+  const res = await f(cfg)(url, { method: 'DELETE' });
+  if (!res.ok && res.status !== 404) throw new Error(`S3 DELETE failed (${res.status}).`);
+  return {};
+}
+
+// Listing: S3 ListObjectsV2 returns XML (?list-type=2&prefix=...). The user
+// supplies a presigned/anonymous list URL; we parse <Contents><Key><Size>.
+export async function list(cfg) {
+  const url = cfg.listUrl
+    || (typeof cfg.presign === 'function' ? await cfg.presign('LIST', (cfg.prefix || 'edot-backups')) : null)
+    || (cfg.urls && (typeof cfg.urls.list === 'function' ? cfg.urls.list() : cfg.urls.list));
+  if (!url) throw new Error('S3: set cfg.listUrl (or cfg.presign / cfg.urls.list) to list backups.');
+  const res = await f(cfg)(url, { method: 'GET' });
+  if (!res.ok) throw new Error(`S3 LIST failed (${res.status}).`);
+  return parseListXml(await res.text(), cfg.prefix || 'edot-backups');
+}
+
+// Minimal, dependency-free parse of ListObjectsV2 XML <Contents> entries.
+export function parseListXml(xml, prefix) {
+  const out = [];
+  const re = /<Contents>([\s\S]*?)<\/Contents>/g;
+  let m;
+  while ((m = re.exec(xml))) {
+    const block = m[1];
+    const k = tag(block, 'Key');
+    if (!k || !k.endsWith(EXT)) continue;
+    const base = k.replace(new RegExp(`^${escapeRe(prefix.replace(/\/+$/, ''))}/`), '').slice(0, -EXT.length);
+    out.push({
+      id: base,
+      size: Number(tag(block, 'Size')) || 0,
+      modified: tag(block, 'LastModified') || null,
+    });
+  }
+  return out;
+}
+
+// ---- helpers ----
+function tag(s, name) { const m = new RegExp(`<${name}>([\\s\\S]*?)<\\/${name}>`).exec(s); return m ? m[1] : ''; }
+function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+function safeId(bid) { return String(bid).replace(/[^A-Za-z0-9._-]/g, '_'); }
+function toBody(bytes) { return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes); }

--- a/magpie/edot/backup/js/stores/solid.js
+++ b/magpie/edot/backup/js/stores/solid.js
@@ -1,0 +1,109 @@
+// stores/solid.js — store an encrypted backup in a Solid Pod (LDP container).
+//
+// Solid resources are plain HTTP resources inside an LDP container:
+//   PUT    <container><id>.enc      create/replace the resource
+//   GET    <container><id>.enc      read it
+//   DELETE <container><id>.enc      remove it
+//   GET    <container>  (Accept: text/turtle)   list contained resources via
+//          ldp:contains triples in the container description.
+//
+// AUTH — TIER-1 SHIM vs PRODUCTION:
+//   Here: a bearer access token from cfg (Authorization: Bearer <token>). That's
+//   enough to talk to a Pod for which you already hold a token.
+//   Production Solid is **Solid-OIDC + DPoP**: you authenticate with the Pod's
+//   OIDC issuer and present *DPoP-bound* access tokens (a per-request proof JWT
+//   signed by a key bound to the token). Bearer-only tokens are rejected by
+//   DPoP-enforcing servers. Wiring that up belongs with magpie/edot/auth/
+//   (OidcClient/AuthSession) — see SOLID-OIDC TODO below. This is the storage
+//   adapter that will later consume those tokens.
+//
+// cfg: { container, token?, dpopHeaders?, fetchImpl? }
+//   container : Pod container URL ending in '/', e.g. https://you.pod/edot-backups/
+//   token     : bearer access token (Tier-1 shim)
+//   dpopHeaders: optional async (method, url) -> { Authorization, DPoP } so a
+//                future Solid-OIDC/DPoP layer can inject proofs without forking
+//                this file. (SOLID-OIDC TODO seam.)
+
+export const id = 'solid';
+export const label = 'Solid Pod';
+
+const EXT = '.enc';
+
+function ctx(cfg) {
+  if (!cfg.container) throw new Error('Solid: cfg.container (Pod container URL) is required.');
+  const container = cfg.container.replace(/\/+$/, '') + '/';
+  const f = cfg.fetchImpl || ((...a) => fetch(...a));
+  return { container, f };
+}
+
+// Resolve auth headers. Prefer a DPoP provider (production seam); fall back to
+// the Tier-1 bearer token. SOLID-OIDC TODO: dpopHeaders is where AuthSession
+// hands us a DPoP proof + bound access token per request.
+async function authHeaders(cfg, method, url) {
+  if (typeof cfg.dpopHeaders === 'function') return (await cfg.dpopHeaders(method, url)) || {};
+  return cfg.token ? { Authorization: `Bearer ${cfg.token}` } : {};
+}
+
+const resUrl = (container, bid) => container + encodeURIComponent(safeId(bid)) + EXT;
+
+export async function put(bid, bytes, cfg) {
+  const { container, f } = ctx(cfg);
+  const url = resUrl(container, bid);
+  const res = await f(url, {
+    method: 'PUT',
+    headers: { ...(await authHeaders(cfg, 'PUT', url)), 'Content-Type': 'application/octet-stream' },
+    body: toBody(bytes),
+  });
+  if (!res.ok && res.status !== 201 && res.status !== 204) throw new Error(`Solid PUT failed (${res.status}).`);
+  return {};
+}
+
+export async function get(bid, cfg) {
+  const { container, f } = ctx(cfg);
+  const url = resUrl(container, bid);
+  const res = await f(url, { method: 'GET', headers: await authHeaders(cfg, 'GET', url) });
+  if (!res.ok) throw new Error(`Solid GET failed (${res.status}).`);
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function remove(bid, cfg) {
+  const { container, f } = ctx(cfg);
+  const url = resUrl(container, bid);
+  const res = await f(url, { method: 'DELETE', headers: await authHeaders(cfg, 'DELETE', url) });
+  if (!res.ok && res.status !== 204 && res.status !== 404) throw new Error(`Solid DELETE failed (${res.status}).`);
+  return {};
+}
+
+// List the container: GET it as Turtle and read ldp:contains. We keep parsing
+// to a narrow regex over contained-resource references (the relative <name.enc>
+// URIs) — no RDF library, no CDN.
+export async function list(cfg) {
+  const { container, f } = ctx(cfg);
+  const res = await f(container, {
+    method: 'GET',
+    headers: { ...(await authHeaders(cfg, 'GET', container)), Accept: 'text/turtle' },
+  });
+  if (!res.ok) throw new Error(`Solid container GET failed (${res.status}).`);
+  return parseContainer(await res.text(), container);
+}
+
+// Extract backup ids from a container's Turtle: any contained reference ending
+// in .enc, whether written as <name.enc>, <https://pod/.../name.enc>, or in a
+// ldp:contains list. Returns {id,size,modified}; Turtle listings carry no size.
+export function parseContainer(turtle, container) {
+  const ids = new Set();
+  const re = /<([^>]*?\.enc)>/g;       // any IRI token ending in .enc
+  let m;
+  while ((m = re.exec(turtle))) {
+    let ref = m[1];
+    // Normalise absolute IRIs down to the container-relative basename.
+    if (ref.startsWith(container)) ref = ref.slice(container.length);
+    const name = ref.replace(/^\.?\//, '').split('/').pop();
+    if (name && name.endsWith(EXT)) ids.add(decodeURIComponent(name.slice(0, -EXT.length)));
+  }
+  return [...ids].map((bid) => ({ id: bid, size: null, modified: null }));
+}
+
+// ---- helpers ----
+function safeId(bid) { return String(bid).replace(/[^A-Za-z0-9._-]/g, '_'); }
+function toBody(bytes) { return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes); }

--- a/magpie/edot/backup/js/stores/webdav.js
+++ b/magpie/edot/backup/js/stores/webdav.js
@@ -1,0 +1,98 @@
+// stores/webdav.js — store an encrypted backup on a WebDAV server.
+//
+// Plain HTTP verbs against a WebDAV collection (base URL):
+//   PUT      <base>/<id>.enc        upload ciphertext (raw bytes)
+//   GET      <base>/<id>.enc        download ciphertext
+//   PROPFIND <base>/  Depth: 1      list the collection (XML multistatus)
+//   DELETE   <base>/<id>.enc        remove
+// Basic auth from cfg (user/pass). `fetchImpl` injectable for testing.
+//
+// CORS: most WebDAV servers (Nextcloud, Apache mod_dav) need CORS headers added
+// to allow a browser origin, and PROPFIND must be in Access-Control-Allow-Methods.
+// Documented in README; the protocol itself is fully implemented here.
+//
+// cfg: { baseUrl, user?, password?, fetchImpl? }
+
+export const id = 'webdav';
+export const label = 'WebDAV';
+
+const EXT = '.enc';
+
+function ctx(cfg) {
+  if (!cfg.baseUrl) throw new Error('WebDAV: cfg.baseUrl is required.');
+  const base = cfg.baseUrl.replace(/\/+$/, '') + '/';
+  const f = cfg.fetchImpl || ((...a) => fetch(...a));
+  const headers = {};
+  if (cfg.user != null) headers.Authorization = 'Basic ' + b64utf8(`${cfg.user}:${cfg.password || ''}`);
+  return { base, f, headers };
+}
+
+const fileUrl = (base, bid) => base + encodeURIComponent(safeId(bid)) + EXT;
+
+export async function put(bid, bytes, cfg) {
+  const { base, f, headers } = ctx(cfg);
+  const res = await f(fileUrl(base, bid), {
+    method: 'PUT',
+    headers: { ...headers, 'Content-Type': 'application/octet-stream' },
+    body: toBody(bytes),
+  });
+  if (!res.ok && res.status !== 201 && res.status !== 204) throw new Error(`WebDAV PUT failed (${res.status}).`);
+  return {};
+}
+
+export async function get(bid, cfg) {
+  const { base, f, headers } = ctx(cfg);
+  const res = await f(fileUrl(base, bid), { method: 'GET', headers });
+  if (!res.ok) throw new Error(`WebDAV GET failed (${res.status}).`);
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function remove(bid, cfg) {
+  const { base, f, headers } = ctx(cfg);
+  const res = await f(fileUrl(base, bid), { method: 'DELETE', headers });
+  if (!res.ok && res.status !== 204 && res.status !== 404) throw new Error(`WebDAV DELETE failed (${res.status}).`);
+  return {};
+}
+
+export async function list(cfg) {
+  const { base, f, headers } = ctx(cfg);
+  const res = await f(base, {
+    method: 'PROPFIND',
+    headers: { ...headers, Depth: '1', 'Content-Type': 'application/xml' },
+    // Ask only for the props we use — keeps responses small and predictable.
+    body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop>'
+        + '<d:getcontentlength/><d:getlastmodified/></d:prop></d:propfind>',
+  });
+  if (!res.ok && res.status !== 207) throw new Error(`WebDAV PROPFIND failed (${res.status}).`);
+  return parsePropfind(await res.text());
+}
+
+// Parse a WebDAV multistatus body into {id,size,modified}. Namespace-agnostic
+// (matches d:response / D:response / response) so it works across servers.
+export function parsePropfind(xml) {
+  const out = [];
+  const re = /<(?:\w+:)?response[\s>]([\s\S]*?)<\/(?:\w+:)?response>/g;
+  let m;
+  while ((m = re.exec(xml))) {
+    const block = m[1];
+    const href = decodeURIComponent(tag(block, 'href') || '');
+    const name = href.replace(/\/+$/, '').split('/').pop();
+    if (!name || !name.endsWith(EXT)) continue;     // skip the collection itself + non-backups
+    out.push({
+      id: name.slice(0, -EXT.length),
+      size: Number(tag(block, 'getcontentlength')) || 0,
+      modified: tag(block, 'getlastmodified') || null,
+    });
+  }
+  return out;
+}
+
+// ---- helpers ----
+function tag(s, local) { const m = new RegExp(`<(?:\\w+:)?${local}[^>]*>([\\s\\S]*?)<\\/(?:\\w+:)?${local}>`).exec(s); return m ? m[1].trim() : ''; }
+function safeId(bid) { return String(bid).replace(/[^A-Za-z0-9._-]/g, '_'); }
+function toBody(bytes) { return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes); }
+function b64utf8(str) {
+  const u8 = new TextEncoder().encode(str);
+  let bin = ''; for (let i = 0; i < u8.length; i++) bin += String.fromCharCode(u8[i]);
+  return btoa(bin);
+}

--- a/magpie/edot/backup/test-backup.mjs
+++ b/magpie/edot/backup/test-backup.mjs
@@ -1,0 +1,300 @@
+// test-backup.mjs — headless tests for the Tier-1 encrypted backup feature.
+// Same style as data/test-data.mjs: tiny static server at the repo root, real
+// Chromium, ✅/❌, non-zero exit on failure. All network goes through a MOCKED
+// fetch — no real credentials, no real endpoints are contacted.
+import { chromium } from 'playwright-core';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer(async (req, res) => {
+  try {
+    const rel = decodeURIComponent(req.url.split('?')[0]).replace(/^\//, '') || 'index.html';
+    const buf = await readFile(path.join(ROOT, rel));
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(rel)] || 'application/octet-stream' });
+    res.end(buf);
+  } catch { res.writeHead(404); res.end(); }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const browser = await chromium.launch({ headless: true, executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome', args: ['--no-sandbox'] });
+let fail = 0; const ok = (n, c) => { console.log(`${c ? '✅' : '❌'} ${n}`); if (!c) fail++; };
+
+try {
+  const page = await browser.newPage();
+  const errs = []; page.on('pageerror', (e) => errs.push(String(e)));
+  await page.goto(`http://127.0.0.1:${port}/magpie/edot/backup/backup.html`);
+  await page.waitForFunction(() => !!window.__backup && !!window.__backup.component());
+  ok('page + __backup hook ready', true);
+
+  // Install a shared in-page mock fetch over an in-memory blob store. Each
+  // adapter speaks a different protocol; the mock answers all four.
+  await page.evaluate(() => {
+    const store = new Map();                 // path -> Uint8Array (ciphertext)
+    window.__calls = [];
+    const b64 = (u8) => { let s = ''; for (const b of u8) s += String.fromCharCode(b); return btoa(s); };
+    const unb64 = (s) => { const bin = atob(s); const o = new Uint8Array(bin.length); for (let i = 0; i < bin.length; i++) o[i] = bin.charCodeAt(i); return o; };
+    const json = (o, status = 200) => new Response(JSON.stringify(o), { status, headers: { 'content-type': 'application/json' } });
+    const bin = (u8, status = 200) => new Response((status === 204 || status === 304) ? null : u8, { status, headers: { 'content-type': 'application/octet-stream' } });
+
+    window.__mockFetch = async (url, opts = {}) => {
+      url = String(url); const m = (opts.method || 'GET').toUpperCase();
+      window.__calls.push({ method: m, url });
+      const body = opts.body;
+      const u = new URL(url, 'http://mock.local');
+
+      // --- GitHub Contents API ---
+      if (url.startsWith('https://api.github.com')) {
+        const cm = /\/contents\/(.+?)(\?|$)/.exec(url);
+        const cpath = cm ? decodeURIComponent(cm[1]) : '';
+        if (/\/contents\//.test(url) && m === 'PUT') {
+          const j = JSON.parse(body); store.set('gh:' + cpath, unb64(j.content));
+          return json({ content: { sha: 'sha-' + cpath } });
+        }
+        if (/\/contents\//.test(url) && m === 'GET') {
+          // Directory listing (the dir path itself) vs single file.
+          if (cpath.endsWith('edot-backups') || !cpath.endsWith('.enc')) {
+            const files = [...store.keys()].filter((k) => k.startsWith('gh:' + cpath + '/'))
+              .map((k) => ({ type: 'file', name: k.slice(('gh:' + cpath + '/').length), size: store.get(k).length, sha: 'sha' }));
+            if (files.length) return json(files);
+            // not a dir we know — maybe a missing file
+            return store.has('gh:' + cpath) ? json({ encoding: 'base64', content: b64(store.get('gh:' + cpath)), sha: 's' }) : json({ message: 'Not Found' }, 404);
+          }
+          if (!store.has('gh:' + cpath)) return json({ message: 'Not Found' }, 404);
+          return json({ encoding: 'base64', content: b64(store.get('gh:' + cpath)), sha: 's' });
+        }
+        if (/\/contents\//.test(url) && m === 'DELETE') { store.delete('gh:' + cpath); return json({}); }
+        return json({});
+      }
+
+      // --- S3 presigned-style: key carried in ?key=, op in ?op= ---
+      if (u.searchParams.has('s3key')) {
+        const k = 's3:' + u.searchParams.get('s3key');
+        if (m === 'PUT') { store.set(k, new Uint8Array(body)); return bin(new Uint8Array(0)); }
+        if (m === 'GET') return store.has(k) ? bin(store.get(k)) : bin(new Uint8Array(0), 404);
+        if (m === 'DELETE') { store.delete(k); return bin(new Uint8Array(0), 204); }
+      }
+      if (u.searchParams.get('op') === 'list-s3') {
+        const items = [...store.keys()].filter((k) => k.startsWith('s3:edot-backups/'))
+          .map((k) => `<Contents><Key>${k.slice(3)}</Key><Size>${store.get(k).length}</Size><LastModified>2026-06-23T00:00:00Z</LastModified></Contents>`).join('');
+        return new Response(`<?xml version="1.0"?><ListBucketResult>${items}</ListBucketResult>`, { status: 200 });
+      }
+
+      // --- WebDAV ---
+      if (u.pathname.startsWith('/dav/')) {
+        const k = 'dav:' + u.pathname;
+        if (m === 'PUT') { store.set(k, new Uint8Array(body)); return new Response('', { status: 201 }); }
+        if (m === 'GET') return store.has(k) ? bin(store.get(k)) : bin(new Uint8Array(0), 404);
+        if (m === 'DELETE') { store.delete(k); return new Response(null, { status: 204 }); }
+        if (m === 'PROPFIND') {
+          const resp = [...store.keys()].filter((k2) => k2.startsWith('dav:/dav/'))
+            .map((k2) => { const name = k2.slice('dav:'.length); return `<d:response><d:href>${name}</d:href><d:propstat><d:prop><d:getcontentlength>${store.get(k2).length}</d:getcontentlength><d:getlastmodified>Mon, 23 Jun 2026 00:00:00 GMT</d:getlastmodified></d:prop></d:propstat></d:response>`; }).join('');
+          return new Response(`<?xml version="1.0"?><d:multistatus xmlns:d="DAV:">${resp}</d:multistatus>`, { status: 207 });
+        }
+      }
+
+      // --- Solid Pod (LDP container) ---
+      if (u.pathname.startsWith('/pod/')) {
+        const isContainer = u.pathname.endsWith('/');
+        const k = 'solid:' + u.pathname;
+        if (m === 'PUT') { store.set(k, new Uint8Array(body)); return new Response('', { status: 201 }); }
+        if (m === 'GET' && !isContainer) return store.has(k) ? bin(store.get(k)) : bin(new Uint8Array(0), 404);
+        if (m === 'GET' && isContainer) {
+          const triples = [...store.keys()].filter((k2) => k2.startsWith('solid:' + u.pathname) && k2.endsWith('.enc'))
+            .map((k2) => `<${u.origin}${k2.slice('solid:'.length)}>`).map((iri) => `<> ldp:contains ${iri} .`).join('\n');
+          return new Response(`@prefix ldp: <http://www.w3.org/ns/ldp#> .\n${triples}`, { status: 200, headers: { 'content-type': 'text/turtle' } });
+        }
+        if (m === 'DELETE') { store.delete(k); return new Response(null, { status: 204 }); }
+      }
+
+      return new Response('unhandled ' + url, { status: 500 });
+    };
+  });
+
+  // ---- 1. Crypto round-trip / failure modes ----
+  const crypto = await page.evaluate(async () => {
+    const C = window.__backup.crypto;
+    const bytes = new TextEncoder().encode('the quick brown fox 🦊 — secret data');
+    const env = await C.encryptSnapshot(bytes, 'correct horse battery staple');
+    const back = await C.decryptSnapshot(env, 'correct horse battery staple');
+    const same = back.length === bytes.length && back.every((b, i) => b === bytes[i]);
+
+    const header = C.readEnvelopeHeader(env);
+    const sha = await C.sha256Hex(bytes);
+
+    let wrongPass = false;
+    try { await C.decryptSnapshot(env, 'wrong passphrase'); } catch { wrongPass = true; }
+
+    // Flip one ciphertext byte (well past the header) -> GCM auth must fail.
+    const tampered = env.slice();
+    tampered[tampered.length - 5] ^= 0x01;
+    let tamperFail = false;
+    try { await C.decryptSnapshot(tampered, 'correct horse battery staple'); } catch { tamperFail = true; }
+
+    return { same, wrongPass, tamperFail, shaMatch: header.sha256OfPlaintext === sha, iters: header.kdf.iterations, ver: header.v };
+  });
+  ok('crypto: encrypt→decrypt recovers exact bytes', crypto.same);
+  ok('crypto: wrong passphrase fails', crypto.wrongPass);
+  ok('crypto: flipped ciphertext byte fails (GCM)', crypto.tamperFail);
+  ok('crypto: recorded SHA-256 matches plaintext', crypto.shaMatch);
+  ok('crypto: PBKDF2 iterations >= 200k', crypto.iters >= 200000);
+  ok('crypto: envelope is versioned (v=1)', crypto.ver === 1);
+
+  // ---- 2. Snapshot: seed IndexedDB, snapshot, wipe, restore ----
+  const snap = await page.evaluate(async () => {
+    const S = window.__backup.snapshot;
+    // Seed a custom DB with an inline-key store + a binary value.
+    await new Promise((res, rej) => {
+      const r = indexedDB.open('edot-grid', 1);
+      r.onupgradeneeded = () => { if (!r.result.objectStoreNames.contains('cells')) r.result.createObjectStore('cells', { keyPath: 'id' }); };
+      r.onsuccess = () => { const db = r.result; const tx = db.transaction('cells', 'readwrite');
+        tx.objectStore('cells').put({ id: 'a1', v: 42, blob: new Uint8Array([1, 2, 3, 4]) });
+        tx.objectStore('cells').put({ id: 'b2', v: 'hi' });
+        tx.oncomplete = () => { db.close(); res(); }; tx.onerror = () => rej(tx.error); };
+      r.onerror = () => rej(r.error);
+    });
+
+    const databases = [{ name: 'edot-grid', stores: '*' }];
+    const { bytes, manifest } = await S.createSnapshot({ databases });
+    const grid = manifest.databases.find((d) => d.db === 'edot-grid');
+
+    // Wipe the store.
+    await new Promise((res, rej) => { const r = indexedDB.open('edot-grid', 1); r.onsuccess = () => { const db = r.result; const tx = db.transaction('cells', 'readwrite'); tx.objectStore('cells').clear(); tx.oncomplete = () => { db.close(); res(); }; }; r.onerror = () => rej(r.error); });
+    const afterWipe = await new Promise((res) => { const r = indexedDB.open('edot-grid', 1); r.onsuccess = () => { const db = r.result; const tx = db.transaction('cells', 'readonly'); const c = tx.objectStore('cells').count(); c.onsuccess = () => { db.close(); res(c.result); }; }; });
+
+    await S.restoreSnapshot(bytes, { databases });
+    const restored = await new Promise((res) => { const r = indexedDB.open('edot-grid', 1); r.onsuccess = () => { const db = r.result; const tx = db.transaction('cells', 'readonly'); const g = tx.objectStore('cells').get('a1'); g.onsuccess = () => { db.close(); res(g.result); }; }; });
+
+    return {
+      manifestCount: grid ? grid.stores.find((s) => s.store === 'cells').count : -1,
+      afterWipe,
+      restoredV: restored && restored.v,
+      blobOk: restored && restored.blob instanceof Uint8Array && Array.from(restored.blob).join(',') === '1,2,3,4',
+    };
+  });
+  ok('snapshot: manifest counts the seeded records', snap.manifestCount === 2);
+  ok('snapshot: wipe empties the store', snap.afterWipe === 0);
+  ok('snapshot: restore brings data back', snap.restoredV === 42);
+  ok('snapshot: binary (Uint8Array) value round-trips', snap.blobOk);
+
+  // ---- 3. Each adapter against the mocked fetch ----
+  const adapters = await page.evaluate(async () => {
+    const { getStore } = window.__backup;
+    const f = window.__mockFetch;
+    const payload = new Uint8Array([10, 20, 30, 40, 50]);
+    const eq = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]);
+    const out = {};
+
+    // GitHub
+    {
+      const cfg = { repo: 'me/backups', token: 't', fetchImpl: f };
+      const gh = getStore('github');
+      await gh.put('snap1', payload, cfg);
+      const got = await gh.get('snap1', cfg);
+      const lst = await gh.list(cfg);
+      const sawPut = window.__calls.some((c) => c.method === 'PUT' && /\/contents\/edot-backups\/snap1\.enc/.test(c.url));
+      await gh.remove('snap1', cfg);
+      const after = await gh.list(cfg);
+      out.github = { get: eq(got, payload), listed: lst.some((x) => x.id === 'snap1'), sawPut, removed: !after.some((x) => x.id === 'snap1') };
+    }
+    // S3 (presigned-URL seam)
+    {
+      const presign = (method, key) => `https://s3.mock/bucket?s3key=${encodeURIComponent(key)}`;
+      const listUrl = 'https://s3.mock/bucket?op=list-s3';
+      const cfg = { presign, listUrl, prefix: 'edot-backups', fetchImpl: f };
+      const s3 = getStore('s3');
+      await s3.put('snap2', payload, cfg);
+      const got = await s3.get('snap2', cfg);
+      const lst = await s3.list(cfg);
+      await s3.remove('snap2', cfg);
+      const after = await s3.list(cfg);
+      out.s3 = { get: eq(got, payload), listed: lst.some((x) => x.id === 'snap2'), removed: !after.some((x) => x.id === 'snap2') };
+    }
+    // WebDAV
+    {
+      const cfg = { baseUrl: 'https://dav.mock/dav/edot-backups', user: 'u', password: 'p', fetchImpl: f };
+      const wd = getStore('webdav');
+      await wd.put('snap3', payload, cfg);
+      const got = await wd.get('snap3', cfg);
+      const lst = await wd.list(cfg);
+      const sawPropfind = window.__calls.some((c) => c.method === 'PROPFIND');
+      await wd.remove('snap3', cfg);
+      const after = await wd.list(cfg);
+      out.webdav = { get: eq(got, payload), listed: lst.some((x) => x.id === 'snap3'), sawPropfind, removed: !after.some((x) => x.id === 'snap3') };
+    }
+    // Solid
+    {
+      const cfg = { container: 'http://127.0.0.1/pod/edot-backups/', token: 'bearer-xyz', fetchImpl: f };
+      const sd = getStore('solid');
+      await sd.put('snap4', payload, cfg);
+      const got = await sd.get('snap4', cfg);
+      const lst = await sd.list(cfg);
+      const sawContainerGet = window.__calls.some((c) => c.method === 'GET' && c.url.endsWith('/pod/edot-backups/'));
+      await sd.remove('snap4', cfg);
+      const after = await sd.list(cfg);
+      out.solid = { get: eq(got, payload), listed: lst.some((x) => x.id === 'snap4'), sawContainerGet, removed: !after.some((x) => x.id === 'snap4') };
+    }
+    return out;
+  });
+  for (const [name, r] of Object.entries(adapters)) {
+    ok(`${name}: put→get returns identical bytes`, r.get);
+    ok(`${name}: list returns the put id`, r.listed);
+    ok(`${name}: remove works`, r.removed);
+  }
+  ok('github: issues a Contents PUT', adapters.github.sawPut);
+  ok('webdav: list issues a PROPFIND', adapters.webdav.sawPropfind);
+  ok('solid: list issues a container GET', adapters.solid.sawContainerGet);
+
+  // ---- 4. End-to-end: snapshot → encrypt → github put → get → decrypt ----
+  const e2e = await page.evaluate(async () => {
+    const { crypto: C, snapshot: S, getStore } = window.__backup;
+    const f = window.__mockFetch;
+    const { bytes, manifest } = await S.createSnapshot({ databases: [{ name: 'edot-grid', stores: '*' }] });
+    const env = await C.encryptSnapshot(bytes, 'e2e-pass');
+    const cfg = { repo: 'me/backups', token: 't', fetchImpl: f };
+    await getStore('github').put('e2e', env, cfg);
+    const fetched = await getStore('github').get('e2e', cfg);
+    const plain = await C.decryptSnapshot(fetched, 'e2e-pass');
+    const same = plain.length === bytes.length && plain.every((b, i) => b === bytes[i]);
+    const m2 = await S.readSnapshotManifest(plain);
+    return { same, shaMatch: m2.sha256 === manifest.sha256 };
+  });
+  ok('e2e: snapshot→encrypt→put→get→decrypt recovers bytes', e2e.same);
+  ok('e2e: restored snapshot fingerprint matches', e2e.shaMatch);
+
+  // ---- 5. UI: renders, ALPHA badge present, backup-then-list via the component ----
+  const uiBadge = await page.evaluate(() => {
+    const c = window.__backup.component();
+    const badge = c.querySelector('.bk-badge');
+    return { hasBadge: !!badge && /ALPHA/i.test(badge.textContent), hasWarn: !!c.querySelector('.bk-warn'), hasBackup: !!c.querySelector('#bk-backup') };
+  });
+  ok('ui: ALPHA badge present', uiBadge.hasBadge);
+  ok('ui: experimental warning present', uiBadge.hasWarn);
+  ok('ui: renders the Back up control', uiBadge.hasBackup);
+
+  // Drive the component end-to-end with the mocked fetch injected.
+  const uiFlow = await page.evaluate(async () => {
+    const c = window.__backup.component();
+    c._fetchImpl = window.__mockFetch;
+    c.backend = 'github'; c.cfg = { repo: 'me/ui', token: 't', dir: 'edot-backups', branch: '' };
+    c.querySelector('#bk-pass').value = 'ui-pass';
+    await c.doBackup();
+    const status = c.querySelector('#bk-status').textContent;
+    const fpShown = !c.querySelector('#bk-fp').hidden;
+    await c.refreshList();
+    const listed = c.querySelectorAll('.bk-item').length;
+    return { ok: /Backed up/.test(status), fpShown, listed };
+  });
+  ok('ui: backup via component succeeds', uiFlow.ok);
+  ok('ui: SHA-256 fingerprint shown after backup', uiFlow.fpShown);
+  ok('ui: snapshot appears in the list', uiFlow.listed >= 1);
+
+  ok('no page errors', errs.length === 0);
+  if (errs.length) console.log(errs);
+} finally { await browser.close(); server.close(); }
+console.log(fail ? `\n${fail} FAILURE(S)` : '\nBACKUP OK');
+process.exit(fail ? 1 : 0);

--- a/magpie/edot/calendar/calendar.html
+++ b/magpie/edot/calendar/calendar.html
@@ -7,8 +7,11 @@
   <meta name="color-scheme" content="light dark">
   <title>edot calendar</title>
   <link rel="stylesheet" href="css/calendar.css">
+  <link rel="stylesheet" href="../auth/css/auth.css">
   <style>
     html, body { height: 100%; margin: 0; overflow: hidden; }
+    .login-slot { display: inline-flex; align-items: center; gap: 0.25rem; }
+    .alpha-badge { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: #fff; background: var(--c-accent); padding: 0.05em 0.4em; border-radius: 999px; }
     body { display: flex; flex-direction: column; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--c-bg); color: var(--c-ink); }
     .app-header { display: flex; align-items: center; gap: 0.6rem; padding: 0.4rem 0.75rem; background: var(--c-surface); border-bottom: 1px solid var(--c-line); flex: 0 0 auto; }
     .app-header h1 { font-size: 1.05rem; margin: 0; }
@@ -26,10 +29,12 @@
     <span class="spacer"></span>
     <a href="../data/data.html">data ▦</a>
     <a href="../edot.html">← back to editor</a>
+    <span class="login-slot"><edot-login-button login-href="../auth/login.html"></edot-login-button><span class="alpha-badge" title="Experimental — sign-in is in alpha">alpha</span></span>
   </header>
   <main>
     <edot-calendar><div class="boot">Loading calendar…</div></edot-calendar>
   </main>
+  <script type="module" src="../auth/js/login-ui.js"></script>
   <script type="module">
     // Boot the component and expose a headless-test hook (mirrors window.__edot
     // / window.__cal conventions): the live instance plus a couple of helpers.

--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -421,6 +421,15 @@ select.tbtn {
 .gh-steps li { margin: 0.25rem 0; }
 .gh-steps code { background: var(--bg); padding: 0 0.3em; border-radius: 3px; }
 .gh-tip { color: var(--muted); margin: 0.4rem 0 0; }
+/* System-wide sign-in chip (alpha) in the header */
+.login-slot { display: inline-flex; align-items: center; gap: 0.25rem; }
+.alpha-badge {
+  font-size: 0.6rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+  color: var(--accent-fg); background: var(--accent); padding: 0.05em 0.4em; border-radius: 999px;
+  line-height: 1.4;
+}
+@media (max-width: 30rem) { .alpha-badge { display: none; } }
+
 /* View source */
 .src-bar { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0.4rem 0; }
 .src-bar label { font-size: 0.85rem; color: var(--muted); }

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -64,6 +64,9 @@
         <button type="button" id="mi-login" class="menu-item" role="menuitem">
           <span>Sign in ↗</span><span class="hint">OIDC</span>
         </button>
+        <button type="button" id="mi-backup" class="menu-item" role="menuitem">
+          <span>Encrypted backup ↗</span><span class="hint">alpha</span>
+        </button>
         <div class="menu-sep" role="separator"></div>
         <div id="export-list" role="group" aria-label="Save as"></div>
       </div>

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -12,6 +12,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>edot — accessible word processor</title>
   <link rel="stylesheet" href="css/edot.css">
+  <link rel="stylesheet" href="auth/css/auth.css">
 </head>
 <body>
   <a class="skip-link" href="#editor">Skip to document</a>
@@ -73,6 +74,12 @@
            spellcheck="false" placeholder="Untitled document">
 
     <span id="save-state" class="save-state" role="status" aria-live="polite">Autosaved locally</span>
+
+    <!-- System-wide sign-in (ALPHA) — shared session across the edot suite. -->
+    <span class="login-slot">
+      <edot-login-button login-href="auth/login.html"></edot-login-button>
+      <span class="alpha-badge" title="Experimental — sign-in is in alpha">alpha</span>
+    </span>
   </header>
 
   <div id="toolbar" class="toolbar"><!-- built by toolbar.js --></div>
@@ -206,5 +213,7 @@
   </dialog>
 
   <script type="module" src="js/edot-app.js"></script>
+  <!-- System-wide sign-in chip (self-registers; standalone shared session). -->
+  <script type="module" src="auth/js/login-ui.js"></script>
 </body>
 </html>

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -220,6 +220,7 @@ class App {
     mi('mi-calendar', () => openApp('calendar/calendar.html'));
     mi('mi-maps', () => openApp('maps/maps.html'));
     mi('mi-login', () => openApp('auth/login.html'));
+    mi('mi-backup', () => openApp('backup/backup.html'));
 
     this.fileInput.accept = IO.importAccept();
     this.fileInput.addEventListener('change', () => {

--- a/magpie/edot/maps/maps.html
+++ b/magpie/edot/maps/maps.html
@@ -9,8 +9,11 @@
   <!-- Vendored MapLibre GL JS (BSD-3-Clause) and its CSS — no runtime CDN. -->
   <link rel="stylesheet" href="vendor/maplibre-gl.css">
   <link rel="stylesheet" href="css/maps.css">
+  <link rel="stylesheet" href="../auth/css/auth.css">
   <style>
     html, body { height: 100%; margin: 0; overflow: hidden; }
+    .login-slot { display: inline-flex; align-items: center; gap: 0.25rem; }
+    .alpha-badge { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: #fff; background: var(--m-accent); padding: 0.05em 0.4em; border-radius: 999px; }
     body { display: flex; flex-direction: column; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--m-bg); color: var(--m-ink); }
     .app-header { display: flex; align-items: center; gap: 0.6rem; padding: 0.4rem 0.75rem; background: var(--m-surface); border-bottom: 1px solid var(--m-line); flex: 0 0 auto; }
     .app-header h1 { font-size: 1.05rem; margin: 0; }
@@ -29,10 +32,12 @@
     <a href="../calendar/calendar.html">calendar 📅</a>
     <a href="../data/data.html">data ▦</a>
     <a href="../edot.html">← back to editor</a>
+    <span class="login-slot"><edot-login-button login-href="../auth/login.html"></edot-login-button><span class="alpha-badge" title="Experimental — sign-in is in alpha">alpha</span></span>
   </header>
   <main>
     <edot-maps><div class="boot">Loading map…</div></edot-maps>
   </main>
+  <script type="module" src="../auth/js/login-ui.js"></script>
 
   <!-- MapLibre is a UMD bundle: it defines window.maplibregl synchronously, so
        it must load (and be present) before the component initialises the map.


### PR DESCRIPTION
Second batch on top of #705. No conflicts. All suites green; HTML validates.

- **System-wide sign-in chip (ALPHA)** embedded in the edot editor, calendar, and maps headers (`<edot-login-button>` + "alpha" badge; shared `auth.css` + AuthSession). Inert until provider client IDs are set in `auth/auth-config.js`.
- **Tier-1 encrypted backup/restore** (`magpie/edot/backup/`, verified 35/35): client-side envelope encryption (AES-GCM-256 DEK, KEK = PBKDF2 210k, versioned header, SHA-256 fingerprint) over an IndexedDB snapshot, with pluggable storage adapters — **GitHub** (full), **WebDAV** (full), **S3** (presigned-URL seam), **Solid** (bearer-token Tier-1 shim; Solid-OIDC/DPoP seam left for the auth module). `<edot-backup>` UI flagged ALPHA; OIDC token DBs excluded from snapshots; Tier-2 OIDC-gated-unlock hooks marked.
- **File menu** gains Calendar / Maps / Sign in / Encrypted backup entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_