### PR TITLE
edot: fix Calendar/Maps dropping off the File menu after opening a suite app

### DIFF
--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -17,7 +17,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-23.f';
+const BUILD = '2026-06-23.g';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token
@@ -221,7 +221,16 @@ class App {
     mi('mi-find', () => this.findReplace.open(true));
     mi('mi-source', () => this.openSourceDialog());
     mi('mi-github', () => this.openGithubDialog());
-    const openApp = (path) => { const w = window.open(path, '_blank', 'noopener'); if (!w) location.href = path; else this.attention.arm('Back to edot', { once: true }); };
+    // Open a sibling suite app. Use a real anchor click (target=_blank) — NOT
+    // window.open(...,'noopener'), which returns null and made the old fallback
+    // also navigate THIS tab via location.href; a Back could then reload a stale
+    // edot and drop the Calendar/Maps menu items. An anchor leaves this tab put.
+    const openApp = (path) => {
+      const a = document.createElement('a');
+      a.href = path; a.target = '_blank'; a.rel = 'noopener';
+      document.body.appendChild(a); a.click(); a.remove();
+      this.attention.arm('Back to edot', { once: true });
+    };
     mi('mi-data', () => openApp('data/data.html'));
     mi('mi-calendar', () => openApp('calendar/calendar.html'));
     mi('mi-maps', () => openApp('maps/maps.html'));


### PR DESCRIPTION
`openApp` used `window.open(path,'_blank','noopener')`, which **always returns null** (noopener severs the handle). The `if (!w) location.href = path` fallback then fired every time, navigating the current edot tab to the app too — so a browser **Back** could reload a stale-cached edot and drop the static **Calendar/Maps** File-menu items. Now opens via a real anchor click (`target=_blank rel=noopener`), leaving the edot tab untouched. Build stamp → `2026-06-23.g`. smoke + e2e + mobile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_