### PR TITLE
maps: ease search zoom so water/park features show in context (not "all blue")

### DIFF
--- a/magpie/edot/maps/js/maps-app.js
+++ b/magpie/edot/maps/js/maps-app.js
@@ -293,9 +293,12 @@ export class EdotMaps extends HTMLElement {
     this._setSearchMarker([r.lng, r.lat], r.name);
     if (!this.map) return;
     if (r.bbox && r.bbox.every(Number.isFinite)) {
-      this.map.fitBounds([[r.bbox[0], r.bbox[1]], [r.bbox[2], r.bbox[3]]], { padding: 40, maxZoom: 16 });
+      // Keep neighbourhood context: cap the zoom and pad generously so a large
+      // feature that is mostly one colour (a dock or lake — all water/blue, a
+      // park — all green) doesn't fill the screen edge-to-edge with no streets.
+      this.map.fitBounds([[r.bbox[0], r.bbox[1]], [r.bbox[2], r.bbox[3]]], { padding: 64, maxZoom: 15 });
     } else {
-      this.map.flyTo({ center: [r.lng, r.lat], zoom: Math.max(this.map.getZoom(), 14) });
+      this.map.flyTo({ center: [r.lng, r.lat], zoom: Math.max(this.map.getZoom(), 15) });
     }
   }
 


### PR DESCRIPTION
`flyToResult` used `fitBounds(bbox, { maxZoom: 16, padding: 40 })`, so searching a large single-colour feature (e.g. **Greenland Dock, SE16** — all water) filled the screen edge-to-edge with blue and no street context. Now caps at zoom 15 with 64px padding so you land in the neighbourhood; point results settle at zoom 15. Not a tile bug — the blue was correctly-rendered water (the headless env can't reach OSM tiles, but a real device can); the vector *demo* basemap just has no detail at street zoom. MAPS OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_