### PR TITLE
edot: GFM table parsing in the Markdown importer

### DIFF
--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -18,7 +18,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-23.h';
+const BUILD = '2026-06-23.i';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token

--- a/magpie/edot/js/io-markdown.js
+++ b/magpie/edot/js/io-markdown.js
@@ -77,11 +77,26 @@ export function markdownToHtml(md) {
       continue;
     }
 
+    // GFM table: a header row followed by a delimiter row (|---|:--:|). Must
+    // contain a pipe so a bare "text" line above "---" stays a paragraph/hr.
+    if (line.includes('|') && i + 1 < lines.length && isDelimiterRow(lines[i + 1])) {
+      const header = splitRow(line);
+      const aligns = splitRow(lines[i + 1]).map(alignOf);
+      i += 2;
+      const body = [];
+      while (i < lines.length && lines[i].includes('|') && lines[i].trim() !== '') {
+        body.push(splitRow(lines[i])); i++;
+      }
+      out.push(renderTable(header, aligns, body));
+      continue;
+    }
+
     // Paragraph: gather until blank line
     const buf = [line];
     i++;
     while (i < lines.length && !/^\s*$/.test(lines[i]) &&
-           !/^(#{1,6}\s|```|\s*>|\s*([-*+]|\d+\.)\s)/.test(lines[i])) {
+           !/^(#{1,6}\s|```|\s*>|\s*([-*+]|\d+\.)\s)/.test(lines[i]) &&
+           !(lines[i].includes('|') && i + 1 < lines.length && isDelimiterRow(lines[i + 1]))) {
       buf.push(lines[i]); i++;
     }
     out.push(`<p>${inline(buf.join(' '))}</p>`);
@@ -89,6 +104,47 @@ export function markdownToHtml(md) {
 
   return sanitizeHtml(out.join('\n'));
 }
+
+// ---- GFM tables ----
+// Split a pipe row into trimmed cells, honouring escaped \| and optional outer pipes.
+function splitRow(line) {
+  const cells = []; let cur = '';
+  const s = line.trim();
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '\\' && s[i + 1] === '|') { cur += '|'; i++; continue; }
+    if (s[i] === '|') { cells.push(cur); cur = ''; continue; }
+    cur += s[i];
+  }
+  cells.push(cur);
+  if (cells.length && cells[0].trim() === '') cells.shift();
+  if (cells.length && cells[cells.length - 1].trim() === '') cells.pop();
+  return cells.map((c) => c.trim());
+}
+
+// A delimiter row's cells are each like ---, :--, --:, :-:.
+function isDelimiterRow(line) {
+  if (!/[|-]/.test(line)) return false;
+  const cells = splitRow(line);
+  return cells.length > 0 && cells.every((c) => /^:?-+:?$/.test(c));
+}
+
+function alignOf(cell) {
+  const l = cell.startsWith(':'), r = cell.endsWith(':');
+  return l && r ? 'center' : r ? 'right' : l ? 'left' : '';
+}
+
+function renderTable(header, aligns, body) {
+  const sty = (a) => (a ? ` style="text-align:${a}"` : '');
+  const head = header.map((h, c) => `<th${sty(aligns[c])}>${inline(h)}</th>`).join('');
+  let html = `<table><thead><tr>${head}</tr></thead><tbody>`;
+  for (const row of body) {
+    let tds = '';
+    for (let c = 0; c < header.length; c++) tds += `<td${sty(aligns[c])}>${inline(row[c] || '')}</td>`;
+    html += `<tr>${tds}</tr>`;
+  }
+  return `${html}</tbody></table>`;
+}
+
 
 export function htmlToMarkdown(html) {
   const doc = new DOMParser().parseFromString(html, 'text/html');

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -127,7 +127,13 @@ try {
   }));
   await page.click('.tree-folder:has-text("Research")'); await page.waitForTimeout(120);
   ok('Research folder expands to the deep-dive report', await page.isVisible('.tree-leaf:has-text("deep-dive")'));
-  // Load the Morton example from the Examples folder.
+  // Load the research markdown — its GFM tables must now render as real tables.
+  await page.click('.tree-leaf:has-text("deep-dive")');
+  await page.waitForFunction(() => /Extensibility|Executive summary/i.test(document.getElementById('editor').textContent), null, { timeout: 20000 });
+  ok('research markdown loads into the editor', /Extensibility|complexity/i.test(await page.textContent('#editor')));
+  ok('GFM tables render as real tables', await page.evaluate(() => document.querySelectorAll('#editor table').length >= 2));
+  // Reopen the Open dialog and load the Morton example from the Examples folder.
+  await page.click('#menu-button'); await page.click('#mi-open'); await page.waitForTimeout(200);
   await page.click('.tree-leaf:has-text("Searching for Logic")');
   await page.waitForFunction(() => /Searching for Logic|searching for logic/i.test(document.getElementById('editor').textContent), null, { timeout: 20000 });
   ok('example loaded with tables', await page.evaluate(() => document.querySelectorAll('#editor table').length > 5));


### PR DESCRIPTION
`markdownToHtml()` now parses GitHub-flavoured tables (pipe header + `|---|:--:|` delimiter + body rows) into real `<table>/<thead>/<tbody>` with per-column `text-align` from the delimiter. Honours escaped `\|` and optional outer pipes; pads/truncates rows to header width. So the research deep-dive (and any `.md` with tables) renders properly in-editor instead of raw `| … |`.

e2e loads the research markdown and asserts its tables render. smoke + e2e + mobile green. Build stamp → `2026-06-23.i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_