### PR TITLE
edot: visible build stamp for deploy-freshness check

### DIFF
--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -421,6 +421,9 @@ select.tbtn {
 .gh-steps li { margin: 0.25rem 0; }
 .gh-steps code { background: var(--bg); padding: 0 0.3em; border-radius: 3px; }
 .gh-tip { color: var(--muted); margin: 0.4rem 0 0; }
+/* Build stamp in the status bar — a quick "am I on the latest deploy?" check. */
+.build-stamp { color: var(--muted); font-size: 0.7rem; opacity: 0.75; font-variant-numeric: tabular-nums; }
+
 /* System-wide sign-in chip (alpha) in the header */
 .login-slot { display: inline-flex; align-items: center; gap: 0.25rem; }
 .alpha-badge {

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -97,6 +97,9 @@
     <span id="stat-words">0 words</span>
     <span id="stat-chars">0 chars</span>
     <span class="spacer"></span>
+    <!-- Set by edot-app.js, so it reflects the JS build your browser actually
+         loaded (stale cache shows the old stamp — a reliable freshness check). -->
+    <span id="build-stamp" class="build-stamp" title="Loaded app build — changes when a newer deploy is live"></span>
     <span id="backend-state" class="visually-hidden"></span>
   </footer>
 

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -15,6 +15,10 @@ import { diffLines, diffStats, collapse } from './diff.js';
 import * as IO from './io.js';
 import * as LO from './libreoffice-bridge.js';
 
+// Bump on each meaningful deploy. Shown in the footer so a stale cached build
+// is obvious (the stamp reflects the JS your browser actually loaded).
+const BUILD = '2026-06-23.e';
+
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token
 const GH_RECENTS_KEY = 'edot.gh.recents'; // remembered save locations (zappable)
@@ -46,6 +50,8 @@ class App {
     this.statWords = document.getElementById('stat-words');
     this.statChars = document.getElementById('stat-chars');
     this.fileInput = document.getElementById('file-input');
+    const stamp = document.getElementById('build-stamp');
+    if (stamp) stamp.textContent = `build ${BUILD}`;
 
     this.doc = null;           // current library record { id, title, html, ... }
     this.lastExportExt = 'docx';


### PR DESCRIPTION
Adds a footer "build <id>" stamp set by edot-app.js, so it reflects the JS the browser actually loaded — a stale cache shows the old stamp. Makes "am I on the latest deploy?" answerable on iOS (no hard-refresh). Tests green; HTML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_