### PR TITLE
edot: disclosure-tree widget + Open ▸ {Examples, Research} hierarchy + research docs

### DIFF
--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -444,6 +444,25 @@ select.tbtn {
 }
 @media (max-width: 30rem) { .alpha-badge { display: none; } }
 
+/* Reusable disclosure tree (js/tree.js) — the clicky open/closey hierarchy. */
+edot-tree { display: block; }
+.tree, .tree-group { list-style: none; margin: 0; padding: 0; }
+.tree-group { margin-left: 0.85rem; padding-left: 0.4rem; border-left: 1px solid var(--line); }
+.tree-row {
+  display: flex; align-items: baseline; gap: 0.4rem; width: 100%; text-align: left;
+  background: none; border: 1px solid transparent; border-radius: var(--radius);
+  padding: 0.4em 0.5em; font: inherit; color: var(--ink); cursor: pointer;
+}
+.tree-row:hover { background: var(--surface); }
+.tree-row:focus-visible { outline: 3px solid var(--focus); outline-offset: 1px; }
+.tree-twisty { width: 1em; flex: 0 0 auto; color: var(--muted); }
+.tree-icon { flex: 0 0 auto; }
+.tree-folder .tree-label { font-weight: 600; }
+.tree-label { flex: 0 0 auto; }
+.tree-note { color: var(--muted); font-size: 0.8rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.open-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.6rem; }
+@media (pointer: coarse) { .tree-row { padding: 0.55em 0.6em; } }
+
 /* View source */
 .src-bar { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0.4rem 0; }
 .src-bar label { font-size: 0.85rem; color: var(--muted); }

--- a/magpie/edot/docs/research/index.json
+++ b/magpie/edot/docs/research/index.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Manifest of research documents shown under File ▸ Open ▸ Research. Add an entry (title, file, note) and drop the .md alongside — nothing else to change.",
+  "docs": [
+    {
+      "title": "UI Extensibility, Complexity & Modularity — a deep-dive",
+      "file": "ui-architecture-deepdive.md",
+      "note": "How office suites, OS & component architectures handle extensibility — applied to edot. Cited."
+    }
+  ]
+}

