### PR TITLE
edot/auth: pre-fill auth-config quick start for Google + Microsoft

### DIFF
--- a/magpie/edot/auth/auth-config.js
+++ b/magpie/edot/auth/auth-config.js
@@ -16,6 +16,27 @@
 // The redirect URI defaults to this directory's login.html, which doubles as
 // the callback handler. On GitHub Pages that is e.g.
 //   https://danbri.github.io/glitchcan-minigam/magpie/edot/auth/login.html
+//
+// ───────────────────────────────────────────────────────────────────────────
+// QUICK START — Google + Microsoft (both work in-browser, no backend)
+// Register the SAME redirect URI with each:
+//   https://danbri.github.io/glitchcan-minigam/magpie/edot/auth/login.html
+//   (for local testing also add your http://localhost:<port>/.../auth/login.html)
+//
+// GOOGLE
+//   1. https://console.cloud.google.com/apis/credentials → Create credentials →
+//      OAuth client ID → Application type: "Web application".
+//   2. Add the redirect URI above under "Authorised redirect URIs".
+//   3. Copy the Client ID (…apps.googleusercontent.com) → paste below.
+//      (PKCE public client — ignore the client secret Google also shows.)
+//
+// MICROSOFT
+//   1. https://entra.microsoft.com → App registrations → New registration.
+//   2. Supported accounts: "Accounts in any org directory and personal MS
+//      accounts" (matches the `common` preset).
+//   3. Add a platform → "Single-page application (SPA)" → paste the redirect URI.
+//   4. Copy the "Application (client) ID" → paste below.
+// ───────────────────────────────────────────────────────────────────────────
 
 export const AUTH_CONFIG = {
   // Computed at runtime when blank: the absolute URL of login.html next to
@@ -29,12 +50,14 @@ export const AUTH_CONFIG = {
   // Only `clientId` is required to light up a provider; the rest are for
   // template providers that need a tenant/domain/region.
   providers: {
-    google: { clientId: '' },
-    microsoft: { clientId: '' },
-    apple: { clientId: '' },          // Apple "Services ID"
+    // ▼▼ PASTE YOUR TWO CLIENT IDs HERE — that's all it takes to go live ▼▼
+    google: { clientId: '' },         // e.g. '1234567890-abc.apps.googleusercontent.com'
+    microsoft: { clientId: '' },      // e.g. '00000000-0000-0000-0000-000000000000' (Application/client ID)
+    // ▲▲ ─────────────────────────────────────────────────────────────── ▲▲
+    apple: { clientId: '' },          // Apple "Services ID" (needs a token-exchange proxy)
     okta: { clientId: '', issuer: '' },      // e.g. https://dev-123.okta.com/oauth2/default
-    auth0: { clientId: '', issuer: '' },     // e.g. https://your-tenant.us.auth0.com/
-    keycloak: { clientId: '', issuer: '' },  // e.g. https://kc.example.com/realms/myrealm
+    auth0: { clientId: '', issuer: '' },     // e.g. https://your-tenant.us.auth0.com/  (broker: one app federates many)
+    keycloak: { clientId: '', issuer: '' },  // e.g. https://kc.example.com/realms/myrealm (self-hosted broker)
     gitlab: { clientId: '' },
     cognito: { clientId: '', issuer: '', authorize: '', token: '', userinfo: '' },
     salesforce: { clientId: '' },


### PR DESCRIPTION
Inline Google + Microsoft registration steps (console URLs, app type, exact redirect URI) and a "paste your two client IDs here" marker in `auth/auth-config.js`. Comment-only; client IDs stay blank until set. Auth module still 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_