### PR TITLE
calendar: fix mobile sidebar drawer that couldn't close

### DIFF
--- a/magpie/edot/calendar/js/calendar-app.js
+++ b/magpie/edot/calendar/js/calendar-app.js
@@ -134,6 +134,12 @@ export class EdotCalendar extends HTMLElement {
     this._built = true;
     this.innerHTML = '';
     const root = document.createElement('div'); root.className = 'cal'; this._root = root;
+    // Tapping the scrim (anywhere outside the drawer) closes the mobile sidebar.
+    // The scrim is .cal.side-open::after, so its clicks land on the root itself;
+    // without this the drawer had no way to close (the scrim covers the ☰).
+    root.addEventListener('click', (e) => {
+      if (e.target === root && root.classList.contains('side-open')) root.classList.remove('side-open');
+    });
 
     root.appendChild(this._buildToolbar());
     root.appendChild(this._buildSidebar());

--- a/magpie/edot/calendar/test-calendar.mjs
+++ b/magpie/edot/calendar/test-calendar.mjs
@@ -213,6 +213,28 @@ try {
 
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
+
+  // 10. Mobile drawer regression: the calendars sidebar opens via ☰ and CLOSES
+  //     on a scrim tap. It previously had no way to close — the scrim covered
+  //     the toggle and nothing closed on an outside tap.
+  {
+    const mctx = await browser.newContext({ viewport: { width: 390, height: 820 }, hasTouch: true, isMobile: true });
+    const mp = await mctx.newPage();
+    const merrs = []; mp.on('pageerror', (e) => merrs.push(String(e)));
+    await mp.goto(`http://127.0.0.1:${port}/magpie/edot/calendar/calendar.html`);
+    await mp.waitForFunction(() => window.__cal && window.__cal.app, null, { timeout: 20000 });
+    const isOpen = () => mp.evaluate(() => document.querySelector('.cal').classList.contains('side-open'));
+    ok('mobile: ☰ toggle is shown', await mp.isVisible('.cal-menu-btn'));
+    await mp.click('.cal-menu-btn'); await mp.waitForTimeout(200);
+    ok('mobile: ☰ opens the calendars drawer', await isOpen());
+    await mp.mouse.click(365, 60); await mp.waitForTimeout(250); // tap the scrim
+    ok('mobile: tapping the scrim closes the drawer', !(await isOpen()));
+    await mp.click('.cal-menu-btn'); await mp.waitForTimeout(200);
+    await mp.mouse.click(365, 60); await mp.waitForTimeout(250);
+    ok('mobile: drawer reopens and recloses', !(await isOpen()));
+    ok('mobile: no page errors', merrs.length === 0);
+    await mctx.close();
+  }
 } finally { await browser.close(); server.close(); }
 console.log(fail ? `\n${fail} FAILURE(S)` : '\nCALENDAR OK');
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
The calendars drawer opened via ☰ but couldn't be closed: the scrim (`.cal.side-open::after`, z-index 39) covers the toggle (toolbar z-index 5), and there was no close-on-outside-tap handler. A headless repro confirmed it stayed stuck open. Fix: a root click handler that removes `side-open` when the scrim (the root itself) is tapped — same pattern as the data workspace. Added a mobile-viewport regression test (open → scrim-close → reopen/reclose). CALENDAR OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_