--- a/magpie/edot/docs/research/ui-architecture-deepdive.md
+++ b/magpie/edot/docs/research/ui-architecture-deepdive.md
@@ -1,0 +1,402 @@
+# UI Extensibility, Complexity & Modularity — a research deep-dive, applied to edot
+
+*Research report (no code changes). Synthesised from five parallel primary-source
+research passes — office suites, open substrates, OS/shell extensibility, component
+architectures, and cross-cutting principles — then applied to the edot suite's UI
+and architecture. Claims carry citations; contested points are flagged as such.*
+
+---
+
+## 0. Executive summary
+
+Across forty years and five very different domains, the same handful of forces
+recur. Extensible UIs all face one trade and one law:
+
+- **The trade:** *in-process, imperative, deeply-coupled* extensions maximise
+  power and minimise friction but share the host's trust and fate; *out-of-process /
+  sandboxed / declarative* extensions with explicit contracts trade raw power for
+  fault-isolation and a tractable security model. Every platform's history runs
+  from the first toward the second — Windows shell extensions → out-of-process
+  handlers; Office COM/VSTO → sandboxed Office.js; first-gen monolithic kernels →
+  microkernel servers. ([MS shell guidance](https://learn.microsoft.com/en-us/windows/win32/shell/shell-and-managed-code), [MS Office add-ins](https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins), [Microkernel](https://en.wikipedia.org/wiki/Microkernel))
+- **The law:** **Tesler's conservation of complexity** — irreducible complexity
+  doesn't vanish, it only moves between user, app developer, and platform
+  developer. ([Tesler](https://www.nomodes.com/larry-tesler-consulting/complexity-law)) An extension *system* is a decision to *relocate* complexity onto an
+  API surface and a third-party ecosystem; do it badly and you get OpenDoc.
+
+**The OpenDoc lesson looms over all of it.** The "data-centric document, editors
+as parts" vision collapsed under part-interoperability difficulty, performance
+weight, an app-centric user mental model, Microsoft's bundled-OLE counter-position,
+and Jobs's 1997 cancellation — and the failure analysis is *genuinely contested*,
+no single cause. ([OpenDoc](https://en.wikipedia.org/wiki/OpenDoc), [instadeq](https://instadeq.com/blog/posts/why-opendoc-failed-and-then-failed-3-more-times/)) **edot already takes the post-OpenDoc shape that survived:** open
+durable *data* at the centre, interchangeable *faces* (not embedded binary parts)
+over it, message-passing between independently-loadable apps, light-DOM web
+components, and no third-party extension surface *yet*. That last point is the
+strategic question this report exists to inform.
+
+**Bottom line for edot:** the architecture is well-aligned with the *durable*
+principles (deep modules, open substrate, lossless round-trip, light-DOM,
+progressive disclosure, late-bound message passing). The two real gaps are (1) no
+**command/action registry** or **declarative contribution model** — the thing
+every successful extensible editor (Eclipse, VS Code) converged on — and (2) no
+**versioned contract** for the data formats or a future plugin API, where Hyrum's
+Law and the Must-Ignore pattern will bite. Recommendation in §9.
+
+---
+
+## 1. Office suites & compound documents
+
+- **OLE & OpenDoc shared the "compound document, editors-as-parts" vision** —
+  one document amalgamating text/graphics/sheets, each region edited in-place by a
+  different component. OpenDoc used *part editors/viewers*, the **Bento** container,
+  and IBM **SOM/DSOM** for cross-language live linking. ([OpenDoc](https://en.wikipedia.org/wiki/OpenDoc), [Grokipedia](https://grokipedia.com/page/OpenDoc)) OLE 2.0 re-based on **COM** and gave us **in-place activation** —
+  editing an embedded object while the container's menus/toolbars morph. ([OLE](https://en.wikipedia.org/wiki/Object_Linking_and_Embedding))
+- **What survived was OLE-in-Office and COM/ActiveX, not OpenDoc.** "There were
+  never many released OpenDoc components compared to Microsoft's ActiveX
+  components." ([OpenDoc](https://en.wikipedia.org/wiki/OpenDoc))
+- **Office's extensibility lineage is the in-process→sandboxed arc in miniature:**
+  COM add-ins/VBA → **VSTO** (.NET, deep object-model, Windows-only, in-process) →
+  **Office.js web add-ins** = a *manifest* (id, version, **permission level**, data
+  requirements) + an externally-hosted web app loaded **in a sandboxed webview**,
+  talking to the document only through the constrained Office.js API. Cross-platform
+  and capability-scoped, at the cost of the full object model — and the bet has real
+  friction (a developer "open letter" on Office.js stability/trust). ([Office add-ins](https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins), [transition guide](https://learn.microsoft.com/en-us/office/dev/add-ins/overview/learning-path-transition), [office-js#6513](https://github.com/OfficeDev/office-js/issues/6513))
+- **The Ribbon is the canonical "command explosion" case study.** Word's toolbars
+  grew 2 (1989) → 31 (2003) with ~20 Task Panes; menu items ~50 → ~300. Office 2000's
+  adaptive **IntelliMenus/rafting** (hide rarely-used commands) *failed* —
+  undiscoverable, unpredictable. The Ribbon unified menus/toolbars/panes into one
+  contextual, results-oriented surface (**contextual tabs**, **galleries**, **Live
+  Preview**). ([uxweek08 notes](https://www.jurecuhalev.com/blog/jensen-harris-the-story-of-the-ribbon-office-2007-uxweek08-notes/), [Ribbon](https://en.wikipedia.org/wiki/Ribbon_(computing)), [Designing the Ribbon](https://jensenharris.com/home/ribbon))
+- *Contested / uncertain:* the exact command counts come from third-party
+  conference notes, not Harris's primary text; the popular "Word had ~1,500 commands"
+  figure was **not** verifiable. ([flag per research](https://learn.microsoft.com/en-us/archive/blogs/jensenh/the-story-of-the-ribbon))
+
+**For edot:** the Ribbon's lesson — *don't hide commands adaptively; make them
+contextual and previewable* — directly validates edot's choices: contextual
+"faces" switcher, long-press readable labels + a Labels mode (the icon-legibility
+problem the Ribbon faced), and recents/merge appearing only when relevant. The
+Office.js arc is the template if edot ever wants third-party add-ins (manifest +
+sandbox + capability scope).
+
+---
+
+## 2. Open document substrates & declarative add-ons
+
+- **LibreOffice UNO** is a language-neutral component model: services bundle
+  interfaces, components are instantiated via a `ServiceManager` from a registry,
+  and the **URP** wire protocol makes it distributed; **add-ons** layer declarative
+  `Addon.xcu`/`ProtocolHandler.xcu` config (menu/toolbar injection) over imperative
+  UNO components. ([UNO component model](http://www.openoffice.org/udk/common/man/componentmodel.html), [UNO](https://en.wikipedia.org/wiki/Universal_Network_Objects)) **ODF** is the open zipped-XML substrate (content/styles/meta
+  streams; ISO/IEC 26300), with RDF metadata since 1.2 — a bridge between document
+  and semantic-data worlds. Round-trip fidelity vs OOXML is imperfect in practice
+  (tracked-changes under-specified). ([OpenDocument](https://en.wikipedia.org/wiki/OpenDocument))
+- **Google Workspace add-ons invert the flexibility/safety dial:** **CardService**
+  is *hosted & declarative* — you describe cards→sections→widgets; Google renders
+  them ("no HTML or CSS needed"), auto-styles per surface, and you "define the
+  interface once" for Gmail/Drive/Calendar/Docs. Flexibility is sacrificed for
+  safety, consistency, and cross-surface portability; review + OAuth-scope
+  verification gate publication. Contrast Office.js's *imperative* web UI. ([CardService](https://developers.google.com/workspace/add-ons/concepts/card-interfaces), [scope verification](https://developers.google.com/identity/protocols/oauth2/production-readiness/restricted-scope-verification))
+- **The document/data-centric paradigm is having a revival.** *Local-first
+  software* (Ink & Switch / Kleppmann) argues cloud apps make users "borrowers of
+  our own data" and posits seven ideals (fast local, multi-device, offline,
+  collaboration, **the Long Now**, privacy, **user ownership**); CRDTs/Automerge are
+  the enabling tech. Open formats (zip-of-XML, sqlite-as-a-file, RDF) are the durable
+  substrate over which editors are mere views. ([Local-first](https://www.inkandswitch.com/essay/local-first/))
+- *Contested:* **"data ages like wine, software ages like fish"** is a rhetorical
+  frame, not a law — practitioners counter that data goes stale/loses context
+  ("data ages like *fish*"). ([counterpoint](https://infusedinnovations.com/blog/secure-intelligent-workplace/data-ages-like-fish-not-like-wine-a-fresh-take-on-data-management))
+
+**For edot:** this is edot's exact thesis, already built — `OPENDOC.md`, the
+SQLite/zip-of-CSVs/N-Quads durable exports, IndexedDB-local storage, the encrypted
+backup. edot sits between UNO (maximal/imperative) and CardService (hosted/declarative):
+its "faces" are *first-party declarative views* over one object — closer to the
+*spirit* of CardService's safety than UNO's open-ended component soup. The honest
+caveat: heed the "data ages like fish" critique — durability needs *context/metadata*
+(the RDF face and the manifest/fingerprint help here).
+
+---
+
+## 3. OS / shell extensibility & security
+
+- **Windows shell extensions are the in-process cautionary tale:** COM DLLs loaded
+  into *any* process touching the shell namespace; a faulty one "brings down the
+  entire Explorer process," conflicts are load-order-dependent and hard to
+  reproduce, and Microsoft **recommends against** managed in-process extensions,
+  steering to **out-of-process** handlers. Also a DLL-hijack persistence vector. ([MS shell + managed code](https://learn.microsoft.com/en-us/windows/win32/shell/shell-and-managed-code))
+- **Browser MV2→MV3** is the live extensibility-vs-capability fight: service
+  workers replace persistent background pages; **declarativeNetRequest** replaces
+  blocking `webRequest` (rules evaluated *without the extension seeing content*),
+  with a guaranteed **≥30,000** rules but **no body inspection / dynamic logic**;
+  remote code banned. Chrome frames it as security/privacy/perf; **EFF/Ghostery
+  contest** that it mainly harms blockers — genuinely disputed. ([MV3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3), [DNR](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest), [EFF](https://www.eff.org/deeplinks/2021/12/chrome-users-beware-manifest-v3-deceitful-and-threatening))
+- **Inter-app composition = declarative contracts + late binding + capability
+  boundaries:** Android **Intents** (implicit intents matched to manifest
+  `intent-filter`s; explicit intents required for sensitive services);
+  **iOS App Extensions** run in *separate sandboxed processes*, talk only to their
+  host via system IPC, share data only through opt-in App Groups; **macOS Services**
+  compose via a declared `NSServices` pasteboard contract. ([Android intents](https://developer.android.com/guide/components/intents-filters), [iOS extensions](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html), [macOS Services](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/SysServices/Articles/properties.html))
+- **Foundations:** microkernel "mechanism, not policy" + message-passing IPC gives
+  fault isolation; the performance penalty was an implementation artifact (L4 ~20×
+  faster than Mach), not inherent. **Capabilities** (unforgeable tokens, no ambient
+  authority) beat ACLs for sandboxing untrusted code (confused-deputy by design). ([Microkernel](https://en.wikipedia.org/wiki/Microkernel), [Capabilities](https://en.wikipedia.org/wiki/Capability-based_security))
+
+**For edot:** edot's cross-app model is *already* the late-bound, contract-based
+shape — suite apps are **separate pages**, composed by **message passing**
+(`BroadcastChannel('edot')` for data→editor handoff, `BroadcastChannel('edot-auth')`
+for shared session) and a `localStorage` handoff contract, opened by URL (a recently
+fixed "open via anchor, don't navigate this tab" bug). That's macOS-Services /
+Android-Intent thinking: components don't reference each other's internals, they
+exchange typed payloads across a boundary. The capability lesson is the right north
+star for the **encrypted-backup Tier-2** (a token-gated key service = capability
+release by a trusted party) and for any future plugin sandbox (iframe + `postMessage`
++ scoped capabilities, *not* same-origin modules with full DOM access).
+
+---
+
+## 4. Component & module architectures
+
+- **COM/CORBA/OSGi** teach the versioning/decoupling tax. COM's `IUnknown` folds
+  *lifetime* (refcount) and *capability discovery* (`QueryInterface`) into the type
+  system. **CORBA** is the design-by-committee cautionary tale — "union of all
+  proposals with no regard to coherence," and **location transparency treated as a
+  design flaw** (local code forced to carry remote complexity). **OSGi** delivered
+  runtime-dynamic, *per-package* versioned modules + a service registry and was a
+  long-time **SemVer** proponent — but traded "JAR hell" for "classloader/bundle
+  hell." ([COM](https://en.wikipedia.org/wiki/Component_Object_Model), [CORBA](https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture), [OSGi](https://en.wikipedia.org/wiki/OSGi), [JAR hell](https://en.wikipedia.org/wiki/Java_Classloader))
+- **Web Components / Shadow DOM** encapsulate, but the boundary is **leaky in
+  documented ways** — inherited styles pierce it, and **forms/validation/ARIA don't
+  cross by default**, hurting a11y. Consensus: **default to light DOM, opt into
+  shadow only when isolation is worth it**; slots keep children stylable/submittable. ([MDN shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM), [shadow-DOM pros/cons](https://www.matuzo.at/blog/2023/pros-and-cons-of-shadow-dom/), [HTML web components](https://scottjehl.com/posts/html-web-components-shadow-dom/))
+- **Micro-frontends / Module Federation** give independent deploy + runtime
+  composition, with **version-skew** as the headline risk (shared-dependency
+  negotiation, singletons, runtime rejection of incompatible remotes). **Islands**
+  make modularity a *hydration boundary* (zero-JS default, per-island opt-in). ([Module Federation](https://webpack.js.org/concepts/module-federation/), [version skew](https://microfrontend.dev/architecture/webpack-module-federation/), [Islands](https://docs.astro.build/en/concepts/islands/))
+- **Plugin patterns converged on declarative contribution:** Eclipse **extension
+  points + `plugin.xml`** let a plug-in "contribute menus, actions, icons, editors…
+  without ever being loaded" (lazy activation); **VS Code `contributes`** is the
+  modern exemplar — JSON-declared commands/menus with `group`/`when` clauses, UI
+  surface decoupled from runtime code. Underneath: **event bus/pub-sub** (decouple
+  across time/type/number), **DI** (change behaviour) vs **events** (extend without
+  modifying), and **ECS** (composition-over-inheritance, extend by adding a
+  component/system pair). ([Eclipse plug-ins](https://www.eclipse.org/articles/Article-Plug-in-architecture/plugin_architecture.html), [VS Code contributes](https://code.visualstudio.com/api/references/contribution-points), [IoC via events](https://www.cshark.com/inversion-of-control-2-decoupling-through-events/), [ECS](https://en.wikipedia.org/wiki/Entity_component_system))
+
+**For edot:** two strong validations and one clear gap. Validation: edot's
+**light-DOM web components** are exactly the researched-recommended default
+(avoids the shadow-DOM a11y/form traps — and edot is accessibility-first). Validation:
+no bundler/Module-Federation = no version-skew/classloader-hell tax. **Gap:** edot's
+toolbar/menu are **hand-wired** (`mi()` calls, static HTML, imperative `_btn`). There
+is no **command/action registry** and no **declarative contribution point**. Every
+successful extensible editor (Eclipse, VS Code) made that the spine. If edot wants
+extensibility, this is the single most important architectural addition — and it can
+be added *first-party* (internal command registry) long before any third-party plugin.
+
+---
+
+## 5. Cross-cutting principles (the "advanced thinking")
+
+- **Decompose around change, hide secrets (Parnas, 1972).** Modularise by the
+  decisions *likely to change*, each hidden behind an interface, so change doesn't
+  propagate. ([Parnas](http://sunnyday.mit.edu/16.355/parnas-criteria.html))
+- **Deep modules; complexity = dependencies + obscurity (Ousterhout).** Prefer a
+  simple interface over substantial implementation; beware "classitis" (many shallow
+  modules sum to system complexity). ([PoSD](https://milkov.tech/assets/psd.pdf), [deep modules](https://softengbook.org/articles/deep-modules))
+- **Essential vs accidental complexity; conceptual integrity (Brooks).** Tooling
+  only attacks accidental complexity; essential complexity is irreducible — keep the
+  conceptual model small and coherent. ([No Silver Bullet](https://en.wikipedia.org/wiki/No_Silver_Bullet))
+- **Hyrum's Law.** At scale, *every observable behaviour* becomes a depended-upon
+  contract — "no such thing as a private implementation." SemVer is how you signal
+  sanctioned breaks. ([Hyrum's Law](https://www.hyrumslaw.com/))
+- **The robustness principle is now formally contested.** **RFC 9413** (2023)
+  argues Postel's "be liberal in what you accept" *conceals problems* and entrenches
+  bugs unless paired with **active maintenance + explicit extension rules**. The safe
+  form of "liberal" is **lossless pass-through of unknown content** — the XML/HTML
+  **"Must Ignore"** pattern, protobuf **unknown-field preservation** (binary-only,
+  copy-fragile). ([RFC 9413](https://www.rfc-editor.org/rfc/rfc9413.html), [Must Ignore](https://www.xml.com/pub/a/2004/07/21/design.html), [protobuf](https://kmcd.dev/posts/protobuf-unknown-fields/))
+- **Tesler's conservation of complexity.** Irreducible complexity lands on user,
+  app-dev, or platform-dev — push it *off the user*. ([Tesler](https://www.nomodes.com/larry-tesler-consulting/complexity-law))
+- **Hick's & Fitts's laws — useful, with caveats.** Choice time ∝ log(options);
+  acquisition time ∝ log(distance/size). Both have real HCI limits (Hick's fails for
+  familiar/automated/randomly-ordered choices; Fitts's degrades when distance and
+  size both vary widely) — heuristics, not universals. ([Hick](https://en.wikipedia.org/wiki/Hick%27s_law), [Fitts](https://en.wikipedia.org/wiki/Fitts%27s_law))
+- **Progressive disclosure (Nielsen).** Show the few important options first,
+  specialised ones on request — but **>2 disclosure levels usually hurts usability.** ([NN/g](https://www.nngroup.com/articles/progressive-disclosure/))
+- **Permission prompts habituate.** Adherence *drops* over weeks as users tune out;
+  **polymorphic (varying) warnings** resist habituation; sandboxing + signing/
+  provenance are the structural complements. ([habituation](https://misq.umn.edu/misq/article/42/2/355/1716/Tuning-Out-Security-Warnings))
+
+**For edot:** edot scores well here. **Deep modules:** the storage adapters
+(GitHub/S3/WebDAV/Solid behind one `put/get/list/remove`), `DataEngine`, the ICS
+engine, the OIDC client (injectable `fetch`) are simple interfaces over substantial
+implementations. **Lossless pass-through:** `OPENDOC.md` is explicit that SQLite
+round-trips losslessly while CSV/N-Quads are lossy — exactly the Must-Ignore honesty
+RFC 9413 asks for (state what survives). **Tesler/progressive disclosure:** the
+Save-to-GitHub redesign (cards + an "Options" disclosure, ≤2 levels), contextual
+recents/merge, long-press labels — complexity pushed off the user. **Prompt
+habituation:** relevant to the auth/permission and backup-passphrase flows — keep
+prompts rare and meaningful. The gap is **versioning discipline**: no SemVer'd
+contract for the data formats or a plugin API; Hyrum's Law says the moment anyone
+builds on edot's exports or `BroadcastChannel` payloads, those become frozen
+contracts.
+
+---
+
+## 6. Comparative table — extension models
+
+| Model | Mechanism | Isolation | Versioning story | Capability scoping | Classic failure mode |
+|---|---|---|---|---|---|
+| **OLE/OpenDoc parts** | In-place binary parts (COM/SOM) over a container/Bento | In-process | None coherent | Coarse | Part-interop collapse; perf weight ([OpenDoc](https://en.wikipedia.org/wiki/OpenDoc)) |
+| **Office COM/VSTO** | Native add-in into host object model | In-process, full trust | App-version coupled | None (full access) | Windows-only, fragile, blast radius ([transition](https://learn.microsoft.com/en-us/office/dev/add-ins/overview/learning-path-transition)) |
+| **Office.js add-in** | Manifest + hosted web app in webview | **Sandboxed iframe** | Manifest version + API requirement sets | **Permission levels** in manifest | Constrained API; stability friction ([office-js#6513](https://github.com/OfficeDev/office-js/issues/6513)) |
+| **Google CardService** | Declarative cards, host-rendered | Hosted (no client code on surface) | Platform-managed | OAuth scopes + review | Limited expressiveness ([CardService](https://developers.google.com/workspace/add-ons/concepts/card-interfaces)) |
+| **LibreOffice UNO** | Registered components + declarative add-on config | In-process | `.oxt` package versions | Coarse | Steep model; in-process ([UNO](http://www.openoffice.org/udk/common/man/componentmodel.html)) |
+| **Browser WebExtension (MV3)** | Manifest + service worker + DNR rules | **Separate process, sandboxed** | Manifest v3; store review | **permissions + host permissions** | Capability loss (no blocking webRequest) ([MV3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3)) |
+| **Android Intent / iOS Extension** | Declarative filter / extension point; separate process | **Sandboxed process** | OS API levels | **System permissions / App Groups** | Implicit-intent hijack; limited host comms ([Android](https://developer.android.com/guide/components/intents-filters)) |
+| **OSGi bundle** | Versioned bundles + service registry | In-JVM, per-bundle classloader | **SemVer, side-by-side versions** | Package import/export | Classloader/bundle hell ([OSGi](https://en.wikipedia.org/wiki/OSGi)) |
+| **Eclipse / VS Code `contributes`** | **Declarative manifest contribution**, lazy activation | In-process (VS Code: ext host process) | Engine/API version in manifest | Declared activation/when | Contribution sprawl; perf of many exts ([VS Code](https://code.visualstudio.com/api/references/contribution-points)) |
+| **edot today** | First-party web components; **BroadcastChannel/localStorage handoff**; URL-launched apps | **Separate pages**, message-passing; light-DOM in-page | **None formal** (SHA-256 fingerprint + build stamp only) | None (all first-party, same origin) | N/A yet — no 3rd-party surface |
+
+The pattern: the models that *aged well* (Office.js, WebExtensions, VS Code,
+Android) all pair **a declarative manifest** with **process/sandbox isolation** and
+**explicit capability scoping**. edot's *internal* composition already matches the
+late-bound message-passing row; what it lacks is a *contribution manifest* and (for
+any third-party future) *sandbox + capabilities*.
+
+---
+
+## 7. The durable principles (vs the fashions)
+
+**Durable (adopt):**
+1. **Open, durable data substrate; editors are replaceable views.** (Local-first,
+   ODF, OpenDoc's *surviving* idea.)
+2. **Lossless pass-through of the unknown, stated honestly** — Must-Ignore +
+   "here's what each format preserves." (RFC 9413, XML/protobuf.)
+3. **Deep modules behind stable, narrow interfaces.** (Parnas/Ousterhout.)
+4. **Declarative contribution + lazy activation** for UI surface. (Eclipse/VS Code.)
+5. **Late binding via contracts/messages; capability-scoped isolation for untrusted
+   code.** (Intents/Services/microkernel/capabilities.)
+6. **Contextual, results-oriented, progressively-disclosed UI; don't adaptively
+   hide.** (Ribbon; Tesler; Nielsen.)
+7. **Light DOM by default; shadow only where isolation pays.** (web-components consensus.)
+
+**Fashions / hazards (resist or time carefully):**
+- *Compound binary parts* and *deep object-model add-ins* (interop collapse, blast
+  radius). *Location transparency* (CORBA). *Runtime module federation across teams*
+  before you have the version-skew discipline. *Adaptive menu hiding* (IntelliMenus).
+  *Shadow DOM everywhere* (a11y/form leaks). *Permission-prompt spam* (habituation).
+  Treating *"data ages like wine"* as automatic — it needs preserved context.
+
+---
+
+## 8. Applied to edot — scorecard
+
+| Principle | edot today | Verdict |
+|---|---|---|
+| Open durable substrate | SQLite / zip-CSV / N-Quads exports, SHA-256, `OPENDOC.md`, IndexedDB-local | ✅ Strong |
+| Editors-as-faces over one object | Datasheet / Spreadsheet / RDF faces | ✅ Strong (the OpenDoc idea, de-risked) |
+| Lossless pass-through, stated | `OPENDOC.md` says what each format keeps | ✅ Good; extend to a "Must-Ignore" rule for unknown columns/quads |
+| Deep modules / narrow interfaces | storage adapters, DataEngine, ICS, OIDC (injectable fetch) | ✅ Strong |
+| Light DOM web components | Yes, throughout | ✅ Matches consensus |
+| Late-bound message passing | BroadcastChannel + localStorage handoff; URL-launched apps | ✅ Good; needs a **documented payload contract** |
+| Contextual / progressive-disclosure UI | GH dialog cards + Options; faces; long-press labels; recents/merge contextual | ✅ Good |
+| Capability-scoped isolation | First-party only; auth tokens in web storage (XSS-reachable, flagged); JWKS deferred | ⚠️ Fine for first-party; **required** before any third-party plugin or Tier-2 backup |
+| Command/action registry | **None** — hand-wired menus/toolbar | ❌ Gap |
+| Declarative contribution point | **None** | ❌ Gap (the key extensibility enabler) |
+| Versioned contract (formats / API) | Build stamp + content fingerprint only; no SemVer | ⚠️ Hyrum's-Law risk the moment anything depends on exports/handoff |
+
+---
+
+## 9. Decision: if/how edot should add extensibility
+
+Three coherent options, in increasing ambition. **Recommended: A now, design B,
+avoid C until there's a real third-party demand and a sandbox.**
+
+- **A — Internal command/action registry + declarative contribution (do first).**
+  Replace hand-wired `mi()`/`_btn` with a registry: each command = `{id, title,
+  icon, when, run}`; toolbar/menu/face-switcher *render from the registry*, with
+  `group`/`when` ordering (the VS Code/Eclipse model). This is pure first-party
+  refactor — no security surface — and it (i) tidies the current UI, (ii) makes the
+  Labels/long-press/contextual behaviour systematic, and (iii) is the *prerequisite*
+  for any future plugin. Deep module, narrow interface. Aligns with §4, §5.
+- **B — Same-origin, declarative *first-party-trusted* modules.** Let extra faces/
+  panels register against the command registry and the data object via a small,
+  **versioned** API (SemVer + a "Must-Ignore" rule so unknown contributions are
+  preserved, not dropped). Keep it same-origin/trusted for now; document the payload
+  + data-object contract (Hyrum's-Law insurance). This gets you OpenDoc's *good*
+  part (pluggable faces) without its interop collapse, because the substrate is one
+  SQLite/data object, not N binary parts negotiating formats.
+- **C — Third-party untrusted plugins.** Only with **iframe sandbox + `postMessage`
+  + explicit capability grants** (the Office.js / WebExtension / capability-security
+  model), a manifest, and a permission model designed against *habituation*
+  (rare, meaningful, ideally varying prompts; signing/provenance — edot already has
+  the SHA-256 fingerprint gesture to build on). Do **not** expose same-origin DOM/
+  data access to third-party code.
+
+Why not jump to C: every domain's history says untrusted in-process extension =
+blast radius (shell extensions) and trust friction (Office.js). Earn it with A and
+B first.
+
+---
+
+## 10. Actionable checklist & complexity budget
+
+**Extensibility checklist (apply to any new surface):**
+- [ ] Is the new capability behind a **deep, narrow interface** (hides a likely-to-change secret)?
+- [ ] Is UI contributed **declaratively** (registry/manifest) and rendered uniformly, or hand-wired again?
+- [ ] Is the contribution **contextual** (`when`) rather than adaptively hidden?
+- [ ] Is any cross-component link a **message/contract**, not an internal reference?
+- [ ] For untrusted code: **isolated** (iframe/process) + **capability-scoped** (no ambient authority)?
+- [ ] Is the data/API contract **versioned** (SemVer) and does it **pass unknown fields through unharmed**?
+- [ ] Does the export **state what it preserves vs drops** (lossless honesty)?
+- [ ] Are user-facing **prompts rare and meaningful** (anti-habituation)?
+- [ ] ≤ **2 progressive-disclosure levels**; complexity pushed off the user?
+- [ ] Light DOM unless isolation genuinely pays.
+
+**Complexity budget (the Tesler ledger):** every feature relocates complexity.
+Track *where it lands*. edot's current bet — absorb complexity into first-party deep
+modules, keep the user surface contextual and shallow — is the right one. An
+extension system *spends* budget by moving complexity onto an API contract and an
+ecosystem; only spend it when the user value (third-party faces/connectors) exceeds
+the permanent maintenance + Hyrum's-Law cost.
+
+---
+
+## 11. Open questions
+
+1. **Does edot want third-party extensibility at all, or "maximal first-party
+   coherence"?** (Conceptual integrity argues a curated suite may beat an open
+   plugin bazaar for this product.)
+2. **What is the canonical "data object" contract** that faces/plugins bind to —
+   the SQLite schema? a normalized internal model? This is the OpenDoc
+   "format-interop" question; answering it once, centrally, is what avoids the
+   collapse.
+3. **Versioning policy** for exports and `BroadcastChannel`/handoff payloads —
+   adopt SemVer + a documented Must-Ignore rule *before* external dependence forms.
+4. **Where does the Tier-2 capability service live** (the OIDC-gated key release) —
+   the same backend would also unlock untrusted-plugin capability grants and the ICS
+   CORS proxy. One small trusted service, three payoffs.
+5. **Sandbox technology** if/when C: iframe + `postMessage` vs Web Workers vs the
+   emerging `ShadowRealm` — each with different DOM/capability tradeoffs.
+
+---
+
+## 12. Consolidated sources
+
+Office/compound docs: [OpenDoc](https://en.wikipedia.org/wiki/OpenDoc) · [OLE](https://en.wikipedia.org/wiki/Object_Linking_and_Embedding) · [instadeq OpenDoc postmortem](https://instadeq.com/blog/posts/why-opendoc-failed-and-then-failed-3-more-times/) · [Office add-ins](https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins) · [VSTO→Office.js](https://learn.microsoft.com/en-us/office/dev/add-ins/overview/learning-path-transition) · [office-js#6513](https://github.com/OfficeDev/office-js/issues/6513) · [Ribbon](https://en.wikipedia.org/wiki/Ribbon_(computing)) · [uxweek08 Ribbon notes](https://www.jurecuhalev.com/blog/jensen-harris-the-story-of-the-ribbon-office-2007-uxweek08-notes/) · [Designing the Ribbon](https://jensenharris.com/home/ribbon)
+
+Substrates/declarative: [UNO component model](http://www.openoffice.org/udk/common/man/componentmodel.html) · [UNO](https://en.wikipedia.org/wiki/Universal_Network_Objects) · [OpenDocument](https://en.wikipedia.org/wiki/OpenDocument) · [CardService card interfaces](https://developers.google.com/workspace/add-ons/concepts/card-interfaces) · [Google restricted-scope verification](https://developers.google.com/identity/protocols/oauth2/production-readiness/restricted-scope-verification) · [Local-first software](https://www.inkandswitch.com/essay/local-first/) · [Kleppmann local-first PDF](https://martin.kleppmann.com/papers/local-first.pdf) · ["ages like fish" counterpoint](https://infusedinnovations.com/blog/secure-intelligent-workplace/data-ages-like-fish-not-like-wine-a-fresh-take-on-data-management)
+
+OS/shell/security: [MS shell + managed code](https://learn.microsoft.com/en-us/windows/win32/shell/shell-and-managed-code) · [Chrome MV3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3) · [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest) · [EFF on MV3](https://www.eff.org/deeplinks/2021/12/chrome-users-beware-manifest-v3-deceitful-and-threatening) · [Android intents/filters](https://developer.android.com/guide/components/intents-filters) · [iOS App Extensions](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html) · [macOS Services](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/SysServices/Articles/properties.html) · [Microkernel](https://en.wikipedia.org/wiki/Microkernel) · [Capability-based security](https://en.wikipedia.org/wiki/Capability-based_security)
+
+Components/modules: [COM](https://en.wikipedia.org/wiki/Component_Object_Model) · [IUnknown](https://en.wikipedia.org/wiki/IUnknown) · [CORBA](https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture) · [OSGi](https://en.wikipedia.org/wiki/OSGi) · [JAR hell](https://en.wikipedia.org/wiki/Java_Classloader) · [MDN Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM) · [Shadow DOM pros/cons](https://www.matuzo.at/blog/2023/pros-and-cons-of-shadow-dom/) · [HTML web components / light DOM](https://scottjehl.com/posts/html-web-components-shadow-dom/) · [Module Federation](https://webpack.js.org/concepts/module-federation/) · [MF version skew](https://microfrontend.dev/architecture/webpack-module-federation/) · [Islands](https://docs.astro.build/en/concepts/islands/) · [Eclipse plug-in architecture](https://www.eclipse.org/articles/Article-Plug-in-architecture/plugin_architecture.html) · [VS Code contributes](https://code.visualstudio.com/api/references/contribution-points) · [IoC via events](https://www.cshark.com/inversion-of-control-2-decoupling-through-events/) · [ECS](https://en.wikipedia.org/wiki/Entity_component_system)
+
+Principles: [Parnas 1972 (MIT mirror)](http://sunnyday.mit.edu/16.355/parnas-criteria.html) · [Ousterhout PoSD](https://milkov.tech/assets/psd.pdf) · [Deep modules](https://softengbook.org/articles/deep-modules) · [No Silver Bullet](https://en.wikipedia.org/wiki/No_Silver_Bullet) · [Mythical Man-Month](https://en.wikipedia.org/wiki/The_Mythical_Man-Month) · [Hyrum's Law](https://www.hyrumslaw.com/) · [RFC 9413](https://www.rfc-editor.org/rfc/rfc9413.html) · [XML Must-Ignore](https://www.xml.com/pub/a/2004/07/21/design.html) · [Protobuf unknown fields](https://kmcd.dev/posts/protobuf-unknown-fields/) · [Tesler's Law](https://www.nomodes.com/larry-tesler-consulting/complexity-law) · [Hick's Law](https://en.wikipedia.org/wiki/Hick%27s_law) · [Fitts's Law](https://en.wikipedia.org/wiki/Fitts%27s_law) · [Progressive disclosure (NN/g)](https://www.nngroup.com/articles/progressive-disclosure/) · [Warning habituation (MISQ/BYU)](https://misq.umn.edu/misq/article/42/2/355/1716/Tuning-Out-Security-Warnings)
+
+---
+
+*Method note: five parallel research passes fetched primary sources (papers,
+official docs, postmortems) and flagged contested claims; this synthesis preserves
+those flags. Inaccessible primaries (Henning's "Rise and Fall of CORBA" 403; the
+verbatim Parnas PDF; one EFF page 404) are noted where their claims are load-bearing.
+The edot-applied analysis (§§ 1–11 "For edot" / scorecard / options / checklist) is
+the report author's architectural assessment of the current codebase, not a cited
+external claim.*

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -28,14 +28,8 @@
         <button type="button" id="mi-new" class="menu-item" role="menuitem">
           <span>New document</span><span class="hint">Ctrl/⌘N</span>
         </button>
-        <button type="button" id="mi-open" class="menu-item" role="menuitem">
-          <span>Open file…</span><span class="hint">Ctrl/⌘O</span>
-        </button>
-        <button type="button" id="mi-url" class="menu-item" role="menuitem">
-          <span>Open from URL…</span><span class="hint">git-aware</span>
-        </button>
-        <button type="button" id="mi-examples" class="menu-item" role="menuitem" aria-haspopup="dialog">
-          <span>Examples…</span>
+        <button type="button" id="mi-open" class="menu-item" role="menuitem" aria-haspopup="dialog">
+          <span>Open…</span><span class="hint">Examples · Research · file · URL</span>
         </button>
         <button type="button" id="mi-docs" class="menu-item" role="menuitem">
           <span>My documents…</span><span class="hint">Ctrl/⌘⇧O</span>
@@ -122,13 +116,19 @@
     </div>
   </dialog>
 
-  <!-- Examples -->
-  <dialog id="examples-dialog" class="dialog" aria-labelledby="examples-dialog-title">
+  <!-- Open: a hierarchy of Examples, Research, plus file / URL openers -->
+  <dialog id="open-dialog" class="dialog" aria-labelledby="open-dialog-title">
     <form method="dialog" class="dialog-head">
-      <h2 id="examples-dialog-title">Examples</h2>
+      <h2 id="open-dialog-title">Open</h2>
       <button type="submit" class="tbtn" aria-label="Close">✕</button>
     </form>
-    <ul id="examples-list" class="docs-list"></ul>
+    <div class="dialog-body">
+      <div class="open-actions">
+        <button type="button" id="open-from-file" class="tbtn">📄 From a file…</button>
+        <button type="button" id="open-from-url" class="tbtn">🔗 From a URL…</button>
+      </div>
+      <edot-tree id="open-tree" aria-label="Examples and research"></edot-tree>
+    </div>
   </dialog>
 
   <!-- View source: the underlying file in each text format -->

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -10,6 +10,7 @@ import { FindReplace } from './find-replace.js';
 import { Attention } from './attention.js';
 import { resolveSourceUrl, filenameFromUrl } from './open-url.js';
 import { EXAMPLES } from './examples.js';
+import './tree.js';
 import { GitHubRemote, commitViaPullRequest } from './git-remote.js';
 import { diffLines, diffStats, collapse } from './diff.js';
 import * as IO from './io.js';
@@ -17,7 +18,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-23.g';
+const BUILD = '2026-06-23.h';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token
@@ -62,7 +63,7 @@ class App {
     this._wireTitle();
     this._wireDialog();
     this._wireUrlDialog();
-    this._wireExamplesDialog();
+    this._wireOpenDialog();
     this._wireGithubDialog();
     this._wireSourceDialog();
     this._wireGlobalKeys();
@@ -213,9 +214,7 @@ class App {
 
     const mi = (id, fn) => document.getElementById(id).addEventListener('click', () => { this._closeMenu(); fn(); });
     mi('mi-new', () => this.newDocument());
-    mi('mi-open', () => this.fileInput.click());
-    mi('mi-url', () => this.openUrlDialog());
-    mi('mi-examples', () => this.openExamplesDialog());
+    mi('mi-open', () => this.openOpenDialog());
     mi('mi-docs', () => this.openLibrary());
     mi('mi-close', () => this.closeDocument());
     mi('mi-find', () => this.findReplace.open(true));
@@ -305,26 +304,44 @@ class App {
     await this.openFromUrl(value);
   }
 
-  // ---- Examples dialog ----
-  _wireExamplesDialog() {
-    this.examplesDialog = document.getElementById('examples-dialog');
-    const list = document.getElementById('examples-list');
-    for (const ex of EXAMPLES) {
-      const li = document.createElement('li');
-      li.className = 'doc-row';
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'doc-open';
-      btn.innerHTML = `<span class="doc-name">${esc(ex.title)}</span>` +
-        (ex.note ? `<span class="doc-note">${esc(ex.note)}</span>` : '') +
-        (ex.credit ? `<span class="doc-note">${esc(ex.credit)}</span>` : '');
-      btn.addEventListener('click', () => { this.examplesDialog.close(); this.openExample(ex); });
-      li.appendChild(btn);
-      list.appendChild(li);
-    }
+  // ---- Open dialog: Examples / Research hierarchy + file/URL openers ----
+  _wireOpenDialog() {
+    this.openDialog = document.getElementById('open-dialog');
+    this.openTree = document.getElementById('open-tree');
+    document.getElementById('open-from-file').addEventListener('click', () => { this.openDialog.close(); this.fileInput.click(); });
+    document.getElementById('open-from-url').addEventListener('click', () => { this.openDialog.close(); this.openUrlDialog(); });
   }
 
-  openExamplesDialog() { showModal(this.examplesDialog); }
+  async openOpenDialog() {
+    const close = () => this.openDialog.close();
+    const exNodes = EXAMPLES.map((ex) => ({
+      label: ex.title, note: ex.note,
+      onActivate: () => { close(); this.openExample(ex); },
+    }));
+    const research = await this._loadResearch();
+    const reNodes = research.length
+      ? research.map((r) => ({
+        label: r.title, note: r.note,
+        onActivate: () => { close(); this.openExample({ title: r.title, src: `docs/research/${r.file}`, local: true }); },
+      }))
+      : [{ label: '(no research documents yet)', note: 'Add markdown to docs/research/ and list it in index.json' }];
+    this.openTree.setData([
+      { label: 'Examples', icon: '📚', expanded: true, children: exNodes },
+      { label: 'Research', icon: '🔬', expanded: false, children: reNodes },
+    ]);
+    showModal(this.openDialog);
+  }
+
+  // Load the research manifest (docs/research/index.json) once, best-effort.
+  async _loadResearch() {
+    if (this._research) return this._research;
+    try {
+      const resp = await fetch('docs/research/index.json');
+      const json = await resp.json();
+      this._research = Array.isArray(json.docs) ? json.docs : [];
+    } catch { this._research = []; }
+    return this._research;
+  }
 
   // ---- Save to GitHub (branch + pull request) ----
   _wireGithubDialog() {

--- a/magpie/edot/js/tree.js
+++ b/magpie/edot/js/tree.js
@@ -1,0 +1,97 @@
+// tree.js — <edot-tree>: a reusable, accessible, collapsible disclosure tree for
+// deep hierarchies (the "clicky open/closey" widget). Light DOM so it shares the
+// page stylesheet, like edot's other components. Folders expand/collapse on click;
+// leaves invoke an `onActivate` callback. ARIA tree semantics + roving-focus
+// keyboard nav (Up/Down between visible rows, Right/Left expand/collapse,
+// Enter/Space activate, Home/End).
+//
+// Data shape — setData(nodes), where each node is:
+//   { label, icon?, note?, expanded?, children?: [node…], onActivate?: () => void }
+// A node with `children` renders as a folder; otherwise it's an activatable leaf.
+
+export class EdotTree extends HTMLElement {
+  setData(nodes) { this._nodes = nodes || []; this._render(); }
+
+  connectedCallback() { if (!this._built) this._render(); }
+
+  _render() {
+    this._built = true;
+    this.innerHTML = '';
+    const root = document.createElement('ul');
+    root.className = 'tree'; root.setAttribute('role', 'tree');
+    (this._nodes || []).forEach((n) => root.appendChild(this._node(n, 1)));
+    this.appendChild(root);
+    this.addEventListener('keydown', (e) => this._onKey(e));
+    // Roving focus: exactly one row is tab-focusable at a time.
+    const rows = this._allRows();
+    rows.forEach((r, i) => { r.tabIndex = i === 0 ? 0 : -1; });
+  }
+
+  _node(n, level) {
+    const li = document.createElement('li');
+    li.setAttribute('role', 'none');
+    const isFolder = Array.isArray(n.children);
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'tree-row ' + (isFolder ? 'tree-folder' : 'tree-leaf');
+    row.setAttribute('role', 'treeitem');
+    row.setAttribute('aria-level', String(level));
+
+    if (isFolder) {
+      const tw = document.createElement('span'); tw.className = 'tree-twisty';
+      tw.textContent = n.expanded ? '▾' : '▸'; tw.setAttribute('aria-hidden', 'true');
+      row.appendChild(tw);
+    }
+    if (n.icon) { const ic = document.createElement('span'); ic.className = 'tree-icon'; ic.textContent = n.icon; ic.setAttribute('aria-hidden', 'true'); row.appendChild(ic); }
+    const lab = document.createElement('span'); lab.className = 'tree-label'; lab.textContent = n.label; row.appendChild(lab);
+    if (n.note) { const nt = document.createElement('span'); nt.className = 'tree-note'; nt.textContent = n.note; row.appendChild(nt); }
+    li.appendChild(row);
+
+    if (isFolder) {
+      const group = document.createElement('ul'); group.className = 'tree-group'; group.setAttribute('role', 'group');
+      n.children.forEach((c) => group.appendChild(this._node(c, level + 1)));
+      row.setAttribute('aria-expanded', String(!!n.expanded));
+      group.hidden = !n.expanded;
+      li.appendChild(group);
+      row.addEventListener('click', () => this._toggle(row, group));
+    } else {
+      row.addEventListener('click', () => { if (typeof n.onActivate === 'function') n.onActivate(); });
+    }
+    return li;
+  }
+
+  _toggle(row, group) {
+    const open = row.getAttribute('aria-expanded') === 'true';
+    row.setAttribute('aria-expanded', String(!open));
+    group.hidden = open;
+    const tw = row.querySelector('.tree-twisty'); if (tw) tw.textContent = open ? '▸' : '▾';
+  }
+
+  // All rows, document order; visible rows are those with a laid-out ancestor.
+  _allRows() { return [...this.querySelectorAll('.tree-row')]; }
+  _visibleRows() { return this._allRows().filter((r) => r.offsetParent !== null); }
+
+  _focus(row) {
+    this._allRows().forEach((r) => { r.tabIndex = -1; });
+    row.tabIndex = 0; row.focus();
+  }
+
+  _onKey(e) {
+    const rows = this._visibleRows();
+    const i = rows.indexOf(document.activeElement);
+    if (i < 0) return;
+    const row = rows[i];
+    const expanded = row.getAttribute('aria-expanded');
+    if (e.key === 'ArrowDown') { e.preventDefault(); this._focus(rows[i + 1] || rows[0]); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); this._focus(rows[i - 1] || rows[rows.length - 1]); }
+    else if (e.key === 'ArrowRight') { e.preventDefault(); if (expanded === 'false') row.click(); else if (rows[i + 1]) this._focus(rows[i + 1]); }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); if (expanded === 'true') row.click(); }
+    else if (e.key === 'Home') { e.preventDefault(); this._focus(rows[0]); }
+    else if (e.key === 'End') { e.preventDefault(); this._focus(rows[rows.length - 1]); }
+    else if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); row.click(); }
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('edot-tree')) {
+  customElements.define('edot-tree', EdotTree);
+}

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -116,10 +116,19 @@ try {
   }));
   await page.keyboard.press('Escape');
 
-  // Examples dialog lists and loads the Morton book (same-origin docx import).
-  await page.click('#menu-button'); await page.click('#mi-examples'); await page.waitForTimeout(150);
-  ok('examples dialog lists the Morton book', await page.isVisible('text=Searching for Logic'));
-  await page.click('.doc-open:has-text("Searching for Logic")');
+  // Open dialog: a tree of Examples + Research. Examples is expanded by default.
+  await page.click('#menu-button'); await page.click('#mi-open'); await page.waitForTimeout(200);
+  ok('Open dialog lists the Morton example under Examples', await page.isVisible('.tree-leaf:has-text("Searching for Logic")'));
+  ok('Open dialog has a Research folder', await page.isVisible('.tree-folder:has-text("Research")'));
+  // The Research folder is collapsed; clicking it reveals the deep-dive report.
+  ok('Research folder is collapsed initially', await page.evaluate(() => {
+    const f = [...document.querySelectorAll('.tree-folder')].find((b) => /Research/.test(b.textContent));
+    return f && f.getAttribute('aria-expanded') === 'false';
+  }));
+  await page.click('.tree-folder:has-text("Research")'); await page.waitForTimeout(120);
+  ok('Research folder expands to the deep-dive report', await page.isVisible('.tree-leaf:has-text("deep-dive")'));
+  // Load the Morton example from the Examples folder.
+  await page.click('.tree-leaf:has-text("Searching for Logic")');
   await page.waitForFunction(() => /Searching for Logic|searching for logic/i.test(document.getElementById('editor').textContent), null, { timeout: 20000 });
   ok('example loaded with tables', await page.evaluate(() => document.querySelectorAll('#editor table').length > 5));
   ok('example title set', /logic/i.test(await page.inputValue('#doc-title')));
@@ -129,8 +138,9 @@ try {
   ok('close yields an empty document', (await page.textContent('#stat-words')).startsWith('0'));
   ok('close titles it Untitled', /Untitled/.test(await page.inputValue('#doc-title')));
 
-  // Open-from-URL dialog: opens and validates bad input.
-  await page.click('#menu-button'); await page.click('#mi-url'); await page.waitForTimeout(150);
+  // Open-from-URL: reached via Open… ▸ "From a URL…"; validates bad input.
+  await page.click('#menu-button'); await page.click('#mi-open'); await page.waitForTimeout(150);
+  await page.click('#open-from-url'); await page.waitForTimeout(150);
   ok('url dialog opens', await page.isVisible('#url-input'));
   await page.fill('#url-input', 'not a url');
   await page.click('#url-open'); await page.waitForTimeout(100);


### PR DESCRIPTION
- Adds the UI-architecture research deep-dive at `magpie/edot/docs/research/ui-architecture-deepdive.md` (+ `index.json` manifest).
- New reusable **`<edot-tree>`** (`js/tree.js`): an accessible, collapsible "clicky open/closey" disclosure tree for deep hierarchies — ARIA tree roles, roving-focus keyboard nav, folder expand/collapse, leaf activation callback.
- Restructures the File menu's open cluster into a single **"Open…"** dialog hosting the tree: **Examples** (expanded) and **Research** folders, plus "From a file…" / "From a URL…" actions. Research `.md`s load into the editor via the existing `openExample` pipeline; adding docs is a data-only change (drop the file + list it in `index.json`).
- e2e updated to drive the tree. smoke + e2e + mobile green; HTML validates. Build stamp → `2026-06-23.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_