### PR TITLE
edot: slides presentation app (author/edit/present + PPTX/ODP/PDF/HTML codecs)

### DIFF
--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -49,6 +49,9 @@
         <button type="button" id="mi-data" class="menu-item" role="menuitem">
           <span>Data workspace ↗</span><span class="hint">SQLite</span>
         </button>
+        <button type="button" id="mi-slides" class="menu-item" role="menuitem">
+          <span>Slides ↗</span><span class="hint">present</span>
+        </button>
         <button type="button" id="mi-calendar" class="menu-item" role="menuitem">
           <span>Calendar ↗</span><span class="hint">ICS</span>
         </button>

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -18,7 +18,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-23.i';
+const BUILD = '2026-06-23.j';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token
@@ -231,6 +231,7 @@ class App {
       this.attention.arm('Back to edot', { once: true });
     };
     mi('mi-data', () => openApp('data/data.html'));
+    mi('mi-slides', () => openApp('slides/slides.html'));
     mi('mi-calendar', () => openApp('calendar/calendar.html'));
     mi('mi-maps', () => openApp('maps/maps.html'));
     mi('mi-login', () => openApp('auth/login.html'));

--- a/magpie/edot/slides/README.md
+++ b/magpie/edot/slides/README.md
@@ -1,0 +1,99 @@
+# edot slides
+
+An accessible, mobile-first slide-presentation app (author + edit + present)
+for the edot suite. Entry point: **`slides.html`** hosting `<edot-slides>`.
+
+Vanilla ES modules, light-DOM Web Components, a shared CSS file, no runtime CDN
+or WASM dependencies. Reuses the repo's offline ZIP layer (`../js/zip.js`,
+native `CompressionStream`) for PPTX/ODP and follows `../js/io-pdf.js`'s
+hand-rolled approach for PDF. Decks persist to IndexedDB (its own
+`edot-slides` database), mirroring the idb helper pattern in
+`../data/data-engine.js`. Only the user's own decks are stored, locally.
+
+## The canonical "core"
+
+The deck is plain JSON; everything else (PPTX / ODP / PDF / HTML / PNG) is
+*derived* from it. Element positions are normalized 0..1 of the slide W×H
+(16:9 default).
+
+```
+{ version, id, title, theme, mtime, slides:[
+  { id, layout, background, notes, elements:[
+    { type:'text',  x,y,w,h, role?, runs:[{text, bold?, italic?, level?}] } |
+    { type:'image', x,y,w,h, dataUrl, alt } |
+    { type:'shape', x,y,w,h, shape:'rect'|'ellipse'|'line', fill, stroke }
+  ] }
+] }
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `slides.html` | Entry page; hosts `<edot-slides>`, links back to the editor. |
+| `slides.css` | Shared light-DOM stylesheet; mobile-first, dark-mode aware. |
+| `slides-model.js` | Canonical deck core: factories, layouts, themes, normalization. |
+| `slides-store.js` | IndexedDB persistence (save/load/list/delete decks). |
+| `slides-formats.js` | All codecs: JSON, PPTX (im/ex), ODP (im/ex), PDF, HTML, PNG/SVG. |
+| `slides-app.js` | `<edot-slides>` component: rail, editor, present mode, file menu. |
+| `test-slides.mjs` | Headless Chromium test harness (run `node test-slides.mjs`). |
+
+`window.__slides` exposes `{ EdotSlides, formats, store, model, el }` as the
+headless-test hook.
+
+## Features
+
+**Authoring / editing (full):** thumbnail rail (select; reorder up/down;
+add / duplicate / delete); five layouts (Title, Title+Content, Two-Column,
+Section, Blank); in-place contenteditable title/body editing with bold/italic
+and bullet indent levels; insert image (file → dataURL); rect/ellipse/line
+shapes; per-slide background color; per-slide speaker notes; four themes.
+
+**Editing (partial / by-design):** the editor is layout-driven (you edit the
+title/body/notes placeholders and add image/shape elements), **not** a full
+freeform drag-resize DTP canvas — that was explicitly de-prioritized in the
+brief. Elements have fixed layout positions; reorder is via buttons (no drag).
+
+**Present mode (full):** fullscreen overlay; next/prev via arrow keys,
+click/tap (left third = back), and swipe; live slide counter; `Esc` exits;
+`Home`/`End` jump. A presenter view (current + next + notes + timer) is **not**
+built (noted as a bonus in the brief).
+
+## Fidelity matrix — be honest, not 100%
+
+| Format | Import | Export | Survives | Dropped / approximated |
+|--------|:------:|:------:|----------|------------------------|
+| **JSON** (native) | ✅ | ✅ | **Everything — lossless.** The core itself. | — |
+| **PPTX** | ✅ best-effort | ✅ best-effort | Titles, body bullet text (bold/italic, indent level), images, speaker notes, slide order, 16:9 size. Import also reads element positions (xfrm). | **Animations, transitions, charts, SmartArt, tables, exact theme/fonts, master/layout placeholders, freeform/grouped shapes.** Export ships one generic blank layout + minimal master/theme. Import infers title vs body from `ph type`; layout id is not preserved. PDF-style precise text autofit is not reproduced. |
+| **ODP** | ✅ best-effort | ✅ best-effort | Title + body text, notes, images, simple shapes (rect/ellipse/line), positions. | Theming/master styles approximate; bullet levels and bold are minimally mapped; no transitions/animations/charts. |
+| **PDF** | — (terminal) | ✅ | One page per slide; background color, title/body text (bold/italic, bullet markers, indent), shape outlines. Page = 16:9 (720×405pt). | **Not re-importable.** Images render as gray placeholder boxes (no PNG/JPEG XObject pipeline here); ellipses drawn as rectangles; non-WinAnsi chars → `?`. |
+| **HTML** | — (terminal) | ✅ | Single self-contained file: every slide, theme colors/font, images (inline data URLs), shapes, notes (toggle with `n`); keyboard + click + swipe nav; print = one slide per page. | **Not re-importable.** No editing. |
+| **PNG** | — | ✅ (per slide) | Current slide rasterized via SVG→canvas at requested width. | Browser-only (needs canvas); fonts depend on the rendering environment. |
+| **Keynote `.key`** | ❌ | ❌ | — | Out of scope (proprietary/undocumented). Interop with Keynote is via PPTX or PDF. |
+
+**Determinism:** generated ZIPs (PPTX/ODP) zero all mod-times (via `zip.js`),
+so repeated exports of the same deck are byte-identical (asserted in the test).
+
+## Known limits / caveats
+
+- PPTX/ODP exports declare a single minimal slide layout + master + theme.
+  PowerPoint / LibreOffice Impress open them and show the text/images/notes,
+  but will not show edot's theme as a native theme — colors are best-effort.
+- PPTX import classifies the **first** `title`/`ctrTitle` placeholder as the
+  title and everything else with text as body; decks authored elsewhere with
+  unusual placeholder structures may import their text but flatten layout.
+- The PDF embeds no raster images by design (keeps the file dependency-free and
+  small); use HTML or PNG export when images must appear.
+- Headless tests check DOM/logic/format-bytes, not pixels (per CLAUDE.md, the
+  remote Chromium's canvas/WebGL is limited).
+
+## Running the tests
+
+```
+node magpie/edot/slides/test-slides.mjs
+```
+
+Drives the real `<edot-slides>` in headless Chromium and exits non-zero on any
+failure. Covers deck CRUD + IndexedDB reload, JSON round-trip, PPTX
+export-validity + round-trip (text/notes/images), ODP round-trip, present-mode
+navigation (programmatic + real keydown), and PDF/HTML export shape.

--- a/magpie/edot/slides/slides-app.js
+++ b/magpie/edot/slides/slides-app.js
@@ -1,0 +1,687 @@
+// slides-app.js — <edot-slides>: authoring, editing, and presenting decks.
+//
+// Light-DOM custom element (customElements.define), shared CSS (slides.css),
+// vanilla ES modules, no globals beyond the window.__slides test hook. Follows
+// the edot conventions (mobile-first, accessible, graceful fallbacks).
+//
+// The component is a thin controller over the canonical deck core
+// (slides-model.js): every edit mutates `this.deck`, re-renders the affected
+// panel, and debounce-persists to IndexedDB (slides-store.js). Exports/imports
+// route through the codecs in slides-formats.js.
+
+import {
+  newDeck, newSlide, cloneSlide, themeOf, THEMES, LAYOUTS,
+  layoutElements, slideTitle, runsText, bulletLines, elementByRole, normalizeDeck,
+} from './slides-model.js';
+import { saveDeck, loadDeck, listDecks, deleteDeck } from './slides-store.js';
+import * as fmt from './slides-formats.js';
+
+const LAYOUT_LABELS = {
+  title: 'Title', 'title-content': 'Title + Content', 'two-column': 'Two-Column',
+  section: 'Section header', blank: 'Blank',
+};
+
+export class EdotSlides extends HTMLElement {
+  constructor() {
+    super();
+    this.deck = null;
+    this.current = 0;       // selected slide index (edit mode)
+    this.presenting = false;
+    this.presentIndex = 0;
+    this._saveTimer = null;
+    this._timerStart = 0;
+  }
+
+  async connectedCallback() {
+    if (this._built) return;
+    this._built = true;
+    // Resume the most recent deck if one exists; else start fresh.
+    const list = await listDecks().catch(() => []);
+    this.deck = list.length ? await loadDeck(list[0].id) : null;
+    if (!this.deck) { this.deck = newDeck(); await saveDeck(this.deck); }
+    this.deck = normalizeDeck(this.deck);
+    this._render();
+  }
+
+  // ---- persistence (debounced, mirrors data-engine._touch) ----
+  _touch() {
+    this.deck.mtime = Date.now();
+    clearTimeout(this._saveTimer);
+    this._saveTimer = setTimeout(() => saveDeck(this.deck).catch(() => {}), 400);
+  }
+  async _saveNow() { clearTimeout(this._saveTimer); await saveDeck(this.deck); }
+
+  get slide() { return this.deck.slides[this.current]; }
+
+  // ===================================================================
+  // Rendering
+  // ===================================================================
+  _render() {
+    this.innerHTML = '';
+    const root = document.createElement('div');
+    root.className = 'sl-app';
+    root.append(this._toolbar(), this._rail(), this._editorPanel(), this._inspector());
+    this.append(root);
+    this._root = root;
+    this._renderRail();
+    this._renderEditor();
+  }
+
+  _btn(label, onClick, opts = {}) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'sl-btn' + (opts.primary ? ' primary' : '');
+    b.textContent = label;
+    if (opts.title) b.title = opts.title;
+    if (opts.aria) b.setAttribute('aria-label', opts.aria);
+    b.addEventListener('click', onClick);
+    return b;
+  }
+
+  _toolbar() {
+    const tb = document.createElement('div');
+    tb.className = 'sl-toolbar';
+
+    const title = document.createElement('input');
+    title.className = 'sl-title';
+    title.value = this.deck.title;
+    title.setAttribute('aria-label', 'Deck title');
+    title.addEventListener('input', () => { this.deck.title = title.value; this._touch(); });
+    this._titleInput = title;
+
+    const addLayout = document.createElement('select');
+    addLayout.className = 'sl-select';
+    addLayout.setAttribute('aria-label', 'New slide layout');
+    for (const l of LAYOUTS) { const o = document.createElement('option'); o.value = l; o.textContent = LAYOUT_LABELS[l]; addLayout.append(o); }
+    addLayout.value = 'title-content';
+    this._layoutSelect = addLayout;
+
+    const theme = document.createElement('select');
+    theme.className = 'sl-select';
+    theme.setAttribute('aria-label', 'Theme');
+    for (const [id, t] of Object.entries(THEMES)) { const o = document.createElement('option'); o.value = id; o.textContent = t.name; theme.append(o); }
+    theme.value = this.deck.theme;
+    theme.addEventListener('change', () => { this.deck.theme = theme.value; this._touch(); this._renderRail(); this._renderEditor(); });
+
+    const menu = this._menu();
+
+    tb.append(
+      this._btn('☰', () => this._root.classList.toggle('rail-open'), { aria: 'Toggle slide list' }),
+      title,
+      this._btn('+ Slide', () => this.addSlide(this._layoutSelect.value), { title: 'Add slide' }),
+      addLayout,
+      theme,
+      spacer(),
+      this._btn('▶ Present', () => this.startPresent(), { primary: true, title: 'Present (F5)' }),
+      menu,
+    );
+    return tb;
+  }
+
+  _menu() {
+    const wrap = document.createElement('div');
+    wrap.className = 'sl-menu-wrap';
+    const btn = this._btn('File ▾', () => panel.classList.toggle('open'), { aria: 'File menu' });
+    const panel = document.createElement('div');
+    panel.className = 'sl-menu';
+    const item = (label, fn) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'sl-menu-item'; b.textContent = label; b.addEventListener('click', () => { panel.classList.remove('open'); fn(); }); return b; };
+
+    panel.append(
+      item('New deck', () => this.newDeckPrompt()),
+      item('Open deck…', () => this.openLibrary()),
+      hr(),
+      item('Import file… (.json/.pptx/.odp)', () => this._fileInput.click()),
+      hr(),
+      item('Export JSON', () => this.exportJson()),
+      item('Export PPTX', () => this.exportPptx()),
+      item('Export ODP', () => this.exportOdp()),
+      item('Export PDF', () => this.exportPdf()),
+      item('Export HTML', () => this.exportHtml()),
+      item('Export PNG (current slide)', () => this.exportPng()),
+    );
+    // shared hidden file input for imports.
+    const file = document.createElement('input');
+    file.type = 'file';
+    file.accept = '.json,.pptx,.odp,application/json';
+    file.style.display = 'none';
+    file.addEventListener('change', () => { if (file.files[0]) this.importFile(file.files[0]); file.value = ''; });
+    this._fileInput = file;
+
+    document.addEventListener('click', (e) => { if (!wrap.contains(e.target)) panel.classList.remove('open'); });
+    wrap.append(btn, panel, file);
+    return wrap;
+  }
+
+  _rail() {
+    const rail = document.createElement('aside');
+    rail.className = 'sl-rail';
+    rail.setAttribute('aria-label', 'Slides');
+    this._railEl = rail;
+    return rail;
+  }
+
+  _renderRail() {
+    const rail = this._railEl;
+    rail.innerHTML = '';
+    this.deck.slides.forEach((slide, i) => {
+      const item = document.createElement('div');
+      item.className = 'sl-thumb' + (i === this.current ? ' active' : '');
+      item.tabIndex = 0;
+      item.setAttribute('role', 'button');
+      item.setAttribute('aria-label', `Slide ${i + 1}: ${slideTitle(slide) || 'untitled'}`);
+      const select = () => { this.current = i; this._renderRail(); this._renderEditor(); };
+      item.addEventListener('click', select);
+      item.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { select(); e.preventDefault(); } });
+
+      const num = document.createElement('span'); num.className = 'sl-thumb-num'; num.textContent = i + 1;
+      const mini = document.createElement('div'); mini.className = 'sl-thumb-mini';
+      mini.innerHTML = fmt.slideToSvg(this.deck, i, { width: 240 });
+
+      const ctrls = document.createElement('div'); ctrls.className = 'sl-thumb-ctrls';
+      ctrls.append(
+        this._miniBtn('▲', 'Move up', () => this.moveSlide(i, -1), i === 0),
+        this._miniBtn('▼', 'Move down', () => this.moveSlide(i, +1), i === this.deck.slides.length - 1),
+        this._miniBtn('⧉', 'Duplicate', () => this.duplicateSlide(i)),
+        this._miniBtn('✕', 'Delete', () => this.deleteSlide(i), this.deck.slides.length <= 1),
+      );
+
+      item.append(num, mini, ctrls);
+      rail.append(item);
+    });
+  }
+
+  _miniBtn(label, aria, fn, disabled = false) {
+    const b = document.createElement('button');
+    b.type = 'button'; b.className = 'sl-mini'; b.textContent = label;
+    b.setAttribute('aria-label', aria); b.title = aria;
+    b.disabled = disabled;
+    b.addEventListener('click', (e) => { e.stopPropagation(); fn(); });
+    return b;
+  }
+
+  _editorPanel() {
+    const main = document.createElement('main');
+    main.className = 'sl-editor';
+    main.setAttribute('aria-label', 'Slide editor');
+    this._editorEl = main;
+    return main;
+  }
+
+  // Render the WYSIWYG-ish editor for the current slide: a 16:9 canvas with
+  // contenteditable text placeholders, plus a layout switcher.
+  _renderEditor() {
+    const main = this._editorEl;
+    main.innerHTML = '';
+    if (!this.slide) return;
+    const slide = this.slide;
+    const th = themeOf(this.deck);
+
+    // Per-slide controls.
+    const bar = document.createElement('div');
+    bar.className = 'sl-slidebar';
+    const layoutSel = document.createElement('select');
+    layoutSel.className = 'sl-select';
+    layoutSel.setAttribute('aria-label', 'Slide layout');
+    for (const l of LAYOUTS) { const o = document.createElement('option'); o.value = l; o.textContent = LAYOUT_LABELS[l]; layoutSel.append(o); }
+    layoutSel.value = slide.layout;
+    layoutSel.addEventListener('change', () => this.changeLayout(layoutSel.value));
+
+    bar.append(
+      tag('span', 'sl-slidebar-label', `Slide ${this.current + 1}`),
+      layoutSel,
+      this._fmtBtn('B', 'bold', 'Bold'),
+      this._fmtBtn('I', 'italic', 'Italic'),
+      this._btn('• Bullet', () => this._addBullet(), { title: 'Add bullet line to body' }),
+      this._btn('⇥ Indent', () => this._indent(+1), { title: 'Indent bullet' }),
+      this._btn('⇤ Outdent', () => this._indent(-1), { title: 'Outdent bullet' }),
+      spacer(),
+      this._btn('🖼 Image', () => this._imgInput.click(), { title: 'Insert image' }),
+      this._shapeMenu(),
+      this._bgControl(),
+    );
+
+    // Canvas.
+    const stage = document.createElement('div');
+    stage.className = 'sl-stage';
+    const canvas = document.createElement('div');
+    canvas.className = 'sl-canvas';
+    canvas.style.background = slide.background || th.bg;
+    canvas.style.setProperty('--accent', th.accent);
+    canvas.style.setProperty('--fg', th.fg);
+    canvas.style.setProperty('--font', th.font);
+
+    slide.elements.forEach((el, idx) => canvas.append(this._renderElement(el, idx)));
+    stage.append(canvas);
+
+    // Notes.
+    const notesWrap = document.createElement('div');
+    notesWrap.className = 'sl-notes';
+    const nlabel = document.createElement('label');
+    nlabel.textContent = 'Speaker notes';
+    nlabel.setAttribute('for', 'sl-notes-area');
+    const notes = document.createElement('textarea');
+    notes.id = 'sl-notes-area';
+    notes.className = 'sl-notes-area';
+    notes.value = slide.notes;
+    notes.placeholder = 'Notes for this slide (only shown to you in present mode)…';
+    notes.addEventListener('input', () => { slide.notes = notes.value; this._touch(); });
+    notesWrap.append(nlabel, notes);
+
+    // hidden image input.
+    const imgInput = document.createElement('input');
+    imgInput.type = 'file'; imgInput.accept = 'image/*'; imgInput.style.display = 'none';
+    imgInput.addEventListener('change', () => { if (imgInput.files[0]) this.insertImage(imgInput.files[0]); imgInput.value = ''; });
+    this._imgInput = imgInput;
+
+    main.append(bar, stage, notesWrap, imgInput);
+  }
+
+  _renderElement(el, idx) {
+    const box = document.createElement('div');
+    box.className = 'sl-el sl-el-' + el.type;
+    box.style.left = pct(el.x); box.style.top = pct(el.y);
+    box.style.width = pct(el.w); box.style.height = pct(el.h);
+
+    if (el.type === 'text') {
+      const isTitle = el.role === 'title' || el.role === 'section';
+      const ed = document.createElement('div');
+      ed.className = 'sl-text' + (isTitle ? ' is-title' : '');
+      ed.contentEditable = 'true';
+      ed.setAttribute('role', 'textbox');
+      ed.setAttribute('aria-label', isTitle ? 'Title text' : 'Body text');
+      ed.dataset.idx = idx;
+      // Render runs as <div> lines (one per run) so caret + bullet levels map.
+      ed.innerHTML = this._runsToHtml(el);
+      ed.addEventListener('input', () => this._syncTextFromDom(idx, ed));
+      ed.addEventListener('focus', () => { this._activeEl = idx; });
+      box.append(ed);
+    } else if (el.type === 'image') {
+      const img = document.createElement('img');
+      img.className = 'sl-img'; img.src = el.dataUrl; img.alt = el.alt || '';
+      box.append(img);
+      box.append(this._delHandle(idx));
+    } else if (el.type === 'shape') {
+      const s = document.createElement('div');
+      s.className = 'sl-shape sl-shape-' + el.shape;
+      s.style.background = el.shape === 'line' ? 'transparent' : el.fill;
+      s.style.borderColor = el.stroke;
+      box.append(s);
+      box.append(this._delHandle(idx));
+    }
+    return box;
+  }
+
+  _delHandle(idx) {
+    const b = document.createElement('button');
+    b.type = 'button'; b.className = 'sl-el-del'; b.textContent = '✕';
+    b.setAttribute('aria-label', 'Delete element');
+    b.addEventListener('click', (e) => { e.stopPropagation(); this.deleteElement(idx); });
+    return b;
+  }
+
+  _runsToHtml(el) {
+    const lines = bulletLines(el);
+    if (!lines.length) return '<div><br></div>';
+    return lines.map((ln) => {
+      let t = escapeHtml(ln.text) || '<br>';
+      if (ln.bold) t = `<b>${t}</b>`;
+      if (ln.italic) t = `<i>${t}</i>`;
+      const ind = ln.level ? ` style="margin-left:${ln.level * 1.4}em" data-level="${ln.level}"` : ' data-level="0"';
+      return `<div${ind}>${t}</div>`;
+    }).join('');
+  }
+
+  // Read DOM lines back into runs, preserving bold/italic/level per line.
+  _syncTextFromDom(idx, ed) {
+    const el = this.slide.elements[idx];
+    const lineNodes = Array.from(ed.children).filter((n) => n.tagName === 'DIV');
+    const nodes = lineNodes.length ? lineNodes : [ed];
+    el.runs = nodes.map((node) => {
+      const level = parseInt(node.dataset && node.dataset.level || '0', 10) || 0;
+      const bold = !!node.querySelector('b, strong') || /^(B|STRONG)$/.test(node.tagName);
+      const italic = !!node.querySelector('i, em') || /^(I|EM)$/.test(node.tagName);
+      return { text: node.textContent, bold, italic, level };
+    });
+    if (!el.runs.length) el.runs = [{ text: '' }];
+    this._touch();
+    this._renderRailThumb(this.current);
+  }
+
+  // Cheap thumbnail refresh for one slide (avoids re-rendering the whole rail
+  // on every keystroke).
+  _renderRailThumb(i) {
+    const item = this._railEl.children[i];
+    if (!item) return;
+    const mini = item.querySelector('.sl-thumb-mini');
+    if (mini) mini.innerHTML = fmt.slideToSvg(this.deck, i, { width: 240 });
+  }
+
+  _fmtBtn(label, cmd, aria) {
+    const b = document.createElement('button');
+    b.type = 'button'; b.className = 'sl-btn sl-fmt'; b.textContent = label; b.title = aria;
+    b.setAttribute('aria-label', aria);
+    // Use execCommand on the live selection — applies to the focused editable.
+    b.addEventListener('mousedown', (e) => e.preventDefault()); // keep selection
+    b.addEventListener('click', () => {
+      document.execCommand(cmd, false, null);
+      const ed = document.activeElement;
+      if (ed && ed.classList && ed.classList.contains('sl-text')) this._syncTextFromDom(+ed.dataset.idx, ed);
+    });
+    return b;
+  }
+
+  _shapeMenu() {
+    const wrap = document.createElement('div');
+    wrap.className = 'sl-menu-wrap';
+    const btn = this._btn('◇ Shape ▾', () => panel.classList.toggle('open'), { aria: 'Insert shape' });
+    const panel = document.createElement('div'); panel.className = 'sl-menu';
+    for (const [shape, label] of [['rect', '▭ Rectangle'], ['ellipse', '◯ Ellipse'], ['line', '╲ Line']]) {
+      const it = document.createElement('button'); it.type = 'button'; it.className = 'sl-menu-item'; it.textContent = label;
+      it.addEventListener('click', () => { panel.classList.remove('open'); this.insertShape(shape); });
+      panel.append(it);
+    }
+    document.addEventListener('click', (e) => { if (!wrap.contains(e.target)) panel.classList.remove('open'); });
+    wrap.append(btn, panel);
+    return wrap;
+  }
+
+  _bgControl() {
+    const label = document.createElement('label');
+    label.className = 'sl-bg';
+    label.title = 'Slide background';
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = this.slide.background || themeOf(this.deck).bg;
+    input.setAttribute('aria-label', 'Slide background color');
+    input.addEventListener('input', () => { this.slide.background = input.value; this._touch(); this._renderEditor(); this._renderRailThumb(this.current); });
+    label.append(document.createTextNode('🎨'), input);
+    return label;
+  }
+
+  _inspector() {
+    // Reserved column for future element inspector; kept minimal for now so the
+    // editor stays the focus (per the brief: prioritise a working editor).
+    const el = document.createElement('div');
+    el.className = 'sl-inspector';
+    el.hidden = true;
+    return el;
+  }
+
+  // ===================================================================
+  // Editing operations (all mutate this.deck then re-render + persist)
+  // ===================================================================
+  addSlide(layout = 'title-content') {
+    const s = newSlide(layout, { title: 'New slide' });
+    this.deck.slides.splice(this.current + 1, 0, s);
+    this.current += 1;
+    this._touch(); this._renderRail(); this._renderEditor();
+  }
+
+  duplicateSlide(i = this.current) {
+    const copy = cloneSlide(this.deck.slides[i]);
+    this.deck.slides.splice(i + 1, 0, copy);
+    this.current = i + 1;
+    this._touch(); this._renderRail(); this._renderEditor();
+  }
+
+  deleteSlide(i = this.current) {
+    if (this.deck.slides.length <= 1) return;
+    this.deck.slides.splice(i, 1);
+    this.current = Math.min(this.current, this.deck.slides.length - 1);
+    this._touch(); this._renderRail(); this._renderEditor();
+  }
+
+  moveSlide(i, dir) {
+    const j = i + dir;
+    if (j < 0 || j >= this.deck.slides.length) return;
+    const [s] = this.deck.slides.splice(i, 1);
+    this.deck.slides.splice(j, 0, s);
+    if (this.current === i) this.current = j;
+    else if (this.current === j) this.current = i;
+    this._touch(); this._renderRail(); this._renderEditor();
+  }
+
+  // Changing layout remaps existing title/body text into the new placeholders so
+  // content isn't lost when the user reshapes a slide.
+  changeLayout(layout) {
+    const slide = this.slide;
+    const oldTitle = elementByRole(slide, 'title') || elementByRole(slide, 'section');
+    const oldBody = elementByRole(slide, 'body');
+    const titleText = oldTitle ? runsText(oldTitle.runs) : '';
+    const fresh = layoutElements(layout, { title: titleText });
+    // Carry the body runs over to the new body placeholder if both exist.
+    if (oldBody) {
+      const newBody = fresh.find((e) => e.role === 'body');
+      if (newBody) newBody.runs = oldBody.runs;
+    }
+    // Keep any non-placeholder elements (images/shapes/extra text).
+    const extras = slide.elements.filter((e) => e.type !== 'text' || !['title', 'subtitle', 'section', 'body', 'body2'].includes(e.role));
+    slide.layout = layout;
+    slide.elements = [...fresh, ...extras];
+    this._touch(); this._renderEditor(); this._renderRailThumb(this.current);
+  }
+
+  _activeBody() {
+    // Prefer the focused editable; else the body placeholder.
+    if (this._activeEl != null && this.slide.elements[this._activeEl] && this.slide.elements[this._activeEl].type === 'text') {
+      return this.slide.elements[this._activeEl];
+    }
+    return elementByRole(this.slide, 'body');
+  }
+
+  _addBullet() {
+    const el = this._activeBody();
+    if (!el) return;
+    el.runs.push({ text: 'New point', level: 0 });
+    this._touch(); this._renderEditor(); this._renderRailThumb(this.current);
+  }
+
+  _indent(dir) {
+    const el = this._activeBody();
+    if (!el || !el.runs.length) return;
+    // Indent the last run (simple model — fine for the title/body editor).
+    const r = el.runs[el.runs.length - 1];
+    r.level = Math.max(0, Math.min(4, (r.level || 0) + dir));
+    this._touch(); this._renderEditor(); this._renderRailThumb(this.current);
+  }
+
+  async insertImage(file) {
+    const dataUrl = await fileToDataUrl(file);
+    this.slide.elements.push({ type: 'image', x: 0.25, y: 0.25, w: 0.5, h: 0.45, dataUrl, alt: file.name || '' });
+    this._touch(); this._renderEditor(); this._renderRailThumb(this.current);
+  }
+
+  insertShape(shape) {
+    const th = themeOf(this.deck);
+    this.slide.elements.push({ type: 'shape', x: 0.3, y: 0.3, w: 0.3, h: 0.25, shape, fill: th.accent, stroke: th.fg });
+    this._touch(); this._renderEditor(); this._renderRailThumb(this.current);
+  }
+
+  deleteElement(idx) {
+    this.slide.elements.splice(idx, 1);
+    this._touch(); this._renderEditor(); this._renderRailThumb(this.current);
+  }
+
+  async newDeckPrompt() {
+    await this._saveNow();
+    this.deck = newDeck();
+    await saveDeck(this.deck);
+    this.current = 0;
+    this._render();
+  }
+
+  // ===================================================================
+  // Present mode
+  // ===================================================================
+  startPresent() {
+    this.presenting = true;
+    this.presentIndex = this.current;
+    this._timerStart = Date.now();
+    const overlay = document.createElement('div');
+    overlay.className = 'sl-present';
+    overlay.setAttribute('role', 'region');
+    overlay.setAttribute('aria-label', 'Presentation');
+    overlay.tabIndex = -1;
+    const stage = document.createElement('div'); stage.className = 'sl-present-stage';
+    const counter = document.createElement('div'); counter.className = 'sl-present-counter'; counter.setAttribute('aria-live', 'polite');
+    overlay.append(stage, counter);
+    this._presentOverlay = overlay;
+    this._presentStage = stage;
+    this._presentCounter = counter;
+    document.body.append(overlay);
+    this._renderPresent();
+
+    this._keyHandler = (e) => {
+      if (!this.presenting) return;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === ' ' || e.key === 'PageDown') { this.presentNext(); e.preventDefault(); }
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp') { this.presentPrev(); e.preventDefault(); }
+      else if (e.key === 'Escape') { this.exitPresent(); }
+      else if (e.key === 'Home') { this.presentIndex = 0; this._renderPresent(); }
+      else if (e.key === 'End') { this.presentIndex = this.deck.slides.length - 1; this._renderPresent(); }
+    };
+    document.addEventListener('keydown', this._keyHandler);
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target.closest('.sl-present-counter')) return;
+      if (e.clientX < window.innerWidth * 0.3) this.presentPrev(); else this.presentNext();
+    });
+    let sx = null;
+    overlay.addEventListener('touchstart', (e) => { sx = e.touches[0].clientX; }, { passive: true });
+    overlay.addEventListener('touchend', (e) => {
+      if (sx == null) return;
+      const dx = e.changedTouches[0].clientX - sx;
+      if (Math.abs(dx) > 40) { dx < 0 ? this.presentNext() : this.presentPrev(); }
+      sx = null;
+    });
+
+    if (this.requestFullscreen || (overlay.requestFullscreen)) {
+      overlay.requestFullscreen && overlay.requestFullscreen().catch(() => {});
+    }
+    overlay.focus();
+  }
+
+  _renderPresent() {
+    const i = this.presentIndex;
+    this._presentStage.innerHTML = fmt.slideToSvg(this.deck, i, { width: 1600 });
+    this._presentCounter.textContent = `${i + 1} / ${this.deck.slides.length}`;
+  }
+
+  presentNext() { if (this.presentIndex < this.deck.slides.length - 1) { this.presentIndex++; this._renderPresent(); } }
+  presentPrev() { if (this.presentIndex > 0) { this.presentIndex--; this._renderPresent(); } }
+
+  exitPresent() {
+    this.presenting = false;
+    document.removeEventListener('keydown', this._keyHandler);
+    if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
+    if (this._presentOverlay) this._presentOverlay.remove();
+    this._presentOverlay = null;
+    // Sync edit selection to where presenting ended.
+    this.current = this.presentIndex;
+    this._renderRail(); this._renderEditor();
+  }
+
+  // ===================================================================
+  // Library (open existing decks)
+  // ===================================================================
+  async openLibrary() {
+    const decks = await listDecks();
+    const dlg = document.createElement('div');
+    dlg.className = 'sl-dialog-bg';
+    const box = document.createElement('div'); box.className = 'sl-dialog'; box.setAttribute('role', 'dialog'); box.setAttribute('aria-label', 'Open deck');
+    const h = document.createElement('h2'); h.textContent = 'Your decks'; h.className = 'sl-dialog-h';
+    const list = document.createElement('div'); list.className = 'sl-dialog-list';
+    if (!decks.length) { const e = document.createElement('p'); e.textContent = 'No saved decks yet.'; list.append(e); }
+    for (const d of decks) {
+      const row = document.createElement('div'); row.className = 'sl-deck-row';
+      const open = document.createElement('button'); open.type = 'button'; open.className = 'sl-deck-open';
+      open.textContent = `${d.title} — ${d.slides} slide${d.slides === 1 ? '' : 's'}`;
+      open.addEventListener('click', async () => { await this._saveNow(); this.deck = normalizeDeck(await loadDeck(d.id)); this.current = 0; close(); this._render(); });
+      const del = document.createElement('button'); del.type = 'button'; del.className = 'sl-deck-del'; del.textContent = '🗑'; del.setAttribute('aria-label', `Delete ${d.title}`);
+      del.addEventListener('click', async () => { if (d.id !== this.deck.id) { await deleteDeck(d.id); row.remove(); } });
+      row.append(open, del); list.append(row);
+    }
+    const foot = document.createElement('div'); foot.className = 'sl-dialog-foot';
+    const closeBtn = this._btn('Close', () => close());
+    foot.append(closeBtn);
+    const close = () => dlg.remove();
+    dlg.addEventListener('click', (e) => { if (e.target === dlg) close(); });
+    box.append(h, list, foot); dlg.append(box); document.body.append(dlg);
+  }
+
+  // ===================================================================
+  // Import / export
+  // ===================================================================
+  async importFile(file) {
+    const name = (file.name || '').toLowerCase();
+    try {
+      if (name.endsWith('.json')) {
+        this.deck = fmt.jsonToDeck(await file.text());
+      } else if (name.endsWith('.pptx')) {
+        this.deck = await fmt.pptxToDeck(await file.arrayBuffer());
+      } else if (name.endsWith('.odp')) {
+        this.deck = await fmt.odpToDeck(await file.arrayBuffer());
+      } else {
+        // Sniff: try JSON, then ZIP-based.
+        const buf = await file.arrayBuffer();
+        try { this.deck = fmt.jsonToDeck(new TextDecoder().decode(buf)); }
+        catch { this.deck = await fmt.pptxToDeck(buf); }
+      }
+      if (!this.deck.id) this.deck.id = newDeck().id;
+      await saveDeck(this.deck);
+      this.current = 0;
+      this._render();
+    } catch (err) {
+      this._alert('Import failed: ' + err.message);
+    }
+  }
+
+  exportJson() { this._download(new Blob([fmt.deckToJson(this.deck)], { type: 'application/json' }), this._fname('json')); }
+  async exportPptx() { this._download(await fmt.deckToPptx(this.deck), this._fname('pptx')); }
+  async exportOdp() { this._download(await fmt.deckToOdp(this.deck), this._fname('odp')); }
+  exportPdf() { this._download(fmt.deckToPdf(this.deck, this.deck.title), this._fname('pdf')); }
+  exportHtml() { this._download(new Blob([fmt.deckToHtml(this.deck)], { type: 'text/html' }), this._fname('html')); }
+  async exportPng() {
+    const blob = await fmt.slideToPng(this.deck, this.current, { width: 1920 });
+    this._download(blob, this._fname(`slide${this.current + 1}.png`, true));
+  }
+
+  _fname(ext, raw = false) {
+    const base = (this.deck.title || 'deck').replace(/[^\w-]+/g, '-').replace(/^-+|-+$/g, '') || 'deck';
+    return raw ? `${base}-${ext}` : `${base}.${ext}`;
+  }
+
+  _download(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = filename;
+    document.body.append(a); a.click(); a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  _alert(msg) {
+    const t = document.createElement('div'); t.className = 'sl-toast'; t.textContent = msg; t.setAttribute('role', 'status');
+    document.body.append(t); setTimeout(() => t.remove(), 4000);
+  }
+}
+
+// ---- small DOM/util helpers ----
+function spacer() { const s = document.createElement('span'); s.className = 'sl-spacer'; return s; }
+function hr() { const h = document.createElement('hr'); h.className = 'sl-menu-hr'; return h; }
+function tag(name, cls, text) { const e = document.createElement(name); if (cls) e.className = cls; if (text != null) e.textContent = text; return e; }
+function pct(v) { return (v * 100).toFixed(3) + '%'; }
+function escapeHtml(s) { return String(s == null ? '' : s).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c])); }
+function fileToDataUrl(file) {
+  return new Promise((res, rej) => { const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => rej(fr.error); fr.readAsDataURL(file); });
+}
+
+customElements.define('edot-slides', EdotSlides);
+
+// window.__slides — the headless-test hook: the component class, the codecs,
+// the store, and the model factory (so tests can build/inspect decks directly).
+window.__slides = {
+  EdotSlides,
+  formats: fmt,
+  store: { saveDeck, loadDeck, listDecks, deleteDeck },
+  model: { newDeck, newSlide, cloneSlide, normalizeDeck, themeOf, THEMES, LAYOUTS },
+  get el() { return document.querySelector('edot-slides'); },
+};

--- a/magpie/edot/slides/slides-formats.js
+++ b/magpie/edot/slides/slides-formats.js
@@ -1,0 +1,930 @@
+// slides-formats.js — codecs that derive every export from the canonical deck
+// "core" (slides-model.js) and parse foreign formats back into it.
+//
+// Reuses the repo's offline ZIP layer (../js/zip.js, native CompressionStream)
+// for the ZIP-of-XML formats (PPTX, ODP) exactly as io-docx.js does for DOCX,
+// and follows io-pdf.js's hand-rolled-PDF approach for the PDF export. No CDN,
+// no WASM, no vendored deflate.
+//
+// FIDELITY IS BEST-EFFORT AND HONEST. See the matrix in README.md. In short:
+//   • JSON .......... lossless (the core itself)
+//   • PPTX export ... titles, bullet body text, images, notes. NOT exported:
+//                     animations, transitions, charts, SmartArt, exact theme,
+//                     freeform shape geometry beyond rect/ellipse/line.
+//   • PPTX import ... title/body text runs (bold/italic), images, notes,
+//                     bullet indent levels. Layout is inferred, not preserved.
+//   • ODP import/export ... text + notes + simple shapes; theming approximate.
+//   • PDF / HTML / PNG ... terminal renders (one page/slide), not re-importable.
+
+import { zipSync, unzip, utf8 } from '../js/zip.js';
+import {
+  DECK_VERSION, normalizeDeck, newDeck, newSlide, themeOf, THEMES,
+  runsText, bulletLines, slideTitle, uid,
+} from './slides-model.js';
+
+// 16:9 slide in EMUs (English Metric Units; 914400 EMU = 1 inch). 10in × 5.625in.
+const EMU_W = 9144000;
+const EMU_H = 5143500;
+
+function xmlEscape(s) {
+  return String(s == null ? '' : s).replace(/[<>&"']/g, (c) =>
+    ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&apos;' }[c]));
+}
+
+// ============================================================================
+// Native JSON — lossless
+// ============================================================================
+
+export function deckToJson(deck) {
+  return JSON.stringify({ ...normalizeDeck(deck), version: DECK_VERSION }, null, 2);
+}
+
+export function jsonToDeck(text) {
+  return normalizeDeck(JSON.parse(text));
+}
+
+// ============================================================================
+// Image helpers (shared by PPTX/ODP/HTML)
+// ============================================================================
+
+function bytesToBase64(bytes) {
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin);
+}
+
+function base64ToBytes(b64) {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// Parse a data: URL into { mime, ext, bytes }. Returns null if not a data URL.
+function parseDataUrl(dataUrl) {
+  const m = /^data:([^;,]+)?(;base64)?,(.*)$/s.exec(dataUrl || '');
+  if (!m) return null;
+  const mime = m[1] || 'image/png';
+  const ext = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/gif': 'gif', 'image/webp': 'webp', 'image/svg+xml': 'svg' }[mime] || 'png';
+  const bytes = m[2] ? base64ToBytes(m[3]) : utf8.encode(decodeURIComponent(m[3]));
+  return { mime, ext, bytes };
+}
+
+function mimeForExt(ext) {
+  return { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', webp: 'image/webp', svg: 'image/svg+xml' }[(ext || '').toLowerCase()];
+}
+
+// ============================================================================
+// PPTX export (Open XML PresentationML, minimal-but-valid)
+// ============================================================================
+
+// Convert a text element's runs to a:p paragraphs. Bullet body elements emit
+// one paragraph per run with an indent level; title/subtitle emit a single
+// paragraph. Bold/italic map to a:rPr b/i attributes.
+function pptxParagraphs(el, { bullet }) {
+  const lines = bulletLines(el);
+  if (!lines.length) return '<a:p/>';
+  return lines.map((ln) => {
+    const lvl = bullet && ln.level ? ` lvl="${ln.level}"` : '';
+    // buNone on non-bullet placeholders keeps titles clean.
+    const pPr = bullet ? `<a:pPr${lvl}/>` : '<a:pPr><a:buNone/></a:pPr>';
+    const rPr = `<a:rPr lang="en-US"${ln.bold ? ' b="1"' : ''}${ln.italic ? ' i="1"' : ''}/>`;
+    const text = ln.text ? `<a:r>${rPr}<a:t>${xmlEscape(ln.text)}</a:t></a:r>` : '';
+    return `<a:p>${pPr}${text}</a:p>`;
+  }).join('');
+}
+
+// One sp (shape) per text element, positioned with a normalized→EMU xfrm.
+function pptxTextShape(el, idAttr) {
+  const x = Math.round(el.x * EMU_W), y = Math.round(el.y * EMU_H);
+  const w = Math.round(el.w * EMU_W), h = Math.round(el.h * EMU_H);
+  const isTitle = el.role === 'title' || el.role === 'section';
+  const phType = isTitle ? ' type="title"' : '';
+  const bullet = !isTitle && el.role !== 'subtitle';
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${idAttr}" name="${xmlEscape(el.role || 'Text')}"/>` +
+    `<p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph${phType}/></p:nvPr></p:nvSpPr>` +
+    `<p:spPr><a:xfrm><a:off x="${x}" y="${y}"/><a:ext cx="${w}" cy="${h}"/></a:xfrm></p:spPr>` +
+    `<p:txBody><a:bodyPr/><a:lstStyle/>${pptxParagraphs(el, { bullet })}</p:txBody></p:sp>`;
+}
+
+function pptxPicShape(el, idAttr, rId) {
+  const x = Math.round(el.x * EMU_W), y = Math.round(el.y * EMU_H);
+  const w = Math.round(el.w * EMU_W), h = Math.round(el.h * EMU_H);
+  return `<p:pic><p:nvPicPr><p:cNvPr id="${idAttr}" name="Image" descr="${xmlEscape(el.alt || '')}"/>` +
+    `<p:cNvPicPr/><p:nvPr/></p:nvPicPr>` +
+    `<p:blipFill><a:blip r:embed="${rId}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>` +
+    `<p:spPr><a:xfrm><a:off x="${x}" y="${y}"/><a:ext cx="${w}" cy="${h}"/></a:xfrm>` +
+    `<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>`;
+}
+
+function pptxShape(el, idAttr) {
+  const x = Math.round(el.x * EMU_W), y = Math.round(el.y * EMU_H);
+  const w = Math.round(el.w * EMU_W), h = Math.round(el.h * EMU_H);
+  const prst = el.shape === 'ellipse' ? 'ellipse' : el.shape === 'line' ? 'line' : 'rect';
+  const fill = el.shape === 'line' ? '<a:noFill/>' : `<a:solidFill><a:srgbClr val="${hex(el.fill)}"/></a:solidFill>`;
+  const ln = `<a:ln><a:solidFill><a:srgbClr val="${hex(el.stroke)}"/></a:solidFill></a:ln>`;
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${idAttr}" name="Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+    `<p:spPr><a:xfrm><a:off x="${x}" y="${y}"/><a:ext cx="${w}" cy="${h}"/></a:xfrm>` +
+    `<a:prstGeom prst="${prst}"><a:avLst/></a:prstGeom>${fill}${ln}</p:spPr></p:sp>`;
+}
+
+function hex(c) {
+  const m = /^#?([0-9a-f]{6})$/i.exec(String(c || '').trim());
+  if (m) return m[1].toUpperCase();
+  const m3 = /^#?([0-9a-f]{3})$/i.exec(String(c || '').trim());
+  if (m3) return m3[1].split('').map((x) => x + x).join('').toUpperCase();
+  return 'DDDDDD';
+}
+
+const CT_HEAD = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
+const P_NS = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+  'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"';
+
+export async function deckToPptx(deckRaw) {
+  const deck = normalizeDeck(deckRaw);
+  const files = {};
+  const media = []; // { name, bytes, contentType }
+  const slideCount = deck.slides.length;
+
+  // [Content_Types].xml — declare slide + notesSlide overrides and image defaults.
+  const overrides = [];
+  const slideRelsList = [];
+  let mediaSeq = 0;
+
+  deck.slides.forEach((slide, i) => {
+    const n = i + 1;
+    let nextId = 2;
+    const slideRels = []; // { id, type, target }
+    let bodyXml = '';
+
+    for (const el of slide.elements) {
+      if (el.type === 'text') {
+        bodyXml += pptxTextShape(el, nextId++);
+      } else if (el.type === 'image') {
+        const parsed = parseDataUrl(el.dataUrl);
+        if (!parsed) continue;
+        mediaSeq += 1;
+        const name = `image${mediaSeq}.${parsed.ext}`;
+        media.push({ name, bytes: parsed.bytes, contentType: parsed.mime });
+        const rId = `rId${slideRels.length + 2}`;
+        slideRels.push({ id: rId, type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', target: `../media/${name}` });
+        bodyXml += pptxPicShape(el, nextId++, rId);
+      } else if (el.type === 'shape') {
+        bodyXml += pptxShape(el, nextId++);
+      }
+    }
+
+    const bg = slide.background ? `<p:bg><p:bgPr><a:solidFill><a:srgbClr val="${hex(slide.background)}"/></a:solidFill><a:effectLst/></p:bgPr></p:bg>` : '';
+    files[`ppt/slides/slide${n}.xml`] = CT_HEAD +
+      `<p:sld ${P_NS}><p:cSld>${bg}<p:spTree>` +
+      '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+      '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>' +
+      `${bodyXml}</p:spTree></p:cSld><p:clrMapOvr><a:overrideClrMapping bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/></p:clrMapOvr></p:sld>`;
+
+    // Slide → layout rel (always present) + image rels + optional notes rel.
+    slideRels.unshift({ id: 'rId1', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout', target: '../slideLayouts/slideLayout1.xml' });
+
+    // Notes slide.
+    if (slide.notes && slide.notes.trim()) {
+      files[`ppt/notesSlides/notesSlide${n}.xml`] = CT_HEAD + notesXml(slide.notes);
+      files[`ppt/notesSlides/_rels/notesSlide${n}.xml.rels`] = relsXml([
+        { id: 'rId1', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide', target: `../slides/slide${n}.xml` },
+      ]);
+      slideRels.push({ id: `rId${slideRels.length + 1}`, type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide', target: `../notesSlides/notesSlide${n}.xml` });
+      overrides.push(`<Override PartName="/ppt/notesSlides/notesSlide${n}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml"/>`);
+    }
+
+    files[`ppt/slides/_rels/slide${n}.xml.rels`] = relsXml(slideRels);
+    overrides.push(`<Override PartName="/ppt/slides/slide${n}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`);
+    slideRelsList.push(n);
+  });
+
+  // Media files + content-type defaults for the extensions actually used.
+  const imageDefaults = new Set();
+  for (const m of media) {
+    files[`ppt/media/${m.name}`] = m.bytes;
+    imageDefaults.add(m.name.split('.').pop());
+  }
+
+  // presentation.xml — slide id list + slide size.
+  const sldIdList = deck.slides.map((_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 1}"/>`).join('');
+  files['ppt/presentation.xml'] = CT_HEAD +
+    `<p:presentation ${P_NS}><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rIdMaster"/></p:sldMasterIdLst>` +
+    `<p:sldIdLst>${sldIdList}</p:sldIdLst>` +
+    `<p:sldSz cx="${EMU_W}" cy="${EMU_H}" type="screen16x9"/><p:notesSz cx="${EMU_H}" cy="${EMU_W}"/></p:presentation>`;
+
+  const presRels = deck.slides.map((_, i) => ({ id: `rId${i + 1}`, type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide', target: `slides/slide${i + 1}.xml` }));
+  presRels.push({ id: 'rIdMaster', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster', target: 'slideMasters/slideMaster1.xml' });
+  presRels.push({ id: 'rIdTheme', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', target: 'theme/theme1.xml' });
+  files['ppt/_rels/presentation.xml.rels'] = relsXml(presRels);
+
+  // Master + layout + theme (minimal but referenced, so PowerPoint opens cleanly).
+  const th = themeOf(deck);
+  files['ppt/slideMasters/slideMaster1.xml'] = CT_HEAD + slideMasterXml();
+  files['ppt/slideMasters/_rels/slideMaster1.xml.rels'] = relsXml([
+    { id: 'rId1', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout', target: '../slideLayouts/slideLayout1.xml' },
+    { id: 'rIdTheme', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', target: '../theme/theme1.xml' },
+  ]);
+  files['ppt/slideLayouts/slideLayout1.xml'] = CT_HEAD + slideLayoutXml();
+  files['ppt/slideLayouts/_rels/slideLayout1.xml.rels'] = relsXml([
+    { id: 'rId1', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster', target: '../slideMasters/slideMaster1.xml' },
+  ]);
+  files['ppt/theme/theme1.xml'] = CT_HEAD + themeXml(th);
+
+  files['[Content_Types].xml'] = CT_HEAD +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    [...imageDefaults].map((ext) => `<Default Extension="${ext}" ContentType="${mimeForExt(ext)}"/>`).join('') +
+    '<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>' +
+    '<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>' +
+    '<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>' +
+    '<Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>' +
+    overrides.join('') +
+    '</Types>';
+
+  files['_rels/.rels'] = relsXml([
+    { id: 'rId1', type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument', target: 'ppt/presentation.xml' },
+  ]);
+
+  return zipSync(files);
+}
+
+function relsXml(rels) {
+  return CT_HEAD + '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    rels.map((r) => `<Relationship Id="${r.id}" Type="${r.type}" Target="${xmlEscape(r.target)}"/>`).join('') +
+    '</Relationships>';
+}
+
+function notesXml(notes) {
+  const paras = String(notes).split('\n').map((line) =>
+    `<a:p><a:r><a:rPr lang="en-US"/><a:t>${xmlEscape(line)}</a:t></a:r></a:p>`).join('');
+  return `<p:notes ${P_NS}><p:cSld><p:spTree>` +
+    '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/>' +
+    '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Notes Placeholder"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>' +
+    '<p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr/>' +
+    `<p:txBody><a:bodyPr/><a:lstStyle/>${paras}</p:txBody></p:sp>` +
+    '</p:spTree></p:cSld></p:notes>';
+}
+
+function slideMasterXml() {
+  return `<p:sldMaster ${P_NS}><p:cSld><p:bg><p:bgRef idx="1001"><a:schemeClr val="bg1"/></p:bgRef></p:bg>` +
+    '<p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+    '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld>' +
+    '<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>' +
+    '<p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst></p:sldMaster>';
+}
+
+function slideLayoutXml() {
+  return `<p:sldLayout ${P_NS} type="blank" preserve="1"><p:cSld name="Blank">` +
+    '<p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+    '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld>' +
+    '<p:clrMapOvr><a:overrideClrMapping bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/></p:clrMapOvr></p:sldLayout>';
+}
+
+function themeXml(th) {
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const accent = hex(th.accent);
+  return `<a:theme xmlns:a="${A}" name="edot"><a:themeElements>` +
+    '<a:clrScheme name="edot"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>' +
+    '<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>' +
+    `<a:dk2><a:srgbClr val="${hex(th.fg)}"/></a:dk2><a:lt2><a:srgbClr val="${hex(th.bg)}"/></a:lt2>` +
+    `<a:accent1><a:srgbClr val="${accent}"/></a:accent1><a:accent2><a:srgbClr val="${accent}"/></a:accent2>` +
+    `<a:accent3><a:srgbClr val="${accent}"/></a:accent3><a:accent4><a:srgbClr val="${accent}"/></a:accent4>` +
+    `<a:accent5><a:srgbClr val="${accent}"/></a:accent5><a:accent6><a:srgbClr val="${accent}"/></a:accent6>` +
+    '<a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink></a:clrScheme>' +
+    '<a:fontScheme name="edot"><a:majorFont><a:latin typeface="Georgia"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>' +
+    '<a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont></a:fontScheme>' +
+    '<a:fmtScheme name="edot"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>' +
+    '<a:lnStyleLst><a:ln><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+    '<a:ln><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+    '<a:ln><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></a:lnStyleLst>' +
+    '<a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle>' +
+    '<a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst>' +
+    '<a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>' +
+    '</a:fmtScheme></a:themeElements></a:theme>';
+}
+
+// ============================================================================
+// PPTX import — best-effort text/notes/images into the core
+// ============================================================================
+
+export async function pptxToDeck(arrayBuffer) {
+  const entries = await unzip(arrayBuffer);
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+  const P = 'http://schemas.openxmlformats.org/presentationml/2006/main';
+
+  // Slide order from presentation.xml.rels + presentation.xml sldIdLst.
+  const presRels = parseRels(entries['ppt/_rels/presentation.xml.rels'], entries);
+  const presXml = entries['ppt/presentation.xml'] ? parseXml(entries['ppt/presentation.xml']) : null;
+  const slidePaths = [];
+  if (presXml) {
+    const ids = presXml.getElementsByTagNameNS('http://schemas.openxmlformats.org/presentationml/2006/main', 'sldId');
+    for (const id of Array.from(ids)) {
+      const rid = id.getAttributeNS(R, 'id');
+      const target = presRels[rid];
+      if (target) slidePaths.push(normPath('ppt/', target));
+    }
+  }
+  // Fallback: any slideN.xml, numerically sorted.
+  if (!slidePaths.length) {
+    Object.keys(entries).filter((k) => /^ppt\/slides\/slide\d+\.xml$/.test(k))
+      .sort((a, b) => slideNum(a) - slideNum(b)).forEach((k) => slidePaths.push(k));
+  }
+
+  const deck = newDeck('Imported deck');
+  deck.slides = [];
+
+  for (const path of slidePaths) {
+    const bytes = entries[path];
+    if (!bytes) continue;
+    const doc = parseXml(bytes);
+    const rels = parseRels(entries[relsPathFor(path)], entries);
+
+    const slide = newSlide('title-content');
+    slide.elements = [];
+    slide.notes = '';
+
+    // Walk every sp (shape) on the slide; classify title vs body by ph type.
+    const sps = doc.getElementsByTagNameNS('http://schemas.openxmlformats.org/presentationml/2006/main', 'sp');
+    let titleSet = false;
+    for (const sp of Array.from(sps)) {
+      const ph = sp.getElementsByTagNameNS(P, 'ph')[0];
+      const phType = ph ? (ph.getAttribute('type') || '') : '';
+      // txBody is p:txBody in PresentationML; its paragraphs/runs are a:p / a:r.
+      const txBody = sp.getElementsByTagNameNS(P, 'txBody')[0] || sp.getElementsByTagNameNS(A, 'txBody')[0];
+      if (!txBody) continue;
+      const { runs, isMultiline } = paragraphsToRuns(txBody, A);
+      if (!runs.length) continue;
+      const isTitle = /^(title|ctrTitle)$/.test(phType) && !titleSet;
+      const xfrm = readXfrm(sp, A);
+      if (isTitle) {
+        titleSet = true;
+        slide.elements.push({ type: 'text', role: 'title', ...(xfrm || { x: 0.06, y: 0.06, w: 0.88, h: 0.16 }), runs: [{ text: runsText(runs) }] });
+      } else {
+        slide.elements.push({ type: 'text', role: 'body', ...(xfrm || { x: 0.06, y: 0.26, w: 0.88, h: 0.66 }), runs });
+      }
+    }
+
+    // Images (p:pic → blip r:embed → media bytes → data URL).
+    const pics = doc.getElementsByTagNameNS('http://schemas.openxmlformats.org/presentationml/2006/main', 'pic');
+    for (const pic of Array.from(pics)) {
+      const blip = pic.getElementsByTagNameNS(A, 'blip')[0];
+      const embed = blip && (blip.getAttributeNS(R, 'embed') || blip.getAttributeNS(R, 'link'));
+      const target = embed && rels[embed];
+      if (!target) continue;
+      const mediaPath = normPath(dirOf(path) + '/', target);
+      const mbytes = entries[mediaPath];
+      if (!mbytes) continue;
+      const ext = (mediaPath.split('.').pop() || 'png').toLowerCase();
+      const mime = mimeForExt(ext);
+      if (!mime) continue;
+      const xfrm = readXfrm(pic, A) || { x: 0.2, y: 0.2, w: 0.6, h: 0.6 };
+      slide.elements.push({ type: 'image', ...xfrm, dataUrl: `data:${mime};base64,${bytesToBase64(mbytes)}`, alt: '' });
+    }
+
+    // Notes (notesSlide rel → body text).
+    const notesRel = Object.entries(rels).find(([, t]) => /notesSlide\d+\.xml$/.test(t));
+    if (notesRel) {
+      const notesPath = normPath(dirOf(path) + '/', notesRel[1]);
+      if (entries[notesPath]) {
+        const ndoc = parseXml(entries[notesPath]);
+        slide.notes = collectText(ndoc, A).trim();
+      }
+    }
+
+    if (!slide.elements.length) slide.elements = newSlide('blank').elements;
+    deck.slides.push(slide);
+  }
+
+  if (!deck.slides.length) deck.slides.push(newSlide('title', { title: 'Imported deck' }));
+  deck.title = slideTitle(deck.slides[0]) || 'Imported deck';
+  return normalizeDeck(deck);
+}
+
+// Each a:p → one run (with first-run bold/italic + indent level). Joins
+// inner runs' text so a bulleted line survives as a single logical line.
+function paragraphsToRuns(txBody, A) {
+  const ps = txBody.getElementsByTagNameNS(A, 'p');
+  const runs = [];
+  for (const p of Array.from(ps)) {
+    const rs = p.getElementsByTagNameNS(A, 'r');
+    let text = '';
+    let bold = false, italic = false, gotProps = false;
+    for (const r of Array.from(rs)) {
+      const t = r.getElementsByTagNameNS(A, 't')[0];
+      if (t) text += t.textContent;
+      if (!gotProps) {
+        const rPr = r.getElementsByTagNameNS(A, 'rPr')[0];
+        if (rPr) { bold = rPr.getAttribute('b') === '1'; italic = rPr.getAttribute('i') === '1'; gotProps = true; }
+      }
+    }
+    const pPr = p.getElementsByTagNameNS(A, 'pPr')[0];
+    const level = pPr ? parseInt(pPr.getAttribute('lvl') || '0', 10) : 0;
+    if (text) runs.push({ text, bold, italic, level: level || 0 });
+  }
+  return { runs, isMultiline: runs.length > 1 };
+}
+
+function readXfrm(sp, A) {
+  const xfrm = sp.getElementsByTagNameNS(A, 'xfrm')[0];
+  if (!xfrm) return null;
+  const off = xfrm.getElementsByTagNameNS(A, 'off')[0];
+  const ext = xfrm.getElementsByTagNameNS(A, 'ext')[0];
+  if (!off || !ext) return null;
+  const x = +off.getAttribute('x'), y = +off.getAttribute('y');
+  const cx = +ext.getAttribute('cx'), cy = +ext.getAttribute('cy');
+  if (![x, y, cx, cy].every(Number.isFinite)) return null;
+  return {
+    x: Math.max(0, Math.min(1, x / EMU_W)),
+    y: Math.max(0, Math.min(1, y / EMU_H)),
+    w: Math.max(0.01, Math.min(1, cx / EMU_W)),
+    h: Math.max(0.01, Math.min(1, cy / EMU_H)),
+  };
+}
+
+function collectText(doc, A) {
+  const ts = doc.getElementsByTagNameNS(A, 't');
+  return Array.from(ts).map((t, i) => (i ? '\n' : '') + t.textContent).join('');
+}
+
+// ============================================================================
+// ODP (OpenDocument Presentation) — import + export, best-effort
+// ============================================================================
+
+const ODF_OFFICE = 'urn:oasis:names:tc:opendocument:xmlns:office:1.0';
+const ODF_DRAW = 'urn:oasis:names:tc:opendocument:xmlns:drawing:1.0';
+const ODF_TEXT = 'urn:oasis:names:tc:opendocument:xmlns:text:1.0';
+const ODF_SVG = 'urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0';
+const ODF_PRES = 'urn:oasis:names:tc:opendocument:xmlns:presentation:1.0';
+
+// ODF page is 10in × 5.625in expressed in cm for a 16:9 page (25.4 × 14.288cm).
+const ODF_W_CM = 25.4;
+const ODF_H_CM = 14.288;
+
+export async function deckToOdp(deckRaw) {
+  const deck = normalizeDeck(deckRaw);
+  const media = [];
+  let mseq = 0;
+
+  const pages = deck.slides.map((slide) => {
+    let frames = '';
+    for (const el of slide.elements) {
+      const x = (el.x * ODF_W_CM).toFixed(3), y = (el.y * ODF_H_CM).toFixed(3);
+      const w = (el.w * ODF_W_CM).toFixed(3), h = (el.h * ODF_H_CM).toFixed(3);
+      if (el.type === 'text') {
+        const paras = bulletLines(el).map((ln) =>
+          `<text:p>${ln.bold ? '<text:span text:style-name="Tb">' : ''}${xmlEscape(ln.text)}${ln.bold ? '</text:span>' : ''}</text:p>`).join('') || '<text:p/>';
+        frames += `<draw:frame svg:x="${x}cm" svg:y="${y}cm" svg:width="${w}cm" svg:height="${h}cm">` +
+          `<draw:text-box>${paras}</draw:text-box></draw:frame>`;
+      } else if (el.type === 'image') {
+        const parsed = parseDataUrl(el.dataUrl);
+        if (!parsed) continue;
+        mseq += 1;
+        const name = `Pictures/image${mseq}.${parsed.ext}`;
+        media.push({ name, bytes: parsed.bytes, mime: parsed.mime });
+        frames += `<draw:frame svg:x="${x}cm" svg:y="${y}cm" svg:width="${w}cm" svg:height="${h}cm">` +
+          `<draw:image xlink:href="${name}" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/>` +
+          (el.alt ? `<svg:title>${xmlEscape(el.alt)}</svg:title>` : '') + '</draw:frame>';
+      } else if (el.type === 'shape') {
+        const tag = el.shape === 'ellipse' ? 'draw:ellipse' : el.shape === 'line' ? 'draw:line' : 'draw:rect';
+        if (el.shape === 'line') {
+          const x2 = ((el.x + el.w) * ODF_W_CM).toFixed(3), y2 = ((el.y + el.h) * ODF_H_CM).toFixed(3);
+          frames += `<draw:line svg:x1="${x}cm" svg:y1="${y}cm" svg:x2="${x2}cm" svg:y2="${y2}cm"/>`;
+        } else {
+          frames += `<${tag} svg:x="${x}cm" svg:y="${y}cm" svg:width="${w}cm" svg:height="${h}cm"/>`;
+        }
+      }
+    }
+    const notes = slide.notes && slide.notes.trim()
+      ? `<presentation:notes><draw:frame><draw:text-box>${
+        slide.notes.split('\n').map((l) => `<text:p>${xmlEscape(l)}</text:p>`).join('')
+      }</draw:text-box></draw:frame></presentation:notes>` : '';
+    return `<draw:page draw:name="${xmlEscape(slideTitle(slide) || 'Slide')}">${frames}${notes}</draw:page>`;
+  }).join('');
+
+  const NS =
+    `xmlns:office="${ODF_OFFICE}" xmlns:draw="${ODF_DRAW}" xmlns:text="${ODF_TEXT}" ` +
+    `xmlns:svg="${ODF_SVG}" xmlns:presentation="${ODF_PRES}" ` +
+    'xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" ' +
+    'xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"';
+
+  const content = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    `<office:document-content ${NS} office:version="1.2"><office:automatic-styles>` +
+    '<style:style style:name="Tb" style:family="text"><style:text-properties fo:font-weight="bold"/></style:style>' +
+    '</office:automatic-styles>' +
+    `<office:body><office:presentation>${pages}</office:presentation></office:body></office:document-content>`;
+
+  const manifestEntries = [
+    '<manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.presentation"/>',
+    '<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>',
+    '<manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>',
+    '<manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>',
+    ...media.map((m) => `<manifest:file-entry manifest:full-path="${m.name}" manifest:media-type="${m.mime}"/>`),
+  ].join('');
+
+  const files = {
+    // mimetype must be the first, STORED entry; zip.js stores when not smaller,
+    // and this short string never benefits from deflate, so it stays STORED.
+    mimetype: 'application/vnd.oasis.opendocument.presentation',
+    'content.xml': content,
+    'styles.xml': '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      `<office:document-styles ${NS} office:version="1.2"><office:styles/><office:master-styles>` +
+      '<style:master-page style:name="Default"/></office:master-styles></office:document-styles>',
+    'meta.xml': '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      `<office:document-meta ${NS}><office:meta><meta:generator xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0">edot-slides</meta:generator></office:meta></office:document-meta>`,
+    'META-INF/manifest.xml': '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      `<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.2">${manifestEntries}</manifest:manifest>`,
+  };
+  for (const m of media) files[m.name] = m.bytes;
+  return zipSync(files);
+}
+
+export async function odpToDeck(arrayBuffer) {
+  const entries = await unzip(arrayBuffer);
+  if (!entries['content.xml']) throw new Error('Not an ODP file (missing content.xml)');
+  const doc = parseXml(entries['content.xml']);
+  const pages = doc.getElementsByTagNameNS(ODF_DRAW, 'page');
+  const deck = newDeck('Imported deck');
+  deck.slides = [];
+
+  for (const page of Array.from(pages)) {
+    const slide = newSlide('title-content');
+    slide.elements = [];
+    slide.notes = '';
+
+    const frames = page.getElementsByTagNameNS(ODF_DRAW, 'frame');
+    let first = true;
+    for (const frame of Array.from(frames)) {
+      // Skip frames inside the notes block.
+      if (frame.closest && frame.closest('presentation\\:notes')) continue;
+      const xfrm = readOdfXfrm(frame);
+      const box = frame.getElementsByTagNameNS(ODF_DRAW, 'text-box')[0];
+      const img = frame.getElementsByTagNameNS(ODF_DRAW, 'image')[0];
+      if (img) {
+        const href = img.getAttributeNS('http://www.w3.org/1999/xlink', 'href') || img.getAttribute('xlink:href');
+        const mbytes = href && (entries[href] || entries[href.replace(/^\//, '')]);
+        if (mbytes) {
+          const ext = (href.split('.').pop() || 'png').toLowerCase();
+          const mime = mimeForExt(ext) || 'image/png';
+          slide.elements.push({ type: 'image', ...(xfrm || { x: 0.2, y: 0.2, w: 0.6, h: 0.6 }), dataUrl: `data:${mime};base64,${bytesToBase64(mbytes)}`, alt: '' });
+        }
+        continue;
+      }
+      if (box) {
+        const ps = box.getElementsByTagNameNS(ODF_TEXT, 'p');
+        const runs = Array.from(ps).map((p) => ({ text: p.textContent || '', level: 0 })).filter((r) => r.text);
+        if (!runs.length) continue;
+        if (first) {
+          first = false;
+          slide.elements.push({ type: 'text', role: 'title', ...(xfrm || { x: 0.06, y: 0.06, w: 0.88, h: 0.16 }), runs: [{ text: runsText(runs) }] });
+        } else {
+          slide.elements.push({ type: 'text', role: 'body', ...(xfrm || { x: 0.06, y: 0.26, w: 0.88, h: 0.66 }), runs });
+        }
+      }
+    }
+
+    // Notes.
+    const notesEl = page.getElementsByTagNameNS(ODF_PRES, 'notes')[0];
+    if (notesEl) {
+      const ps = notesEl.getElementsByTagNameNS(ODF_TEXT, 'p');
+      slide.notes = Array.from(ps).map((p) => p.textContent || '').join('\n').trim();
+    }
+
+    if (!slide.elements.length) slide.elements = newSlide('blank').elements;
+    deck.slides.push(slide);
+  }
+
+  if (!deck.slides.length) deck.slides.push(newSlide('title', { title: 'Imported deck' }));
+  deck.title = slideTitle(deck.slides[0]) || 'Imported deck';
+  return normalizeDeck(deck);
+}
+
+function readOdfXfrm(frame) {
+  const px = parseCm(frame.getAttributeNS(ODF_SVG, 'x') || frame.getAttribute('svg:x'));
+  const py = parseCm(frame.getAttributeNS(ODF_SVG, 'y') || frame.getAttribute('svg:y'));
+  const pw = parseCm(frame.getAttributeNS(ODF_SVG, 'width') || frame.getAttribute('svg:width'));
+  const ph = parseCm(frame.getAttributeNS(ODF_SVG, 'height') || frame.getAttribute('svg:height'));
+  if (px == null || py == null || pw == null || ph == null) return null;
+  return {
+    x: Math.max(0, Math.min(1, px / ODF_W_CM)),
+    y: Math.max(0, Math.min(1, py / ODF_H_CM)),
+    w: Math.max(0.01, Math.min(1, pw / ODF_W_CM)),
+    h: Math.max(0.01, Math.min(1, ph / ODF_H_CM)),
+  };
+}
+function parseCm(v) {
+  if (!v) return null;
+  const m = /^([\d.]+)\s*(cm|mm|in|pt)?$/.exec(String(v).trim());
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  switch (m[2]) {
+    case 'mm': return n / 10;
+    case 'in': return n * 2.54;
+    case 'pt': return (n / 72) * 2.54;
+    default: return n; // cm
+  }
+}
+
+// ============================================================================
+// HTML export — a single self-contained, keyboard-navigable deck
+// ============================================================================
+
+export function deckToHtml(deckRaw) {
+  const deck = normalizeDeck(deckRaw);
+  const th = themeOf(deck);
+  const sectionFor = (slide) => {
+    const bg = slide.background || th.bg;
+    let inner = '';
+    for (const el of slide.elements) {
+      const style = `left:${pct(el.x)};top:${pct(el.y)};width:${pct(el.w)};height:${pct(el.h)}`;
+      if (el.type === 'text') {
+        const isTitle = el.role === 'title' || el.role === 'section';
+        const tag = isTitle ? 'h2' : 'div';
+        const cls = isTitle ? 'title' : 'body';
+        const lines = bulletLines(el);
+        const html = isTitle
+          ? xmlEscape(runsText(el.runs))
+          : `<ul>${lines.map((ln) => `<li style="margin-left:${ln.level * 1.2}em">${markup(ln)}</li>`).join('')}</ul>`;
+        inner += `<${tag} class="el ${cls}" style="${style}">${html}</${tag}>`;
+      } else if (el.type === 'image') {
+        inner += `<img class="el" style="${style}" src="${xmlEscape(el.dataUrl)}" alt="${xmlEscape(el.alt)}">`;
+      } else if (el.type === 'shape') {
+        inner += shapeHtml(el, style);
+      }
+    }
+    return `<section style="background:${xmlEscape(bg)}"><div class="canvas">${inner}</div>` +
+      (slide.notes ? `<aside class="notes">${xmlEscape(slide.notes)}</aside>` : '') + '</section>';
+  };
+
+  const sections = deck.slides.map(sectionFor).join('\n');
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="color-scheme" content="light dark">
+<title>${xmlEscape(deck.title)}</title>
+<style>
+  :root { --fg:${th.fg}; --accent:${th.accent}; --font:${th.font}; }
+  * { box-sizing: border-box; }
+  html, body { margin:0; height:100%; background:#000; color:var(--fg); font-family:var(--font); overflow:hidden; }
+  #deck { position:relative; height:100dvh; height:100vh; }
+  section { position:absolute; inset:0; display:none; place-items:center; }
+  section.on { display:grid; }
+  .canvas { position:relative; width:min(100vw, calc(100dvh * 16 / 9)); aspect-ratio:16/9; box-shadow:0 0 0 1px rgba(0,0,0,.2); overflow:hidden; }
+  .el { position:absolute; }
+  .title { margin:0; color:var(--accent); font-size:clamp(1.2rem, 4.5vw, 3rem); display:flex; align-items:center; }
+  .body { font-size:clamp(.8rem, 2.6vw, 1.5rem); }
+  .body ul { margin:0; padding-left:1.2em; }
+  .body li { margin:.25em 0; }
+  .notes { position:absolute; bottom:0; left:0; right:0; max-height:25%; overflow:auto; background:rgba(0,0,0,.65); color:#fff; padding:.4rem .8rem; font-size:.85rem; display:none; white-space:pre-wrap; }
+  body.show-notes .notes { display:block; }
+  #hud { position:fixed; bottom:.5rem; right:.8rem; color:#fff; background:rgba(0,0,0,.5); padding:.2rem .6rem; border-radius:6px; font:600 .85rem var(--font); }
+  @media print { html,body{overflow:visible;background:#fff;} section{position:static;display:grid!important;page-break-after:always;height:100vh;} #hud{display:none;} }
+</style></head>
+<body>
+<div id="deck">${sections}</div>
+<div id="hud" aria-live="polite"><span id="cur">1</span> / ${deck.slides.length}</div>
+<script>
+  (function(){
+    var secs = [].slice.call(document.querySelectorAll('#deck section'));
+    var i = 0;
+    function show(n){ i = Math.max(0, Math.min(secs.length-1, n)); secs.forEach(function(s,k){ s.classList.toggle('on', k===i); }); document.getElementById('cur').textContent = (i+1); location.hash = '#'+(i+1); }
+    function next(){ show(i+1); } function prev(){ show(i-1); }
+    document.addEventListener('keydown', function(e){
+      if (e.key==='ArrowRight'||e.key==='ArrowDown'||e.key===' '||e.key==='PageDown'){ next(); e.preventDefault(); }
+      else if (e.key==='ArrowLeft'||e.key==='ArrowUp'||e.key==='PageUp'){ prev(); e.preventDefault(); }
+      else if (e.key==='Home'){ show(0); } else if (e.key==='End'){ show(secs.length-1); }
+      else if (e.key==='n'||e.key==='N'){ document.body.classList.toggle('show-notes'); }
+      else if (e.key==='f'||e.key==='F'){ if(document.fullscreenElement) document.exitFullscreen(); else document.documentElement.requestFullscreen&&document.documentElement.requestFullscreen(); }
+    });
+    document.addEventListener('click', function(e){ if (e.clientX < window.innerWidth*0.3) prev(); else next(); });
+    var sx=null; document.addEventListener('touchstart', function(e){ sx = e.touches[0].clientX; }, {passive:true});
+    document.addEventListener('touchend', function(e){ if(sx==null) return; var dx = e.changedTouches[0].clientX - sx; if(Math.abs(dx)>40){ dx<0?next():prev(); } sx=null; });
+    var h = parseInt((location.hash||'').slice(1),10); show(isNaN(h)?0:h-1);
+  })();
+</script>
+</body></html>`;
+}
+
+function shapeHtml(el, style) {
+  if (el.shape === 'ellipse') return `<div class="el" style="${style};background:${xmlEscape(el.fill)};border:2px solid ${xmlEscape(el.stroke)};border-radius:50%"></div>`;
+  if (el.shape === 'line') return `<svg class="el" style="${style}" viewBox="0 0 100 100" preserveAspectRatio="none"><line x1="0" y1="0" x2="100" y2="100" stroke="${xmlEscape(el.stroke)}" stroke-width="2"/></svg>`;
+  return `<div class="el" style="${style};background:${xmlEscape(el.fill)};border:2px solid ${xmlEscape(el.stroke)}"></div>`;
+}
+function markup(ln) {
+  let t = xmlEscape(ln.text);
+  if (ln.bold) t = `<strong>${t}</strong>`;
+  if (ln.italic) t = `<em>${t}</em>`;
+  return t || '&nbsp;';
+}
+function pct(v) { return (v * 100).toFixed(3) + '%'; }
+
+// ============================================================================
+// PDF export — one page per slide, hand-rolled PDF 1.4 (io-pdf.js approach)
+// ============================================================================
+
+const PDF_W = 720;   // 10in × 72 — matches the 16:9 slide aspect
+const PDF_H = 405;   // 5.625in × 72
+
+function pdfEsc(s) {
+  let out = '';
+  for (const ch of String(s)) {
+    const code = ch.codePointAt(0);
+    if (ch === '(' || ch === ')' || ch === '\\') out += '\\' + ch;
+    else if (code < 32) out += ' ';
+    else if (code < 256) out += ch;
+    else out += '?';
+  }
+  return out;
+}
+
+export function deckToPdf(deckRaw, title = 'Slides') {
+  const deck = normalizeDeck(deckRaw);
+  const th = themeOf(deck);
+  const accent = rgbOf(th.accent);
+  const fg = rgbOf(th.fg);
+
+  const pages = deck.slides.map((slide) => {
+    const ops = [];
+    const bg = rgbOf(slide.background || th.bg);
+    ops.push(`${bg.join(' ')} rg 0 0 ${PDF_W} ${PDF_H} re f`);
+
+    for (const el of slide.elements) {
+      const x = el.x * PDF_W;
+      const yTop = PDF_H - el.y * PDF_H; // PDF origin is bottom-left
+      const w = el.w * PDF_W, h = el.h * PDF_H;
+      if (el.type === 'shape') {
+        const fill = rgbOf(el.fill), stroke = rgbOf(el.stroke);
+        if (el.shape === 'line') {
+          ops.push(`${stroke.join(' ')} RG 1.5 w ${fmt(x)} ${fmt(yTop)} m ${fmt(x + w)} ${fmt(yTop - h)} l S`);
+        } else {
+          // Rectangle approximation for ellipse too (PDF curve math omitted; honest about it).
+          ops.push(`${fill.join(' ')} rg ${stroke.join(' ')} RG 1 w ${fmt(x)} ${fmt(yTop - h)} ${fmt(w)} ${fmt(h)} re B`);
+        }
+      } else if (el.type === 'text') {
+        const isTitle = el.role === 'title' || el.role === 'section';
+        const size = isTitle ? Math.min(28, 26) : 16;
+        const color = isTitle ? accent : fg;
+        const lines = bulletLines(el);
+        let ty = yTop - size; // first baseline
+        for (const ln of lines) {
+          if (ty < 6) break;
+          const font = ln.bold ? 'Helvetica-Bold' : ln.italic ? 'Helvetica-Oblique' : 'Helvetica';
+          const prefix = (!isTitle) ? '• ' : '';
+          const indent = ln.level * 14;
+          ops.push(`${color.join(' ')} rg BT /${font} ${size} Tf ${fmt(x + indent)} ${fmt(ty)} Td (${pdfEsc(prefix + ln.text)}) Tj ET`);
+          ty -= size * 1.35;
+        }
+      }
+      // Images are intentionally not embedded in the PDF (no JPEG/PNG XObject
+      // pipeline here) — a placeholder box keeps layout honest.
+      if (el.type === 'image') {
+        ops.push(`0.8 0.8 0.8 rg ${fmt(x)} ${fmt(yTop - h)} ${fmt(w)} ${fmt(h)} re f`);
+      }
+    }
+    return ops.join('\n');
+  });
+
+  return assemblePdf(pages, title);
+}
+
+function fmt(n) { return (Math.round(n * 100) / 100).toString(); }
+
+function rgbOf(c) {
+  const h = hex(c);
+  return [parseInt(h.slice(0, 2), 16) / 255, parseInt(h.slice(2, 4), 16) / 255, parseInt(h.slice(4, 6), 16) / 255]
+    .map((v) => Math.round(v * 1000) / 1000);
+}
+
+function assemblePdf(pageStreams, title) {
+  const fonts = ['Helvetica', 'Helvetica-Bold', 'Helvetica-Oblique'];
+  const objects = [];
+  const add = (body) => { objects.push(body); return objects.length; };
+  const catalogNo = 1, pagesNo = 2;
+  objects.push(null, null);
+
+  const fontObjNo = {};
+  for (const fn of fonts) {
+    fontObjNo[fn] = add(`<< /Type /Font /Subtype /Type1 /BaseFont /${fn} /Encoding /WinAnsiEncoding >>`);
+  }
+  const fontRes = fonts.map((fn) => `/${fn} ${fontObjNo[fn]} 0 R`).join(' ');
+
+  const kids = [];
+  for (const content of pageStreams) {
+    const contentNo = add(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`);
+    const pageNo = add(`<< /Type /Page /Parent ${pagesNo} 0 R /MediaBox [0 0 ${PDF_W} ${PDF_H}] /Resources << /Font << ${fontRes} >> >> /Contents ${contentNo} 0 R >>`);
+    kids.push(`${pageNo} 0 R`);
+  }
+
+  objects[catalogNo - 1] = `<< /Type /Catalog /Pages ${pagesNo} 0 R >>`;
+  objects[pagesNo - 1] = `<< /Type /Pages /Count ${pageStreams.length} /Kids [${kids.join(' ')}] >>`;
+  const infoNo = add(`<< /Title (${pdfEsc(title)}) /Producer (edot-slides) /Creator (edot-slides) >>`);
+
+  let pdf = '%PDF-1.4\n%\xE2\xE3\xCF\xD3\n';
+  const offsets = [];
+  objects.forEach((body, i) => { offsets[i] = pdf.length; pdf += `${i + 1} 0 obj\n${body}\nendobj\n`; });
+  const xrefPos = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (let i = 0; i < objects.length; i++) pdf += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root ${catalogNo} 0 R /Info ${infoNo} 0 R >>\nstartxref\n${xrefPos}\n%%EOF`;
+
+  const bytes = new Uint8Array(pdf.length);
+  for (let i = 0; i < pdf.length; i++) bytes[i] = pdf.charCodeAt(i) & 0xff;
+  return new Blob([bytes], { type: 'application/pdf' });
+}
+
+// ============================================================================
+// PNG per slide — render a slide to an SVG then rasterise to PNG via canvas.
+// (Browser-only: needs Image/canvas. Returns a Blob.)
+// ============================================================================
+
+export function slideToSvg(deckRaw, index, { width = 1280 } = {}) {
+  const deck = normalizeDeck(deckRaw);
+  const slide = deck.slides[index];
+  if (!slide) throw new Error('No such slide');
+  const th = themeOf(deck);
+  const W = width, H = Math.round((width * 9) / 16);
+  const bg = slide.background || th.bg;
+  let body = `<rect width="${W}" height="${H}" fill="${xmlEscape(bg)}"/>`;
+  for (const el of slide.elements) {
+    const x = el.x * W, y = el.y * H, w = el.w * W, h = el.h * H;
+    if (el.type === 'text') {
+      const isTitle = el.role === 'title' || el.role === 'section';
+      const size = isTitle ? Math.round(H * 0.09) : Math.round(H * 0.05);
+      const color = isTitle ? th.accent : th.fg;
+      const lines = bulletLines(el);
+      let ty = y + size;
+      for (const ln of lines) {
+        const weight = ln.bold ? ' font-weight="bold"' : '';
+        const style = ln.italic ? ' font-style="italic"' : '';
+        const prefix = isTitle ? '' : '• ';
+        body += `<text x="${(x + ln.level * size * 0.7).toFixed(1)}" y="${ty.toFixed(1)}" font-size="${size}" fill="${xmlEscape(color)}" font-family="${xmlEscape(th.font)}"${weight}${style}>${xmlEscape(prefix + ln.text)}</text>`;
+        ty += size * 1.4;
+      }
+    } else if (el.type === 'image') {
+      body += `<image x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${w.toFixed(1)}" height="${h.toFixed(1)}" href="${xmlEscape(el.dataUrl)}" preserveAspectRatio="xMidYMid meet"/>`;
+    } else if (el.type === 'shape') {
+      if (el.shape === 'ellipse') body += `<ellipse cx="${(x + w / 2).toFixed(1)}" cy="${(y + h / 2).toFixed(1)}" rx="${(w / 2).toFixed(1)}" ry="${(h / 2).toFixed(1)}" fill="${xmlEscape(el.fill)}" stroke="${xmlEscape(el.stroke)}" stroke-width="2"/>`;
+      else if (el.shape === 'line') body += `<line x1="${x.toFixed(1)}" y1="${y.toFixed(1)}" x2="${(x + w).toFixed(1)}" y2="${(y + h).toFixed(1)}" stroke="${xmlEscape(el.stroke)}" stroke-width="2"/>`;
+      else body += `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${w.toFixed(1)}" height="${h.toFixed(1)}" fill="${xmlEscape(el.fill)}" stroke="${xmlEscape(el.stroke)}" stroke-width="2"/>`;
+    }
+  }
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">${body}</svg>`;
+}
+
+export async function slideToPng(deckRaw, index, opts = {}) {
+  const svg = slideToSvg(deckRaw, index, opts);
+  const url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  const img = new Image();
+  await new Promise((res, rej) => { img.onload = res; img.onerror = () => rej(new Error('SVG render failed')); img.src = url; });
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth || (opts.width || 1280);
+  canvas.height = img.naturalHeight || Math.round((opts.width || 1280) * 9 / 16);
+  canvas.getContext('2d').drawImage(img, 0, 0);
+  return new Promise((res) => canvas.toBlob((b) => res(b), 'image/png'));
+}
+
+// ============================================================================
+// small XML/zip helpers shared by the importers
+// ============================================================================
+
+function parseXml(bytes) {
+  return new DOMParser().parseFromString(utf8.decode(bytes), 'application/xml');
+}
+
+// Resolve a *.rels file (Uint8Array) into { relId: target }.
+function parseRels(bytes) {
+  const map = {};
+  if (!bytes) return map;
+  const doc = parseXml(bytes);
+  Array.from(doc.getElementsByTagName('Relationship')).forEach((r) => {
+    map[r.getAttribute('Id')] = r.getAttribute('Target');
+  });
+  return map;
+}
+
+function relsPathFor(partPath) {
+  const i = partPath.lastIndexOf('/');
+  return partPath.slice(0, i + 1) + '_rels/' + partPath.slice(i + 1) + '.rels';
+}
+function dirOf(p) { const i = p.lastIndexOf('/'); return i < 0 ? '' : p.slice(0, i); }
+function slideNum(p) { const m = /slide(\d+)\.xml$/.exec(p); return m ? +m[1] : 0; }
+
+// Resolve a possibly-relative OOXML target ("../media/x.png") against a base dir.
+function normPath(base, target) {
+  if (target.startsWith('/')) return target.replace(/^\//, '');
+  const parts = (base + target).split('/');
+  const out = [];
+  for (const part of parts) {
+    if (part === '..') out.pop();
+    else if (part !== '.' && part !== '') out.push(part);
+  }
+  return out.join('/');
+}

--- a/magpie/edot/slides/slides-model.js
+++ b/magpie/edot/slides/slides-model.js
@@ -1,0 +1,180 @@
+// slides-model.js — the canonical deck "core" and helpers over it.
+//
+// The deck is plain JSON; this is the single source of truth that every other
+// representation (PPTX / ODP / PDF / HTML / PNG) is derived from. Keeping it a
+// pure data structure (no DOM, no classes-with-behaviour) is what makes the
+// native .json export lossless and the round-trip tests meaningful.
+//
+// Coordinate system: element x/y/w/h are normalized 0..1 of the slide W×H.
+// The slide is 16:9 by default (see EMU export math in slides-formats.js).
+
+export const DECK_VERSION = 1;
+
+// A small, deliberately limited theme set (colors + fonts only). Themes are
+// presentation hints; they round-trip through native JSON but are only
+// best-effort in PPTX/ODP (documented in the fidelity matrix).
+export const THEMES = {
+  classic: { name: 'Classic', bg: '#ffffff', fg: '#1c1c1c', accent: '#8b4513', font: 'Georgia, "Times New Roman", serif' },
+  midnight: { name: 'Midnight', bg: '#13151c', fg: '#f0f0f2', accent: '#7aa2ff', font: '-apple-system, "Segoe UI", Roboto, sans-serif' },
+  paper: { name: 'Paper', bg: '#f4f1ea', fg: '#2a2620', accent: '#b5651d', font: 'Palatino, Georgia, serif' },
+  ink: { name: 'Ink', bg: '#fafafa', fg: '#111111', accent: '#1a73e8', font: '-apple-system, "Segoe UI", Roboto, sans-serif' },
+};
+
+// Layout = a named arrangement of placeholder elements. The editor edits these
+// placeholders by `role`; the layout id is preserved for re-export/import.
+export const LAYOUTS = ['title', 'title-content', 'two-column', 'section', 'blank'];
+
+let _seq = 0;
+// Stable-ish unique id. Date.now()+counter avoids crypto dependency and stays
+// deterministic-enough within a session; ids are never used in exported bytes
+// in a way that would break determinism (slide files are numbered slideN.xml).
+export function uid(prefix = 'id') {
+  _seq += 1;
+  return `${prefix}-${Date.now().toString(36)}-${_seq}`;
+}
+
+function textEl(role, x, y, w, h, runs = [{ text: '' }]) {
+  return { type: 'text', role, x, y, w, h, runs };
+}
+
+// Build the placeholder elements for a layout. `title`/`body` strings seed the
+// first run so a freshly added slide is immediately editable.
+export function layoutElements(layout, { title = '', body = '' } = {}) {
+  const t = (s) => [{ text: s }];
+  switch (layout) {
+    case 'title':
+      return [
+        textEl('title', 0.1, 0.34, 0.8, 0.18, t(title || 'Title')),
+        textEl('subtitle', 0.1, 0.54, 0.8, 0.12, t(body || 'Subtitle')),
+      ];
+    case 'section':
+      return [textEl('title', 0.08, 0.42, 0.84, 0.18, t(title || 'Section'))];
+    case 'two-column':
+      return [
+        textEl('title', 0.06, 0.06, 0.88, 0.14, t(title || 'Title')),
+        textEl('body', 0.06, 0.24, 0.43, 0.68, t(body || '')),
+        textEl('body2', 0.51, 0.24, 0.43, 0.68, t('')),
+      ];
+    case 'blank':
+      return [];
+    case 'title-content':
+    default:
+      return [
+        textEl('title', 0.06, 0.06, 0.88, 0.16, t(title || 'Title')),
+        textEl('body', 0.06, 0.26, 0.88, 0.66, t(body || '')),
+      ];
+  }
+}
+
+export function newSlide(layout = 'title-content', seed = {}) {
+  return {
+    id: uid('s'),
+    layout,
+    background: null, // null = inherit theme bg; else a CSS color string
+    elements: layoutElements(layout, seed),
+    notes: '',
+  };
+}
+
+export function newDeck(title = 'Untitled deck') {
+  return {
+    version: DECK_VERSION,
+    id: uid('deck'),
+    title,
+    theme: 'classic',
+    mtime: Date.now(),
+    slides: [
+      newSlide('title', { title, body: '' }),
+      newSlide('title-content', { title: 'Slide 2' }),
+    ],
+  };
+}
+
+export function themeOf(deck) {
+  return THEMES[deck && deck.theme] || THEMES.classic;
+}
+
+// The title element's plain text (used for thumbnails, library, PPTX title id).
+export function slideTitle(slide) {
+  const el = (slide.elements || []).find((e) => e.type === 'text' && (e.role === 'title' || e.role === 'subtitle'));
+  return el ? runsText(el.runs) : '';
+}
+
+export function runsText(runs) {
+  return (runs || []).map((r) => r.text || '').join('');
+}
+
+// Find the placeholder a layout-aware editor edits for a given role.
+export function elementByRole(slide, role) {
+  return (slide.elements || []).find((e) => e.type === 'text' && e.role === role) || null;
+}
+
+// Deep, structural clone for duplicate-slide / undo snapshots. Re-ids the slide
+// (and keeps element role/positions) so the duplicate is independent.
+export function cloneSlide(slide) {
+  const copy = structuredClone(slide);
+  copy.id = uid('s');
+  return copy;
+}
+
+// Validate + normalize an imported/parsed object into a well-formed deck so the
+// rest of the app can trust the shape. Drops unknown element types defensively.
+export function normalizeDeck(obj) {
+  const deck = obj && typeof obj === 'object' ? obj : {};
+  const out = {
+    version: DECK_VERSION,
+    id: typeof deck.id === 'string' ? deck.id : uid('deck'),
+    title: typeof deck.title === 'string' ? deck.title : 'Untitled deck',
+    theme: THEMES[deck.theme] ? deck.theme : 'classic',
+    mtime: Number(deck.mtime) || Date.now(),
+    slides: [],
+  };
+  const slides = Array.isArray(deck.slides) ? deck.slides : [];
+  for (const s of slides) {
+    out.slides.push({
+      id: typeof s.id === 'string' ? s.id : uid('s'),
+      layout: LAYOUTS.includes(s.layout) ? s.layout : 'title-content',
+      background: typeof s.background === 'string' ? s.background : null,
+      elements: (Array.isArray(s.elements) ? s.elements : []).map(normalizeElement).filter(Boolean),
+      notes: typeof s.notes === 'string' ? s.notes : '',
+    });
+  }
+  if (!out.slides.length) out.slides.push(newSlide('title', { title: out.title }));
+  return out;
+}
+
+function num(v, d) { const n = Number(v); return Number.isFinite(n) ? n : d; }
+
+function normalizeElement(e) {
+  if (!e || typeof e !== 'object') return null;
+  const base = { x: num(e.x, 0.1), y: num(e.y, 0.1), w: num(e.w, 0.8), h: num(e.h, 0.2) };
+  if (e.type === 'text') {
+    const runs = (Array.isArray(e.runs) ? e.runs : [{ text: '' }]).map((r) => ({
+      text: typeof r.text === 'string' ? r.text : '',
+      bold: !!r.bold,
+      italic: !!r.italic,
+      level: num(r.level, 0),
+    }));
+    return { type: 'text', role: typeof e.role === 'string' ? e.role : undefined, ...base, runs };
+  }
+  if (e.type === 'image') {
+    if (typeof e.dataUrl !== 'string') return null;
+    return { type: 'image', ...base, dataUrl: e.dataUrl, alt: typeof e.alt === 'string' ? e.alt : '' };
+  }
+  if (e.type === 'shape') {
+    const shape = ['rect', 'ellipse', 'line'].includes(e.shape) ? e.shape : 'rect';
+    return { type: 'shape', ...base, shape, fill: typeof e.fill === 'string' ? e.fill : '#dddddd', stroke: typeof e.stroke === 'string' ? e.stroke : '#333333' };
+  }
+  return null;
+}
+
+// Group a body element's runs into bullet lines (one line per run here; the
+// editor keeps one run per logical line with a `level`). Used by every renderer.
+export function bulletLines(el) {
+  return (el.runs || []).map((r) => ({
+    text: r.text || '',
+    level: Math.max(0, Math.min(4, r.level || 0)),
+    bold: !!r.bold,
+    italic: !!r.italic,
+  }));
+}

--- a/magpie/edot/slides/slides-store.js
+++ b/magpie/edot/slides/slides-store.js
@@ -1,0 +1,74 @@
+// slides-store.js — IndexedDB persistence for slide decks.
+//
+// Mirrors the idb helper pattern in magpie/edot/data/data-engine.js (a tiny
+// key/value object store), scoped to its own database so it can't collide with
+// the editor or data layers. Stores ONLY the user's own decks locally (Data
+// Ethics, CLAUDE.md): nothing leaves the device, no third-party data is mixed.
+//
+// One record per deck, keyed by deck.id. The value is the canonical deck JSON
+// "core" (see slides-model.js) — everything else (PPTX / PDF / HTML / PNG) is
+// derived from it on demand.
+
+const IDB_DB = 'edot-slides';
+const IDB_STORE = 'decks';
+
+function idbOpen() {
+  return new Promise((resolve, reject) => {
+    const r = indexedDB.open(IDB_DB, 1);
+    r.onupgradeneeded = () => {
+      if (!r.result.objectStoreNames.contains(IDB_STORE)) {
+        r.result.createObjectStore(IDB_STORE, { keyPath: 'id' });
+      }
+    };
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+  });
+}
+
+// Persist a deck (insert or replace). Returns the deck id.
+export async function saveDeck(deck) {
+  const db = await idbOpen();
+  await new Promise((res, rej) => {
+    const tx = db.transaction(IDB_STORE, 'readwrite');
+    // structuredClone strips any live DOM/proxy refs so IDB can store it.
+    tx.objectStore(IDB_STORE).put(structuredClone(deck));
+    tx.oncomplete = res;
+    tx.onerror = () => rej(tx.error);
+  });
+  return deck.id;
+}
+
+// Load one deck by id (or null if absent).
+export async function loadDeck(id) {
+  const db = await idbOpen();
+  return new Promise((res, rej) => {
+    const tx = db.transaction(IDB_STORE, 'readonly');
+    const rq = tx.objectStore(IDB_STORE).get(id);
+    rq.onsuccess = () => res(rq.result || null);
+    rq.onerror = () => rej(rq.error);
+  });
+}
+
+// List decks as lightweight summaries (id, title, slide count, mtime) for a
+// library picker — avoids deserialising every deck's images.
+export async function listDecks() {
+  const db = await idbOpen();
+  return new Promise((res, rej) => {
+    const tx = db.transaction(IDB_STORE, 'readonly');
+    const rq = tx.objectStore(IDB_STORE).getAll();
+    rq.onsuccess = () => res((rq.result || [])
+      .map((d) => ({ id: d.id, title: d.title || 'Untitled deck', slides: (d.slides || []).length, mtime: d.mtime || 0 }))
+      .sort((a, b) => b.mtime - a.mtime));
+    rq.onerror = () => rej(rq.error);
+  });
+}
+
+export async function deleteDeck(id) {
+  const db = await idbOpen();
+  await new Promise((res, rej) => {
+    const tx = db.transaction(IDB_STORE, 'readwrite');
+    tx.objectStore(IDB_STORE).delete(id);
+    tx.oncomplete = res;
+    tx.onerror = () => rej(tx.error);
+  });
+}

--- a/magpie/edot/slides/slides.css
+++ b/magpie/edot/slides/slides.css
@@ -1,0 +1,181 @@
+/* slides.css — styles for <edot-slides> (light-DOM custom element).
+   Mobile-first, em/rem units, dark-mode aware. Mirrors edot's palette
+   conventions (data.css / edot.css). */
+
+:root {
+  --s-bg: #f4f4f2; --s-surface: #fff; --s-ink: #1c1c1c; --s-muted: #5a5a5a;
+  --s-line: #d9d6cf; --s-accent: #8b4513; --s-accent-fg: #fff; --s-focus: #1a73e8;
+  --s-head: #efece6; --s-sel: rgba(26,115,232,0.14); --s-danger: #b00020;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --s-bg: #1a1a1a; --s-surface: #242424; --s-ink: #ececec; --s-muted: #a8a8a8;
+    --s-line: #3a3a3a; --s-accent: #d2935a; --s-accent-fg: #1a1a1a; --s-head: #2c2c2c;
+    --s-sel: rgba(120,170,255,0.22);
+  }
+}
+
+* { box-sizing: border-box; }
+edot-slides { display: block; height: 100%; }
+
+.sl-app {
+  display: grid;
+  grid-template-columns: 11rem 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas: "toolbar toolbar" "rail editor";
+  height: 100%;
+  min-height: 0;
+  background: var(--s-bg);
+  color: var(--s-ink);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ---- toolbar ---- */
+.sl-toolbar {
+  grid-area: toolbar;
+  display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center;
+  padding: 0.4rem 0.6rem; background: var(--s-surface); border-bottom: 1px solid var(--s-line);
+}
+.sl-title {
+  font: inherit; font-weight: 600; font-size: 0.95rem;
+  padding: 0.3em 0.5em; min-width: 8rem; flex: 0 1 16rem;
+  border: 1px solid var(--s-line); border-radius: 6px;
+  background: var(--s-bg); color: var(--s-ink);
+}
+.sl-spacer { flex: 1; }
+
+.sl-btn {
+  font: inherit; font-size: 0.85rem; padding: 0.35em 0.7em;
+  border: 1px solid var(--s-line); border-radius: 6px;
+  background: var(--s-surface); color: var(--s-ink); cursor: pointer; white-space: nowrap;
+  touch-action: manipulation;
+}
+.sl-btn:hover { border-color: var(--s-focus); }
+.sl-btn:focus-visible { outline: 2px solid var(--s-focus); outline-offset: 1px; }
+.sl-btn.primary { background: var(--s-accent); color: var(--s-accent-fg); border-color: var(--s-accent); }
+.sl-fmt { font-weight: 700; min-width: 2.2em; }
+.sl-fmt[title="Italic"] { font-style: italic; }
+
+.sl-select {
+  font: inherit; font-size: 0.85rem; padding: 0.3em 0.4em;
+  border: 1px solid var(--s-line); border-radius: 6px; background: var(--s-surface); color: var(--s-ink);
+}
+
+/* ---- file menu ---- */
+.sl-menu-wrap { position: relative; }
+.sl-menu {
+  display: none; position: absolute; right: 0; top: 100%; margin-top: 0.25rem; z-index: 30;
+  min-width: 14rem; background: var(--s-surface); border: 1px solid var(--s-line);
+  border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); padding: 0.3rem;
+}
+.sl-menu.open { display: block; }
+.sl-menu-item {
+  display: block; width: 100%; text-align: left; font: inherit; font-size: 0.88rem;
+  padding: 0.45em 0.6em; border: 0; border-radius: 5px; background: transparent; color: var(--s-ink); cursor: pointer;
+}
+.sl-menu-item:hover { background: var(--s-head); }
+.sl-menu-hr { border: 0; border-top: 1px solid var(--s-line); margin: 0.3rem 0; }
+
+/* ---- slide rail ---- */
+.sl-rail {
+  grid-area: rail;
+  overflow-y: auto; min-height: 0; padding: 0.4rem;
+  background: var(--s-surface); border-right: 1px solid var(--s-line);
+}
+.sl-thumb {
+  position: relative; margin-bottom: 0.5rem; padding: 0.3rem 0.3rem 0.3rem 1.4rem;
+  border: 1px solid var(--s-line); border-radius: 7px; cursor: pointer; background: var(--s-bg);
+}
+.sl-thumb:hover { border-color: var(--s-focus); }
+.sl-thumb.active { border-color: var(--s-focus); box-shadow: 0 0 0 2px var(--s-sel); }
+.sl-thumb:focus-visible { outline: 2px solid var(--s-focus); outline-offset: 1px; }
+.sl-thumb-num { position: absolute; left: 0.3rem; top: 0.3rem; font-size: 0.7rem; color: var(--s-muted); font-weight: 700; }
+.sl-thumb-mini { border-radius: 3px; overflow: hidden; line-height: 0; }
+.sl-thumb-mini svg { width: 100%; height: auto; display: block; }
+.sl-thumb-ctrls { display: flex; gap: 0.15rem; margin-top: 0.25rem; }
+.sl-mini {
+  flex: 1; font-size: 0.75rem; padding: 0.15em 0; border: 1px solid var(--s-line);
+  border-radius: 4px; background: var(--s-surface); color: var(--s-ink); cursor: pointer; touch-action: manipulation;
+}
+.sl-mini:hover:not(:disabled) { border-color: var(--s-focus); }
+.sl-mini:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* ---- editor ---- */
+.sl-editor {
+  grid-area: editor; display: flex; flex-direction: column; min-height: 0; overflow: auto; padding: 0.6rem;
+}
+.sl-slidebar { display: flex; flex-wrap: wrap; gap: 0.3rem; align-items: center; margin-bottom: 0.6rem; }
+.sl-slidebar-label { font-size: 0.8rem; color: var(--s-muted); font-weight: 600; margin-right: 0.3rem; }
+.sl-bg { display: inline-flex; align-items: center; gap: 0.2rem; cursor: pointer; }
+.sl-bg input[type="color"] { width: 1.8rem; height: 1.8rem; border: 1px solid var(--s-line); border-radius: 5px; background: none; cursor: pointer; }
+
+.sl-stage { display: flex; justify-content: center; }
+.sl-canvas {
+  position: relative; width: 100%; max-width: 56rem; aspect-ratio: 16 / 9;
+  border: 1px solid var(--s-line); border-radius: 6px; box-shadow: 0 4px 18px rgba(0,0,0,0.12);
+  overflow: hidden;
+}
+.sl-el { position: absolute; }
+.sl-el-text { padding: 0; }
+.sl-text {
+  width: 100%; height: 100%; outline: none; overflow: auto;
+  color: var(--fg, #1c1c1c); font-family: var(--font, serif);
+  font-size: clamp(0.7rem, 2.2vw, 1.3rem); line-height: 1.3; padding: 0.1em 0.2em;
+}
+.sl-text:focus { box-shadow: inset 0 0 0 2px var(--s-focus); border-radius: 4px; }
+.sl-text.is-title { color: var(--accent, #8b4513); font-weight: 700; font-size: clamp(1rem, 3.5vw, 2.2rem); display: flex; align-items: center; }
+.sl-text div { min-height: 1.2em; }
+.sl-img { width: 100%; height: 100%; object-fit: contain; }
+.sl-shape { width: 100%; height: 100%; border: 2px solid; }
+.sl-shape-ellipse { border-radius: 50%; }
+.sl-shape-line { background: transparent !important; border: 0; border-top: 2px solid; transform: rotate(0); }
+.sl-el-del {
+  position: absolute; top: -0.5rem; right: -0.5rem; width: 1.4rem; height: 1.4rem;
+  border-radius: 50%; border: 1px solid var(--s-line); background: var(--s-surface); color: var(--s-danger);
+  cursor: pointer; font-size: 0.75rem; line-height: 1; display: none;
+}
+.sl-el:hover .sl-el-del, .sl-el:focus-within .sl-el-del { display: block; }
+
+/* ---- notes ---- */
+.sl-notes { margin-top: 0.6rem; display: flex; flex-direction: column; gap: 0.2rem; max-width: 56rem; width: 100%; align-self: center; }
+.sl-notes label { font-size: 0.78rem; color: var(--s-muted); font-weight: 600; }
+.sl-notes-area {
+  font: inherit; font-size: 0.9rem; min-height: 3.5rem; resize: vertical;
+  padding: 0.5em; border: 1px solid var(--s-line); border-radius: 6px; background: var(--s-surface); color: var(--s-ink);
+}
+
+/* ---- present mode ---- */
+.sl-present {
+  position: fixed; inset: 0; z-index: 1000; background: #000;
+  display: grid; place-items: center; cursor: pointer;
+}
+.sl-present-stage { width: min(100vw, calc(100dvh * 16 / 9)); width: min(100vw, calc(100vh * 16 / 9)); aspect-ratio: 16 / 9; line-height: 0; }
+.sl-present-stage svg { width: 100%; height: 100%; }
+.sl-present-counter {
+  position: fixed; bottom: 0.8rem; right: 1rem; color: #fff; background: rgba(0,0,0,0.55);
+  padding: 0.25rem 0.7rem; border-radius: 6px; font-weight: 600; font-size: 0.9rem; cursor: default;
+}
+
+/* ---- dialogs ---- */
+.sl-dialog-bg { position: fixed; inset: 0; z-index: 900; background: rgba(0,0,0,0.45); display: grid; place-items: center; padding: 1rem; }
+.sl-dialog { background: var(--s-surface); color: var(--s-ink); border-radius: 10px; width: min(32rem, 100%); max-height: 85vh; display: flex; flex-direction: column; box-shadow: 0 12px 40px rgba(0,0,0,0.3); }
+.sl-dialog-h { margin: 0; padding: 0.8rem 1rem; font-size: 1.05rem; border-bottom: 1px solid var(--s-line); }
+.sl-dialog-list { overflow: auto; padding: 0.6rem 1rem; flex: 1; }
+.sl-dialog-foot { padding: 0.6rem 1rem; border-top: 1px solid var(--s-line); display: flex; justify-content: flex-end; }
+.sl-deck-row { display: flex; gap: 0.4rem; align-items: center; margin-bottom: 0.4rem; }
+.sl-deck-open { flex: 1; text-align: left; font: inherit; padding: 0.5em 0.7em; border: 1px solid var(--s-line); border-radius: 6px; background: var(--s-bg); color: var(--s-ink); cursor: pointer; }
+.sl-deck-open:hover { border-color: var(--s-focus); }
+.sl-deck-del { border: 1px solid var(--s-line); border-radius: 6px; background: var(--s-surface); cursor: pointer; padding: 0.4em 0.6em; }
+
+.sl-toast { position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%); z-index: 1100; background: var(--s-danger); color: #fff; padding: 0.6rem 1rem; border-radius: 8px; font-size: 0.9rem; box-shadow: 0 6px 20px rgba(0,0,0,0.3); }
+
+/* ---- mobile: rail collapses to a drawer ---- */
+@media (max-width: 640px) {
+  .sl-app { grid-template-columns: 1fr; grid-template-areas: "toolbar" "editor"; }
+  .sl-rail {
+    position: fixed; left: 0; top: 0; bottom: 0; z-index: 50; width: 12rem;
+    transform: translateX(-100%); transition: transform 0.2s ease; box-shadow: 4px 0 16px rgba(0,0,0,0.2);
+  }
+  .sl-app.rail-open .sl-rail { transform: translateX(0); }
+}
+.sl-inspector { display: none; }

--- a/magpie/edot/slides/slides.html
+++ b/magpie/edot/slides/slides.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="description" content="edot slides — an accessible, mobile-first slide presentation app: author, edit, present, and round-trip PPTX / ODP / PDF / HTML, all offline in the browser.">
+  <meta name="color-scheme" content="light dark">
+  <title>edot slides — present + edit</title>
+  <link rel="stylesheet" href="slides.css">
+  <link rel="stylesheet" href="../auth/css/auth.css">
+  <style>
+    html, body { height: 100%; margin: 0; overflow: hidden; }
+    .login-slot { display: inline-flex; align-items: center; gap: 0.25rem; }
+    .alpha-badge { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: #fff; background: var(--s-accent); padding: 0.05em 0.4em; border-radius: 999px; }
+    body {
+      display: flex; flex-direction: column;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--s-bg); color: var(--s-ink);
+    }
+    .app-header { display: flex; align-items: center; gap: 0.6rem; padding: 0.4rem 0.75rem; background: var(--s-surface); border-bottom: 1px solid var(--s-line); flex: 0 0 auto; }
+    .app-header h1 { font-size: 1.05rem; margin: 0; }
+    .app-header .logo { color: var(--s-accent); }
+    .app-header a { color: var(--s-focus); font-size: 0.85rem; text-decoration: none; }
+    .app-header .spacer { flex: 1; }
+    main { flex: 1 1 auto; min-height: 0; }
+    .boot { padding: 2rem; color: var(--s-muted); }
+  </style>
+</head>
+<body>
+  <header class="app-header">
+    <h1><span class="logo">▤ edot slides</span></h1>
+    <span class="spacer"></span>
+    <a href="../edot.html">← back to editor</a>
+    <span class="login-slot"><edot-login-button login-href="../auth/login.html"></edot-login-button><span class="alpha-badge" title="Experimental — sign-in is in alpha">alpha</span></span>
+  </header>
+  <main>
+    <edot-slides><div class="boot">Loading slides…</div></edot-slides>
+  </main>
+  <script type="module" src="slides-app.js"></script>
+  <script type="module" src="../auth/js/login-ui.js"></script>
+</body>
+</html>

--- a/magpie/edot/slides/test-slides.mjs
+++ b/magpie/edot/slides/test-slides.mjs
@@ -1,0 +1,299 @@
+// test-slides.mjs — headless test of the edot slides app: deck CRUD +
+// IndexedDB persistence, native JSON round-trip, PPTX export/import round-trip,
+// ODP round-trip, present-mode navigation, and the terminal exports (PDF/HTML).
+//
+// Same harness style as magpie/edot/data/test-data.mjs: a tiny static server
+// rooted at the repo, the real <edot-slides> driven in Chromium via the
+// window.__slides hook, ✅/❌ lines, and a non-zero exit on any failure.
+//
+// Per CLAUDE.md: headless Canvas/WebGL is limited, so these assertions check
+// DOM/logic/format-bytes (titles in slide1.xml, %PDF header, text in HTML),
+// not pixels.
+import { chromium } from 'playwright-core';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.wasm': 'application/wasm', '.json': 'application/json' };
+const server = http.createServer(async (req, res) => {
+  try {
+    const rel = decodeURIComponent(req.url.split('?')[0]).replace(/^\//, '') || 'index.html';
+    const buf = await readFile(path.join(ROOT, rel));
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(rel)] || 'application/octet-stream' });
+    res.end(buf);
+  } catch { res.writeHead(404); res.end(); }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const browser = await chromium.launch({ headless: true, executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome', args: ['--no-sandbox'] });
+let fail = 0; const ok = (n, c) => { console.log(`${c ? '✅' : '❌'} ${n}`); if (!c) fail++; };
+
+try {
+  const page = await browser.newPage();
+  const errs = []; page.on('pageerror', (e) => errs.push(String(e)));
+  await page.goto(`http://127.0.0.1:${port}/magpie/edot/slides/slides.html`);
+  await page.waitForFunction(() => window.__slides && window.__slides.el && window.__slides.el.deck);
+  ok('component booted with a deck', true);
+
+  // 1. Build a deck programmatically: title + bullets + notes; persist + reload.
+  const built = await page.evaluate(async () => {
+    const S = window.__slides;
+    const el = S.el;
+    const deck = S.model.newDeck('Test Deck');
+    deck.slides = [
+      { id: 's1', layout: 'title', background: null, notes: 'opening remarks', elements: [
+        { type: 'text', role: 'title', x: 0.1, y: 0.34, w: 0.8, h: 0.18, runs: [{ text: 'Hello Slides' }] },
+        { type: 'text', role: 'subtitle', x: 0.1, y: 0.54, w: 0.8, h: 0.12, runs: [{ text: 'a subtitle' }] },
+      ] },
+      { id: 's2', layout: 'title-content', background: null, notes: 'speak slowly', elements: [
+        { type: 'text', role: 'title', x: 0.06, y: 0.06, w: 0.88, h: 0.16, runs: [{ text: 'Agenda' }] },
+        { type: 'text', role: 'body', x: 0.06, y: 0.26, w: 0.88, h: 0.66, runs: [
+          { text: 'First point', level: 0, bold: true },
+          { text: 'Second point', level: 0 },
+          { text: 'A sub-point', level: 1, italic: true },
+        ] },
+      ] },
+    ];
+    el.deck = S.model.normalizeDeck(deck);
+    el.current = 0;
+    el._render();
+    await el._saveNow();
+    // Reload from IDB by id.
+    const reloaded = await S.store.loadDeck(el.deck.id);
+    return {
+      id: el.deck.id,
+      title: reloaded.title,
+      slideCount: reloaded.slides.length,
+      titleText: reloaded.slides[0].elements[0].runs[0].text,
+      bodyBold: reloaded.slides[1].elements[1].runs[0].bold,
+      notes: reloaded.slides[1].notes,
+    };
+  });
+  ok('deck has 2 slides after build', built.slideCount === 2);
+  ok('title text persisted to IndexedDB', built.titleText === 'Hello Slides');
+  ok('bullet bold flag persisted', built.bodyBold === true);
+  ok('speaker notes persisted', built.notes === 'speak slowly');
+
+  // 1b. Edit a slide via the DOM editor (contenteditable) and confirm sync.
+  const edited = await page.evaluate(() => {
+    const el = window.__slides.el;
+    el.current = 1; el._renderEditor();
+    const titleEd = el._editorEl.querySelector('.sl-text.is-title');
+    titleEd.innerHTML = '<div data-level="0">Edited Agenda</div>';
+    titleEd.dispatchEvent(new Event('input', { bubbles: true }));
+    return window.__slides.formats; // force eval; real check below
+  });
+  const editedTitle = await page.evaluate(() => window.__slides.el.deck.slides[1].elements[0].runs.map((r) => r.text).join(''));
+  ok('contenteditable edit syncs into the deck core', editedTitle === 'Edited Agenda');
+
+  // 1c. add / duplicate / delete / reorder.
+  const ops = await page.evaluate(() => {
+    const el = window.__slides.el;
+    const start = el.deck.slides.length;
+    el.current = 0; el.addSlide('section');
+    const afterAdd = el.deck.slides.length;
+    el.duplicateSlide(1);
+    const afterDup = el.deck.slides.length;
+    const firstId = el.deck.slides[0].id;
+    el.moveSlide(0, 1);
+    const movedDown = el.deck.slides[1].id === firstId;
+    el.deleteSlide(el.deck.slides.length - 1);
+    const afterDel = el.deck.slides.length;
+    return { start, afterAdd, afterDup, movedDown, afterDel };
+  });
+  ok('addSlide inserts a slide', ops.afterAdd === ops.start + 1);
+  ok('duplicateSlide adds a copy', ops.afterDup === ops.afterAdd + 1);
+  ok('moveSlide reorders', ops.movedDown === true);
+  ok('deleteSlide removes a slide', ops.afterDel === ops.afterDup - 1);
+
+  // 2. Native JSON round-trip recovers the deck exactly.
+  const json = await page.evaluate(() => {
+    const S = window.__slides;
+    const deck = S.model.newDeck('Round Trip');
+    deck.slides[1].notes = 'note here';
+    deck.slides[1].elements.find((e) => e.role === 'body').runs = [{ text: 'one', level: 0, bold: true, italic: false }, { text: 'two', level: 1, bold: false, italic: false }];
+    const norm = S.model.normalizeDeck(deck);
+    const text = S.formats.deckToJson(norm);
+    const back = S.formats.jsonToDeck(text);
+    return {
+      same: JSON.stringify(back) === JSON.stringify(norm),
+      again: S.formats.deckToJson(back) === text, // determinism / idempotence
+    };
+  });
+  ok('JSON round-trip is lossless', json.same === true);
+  ok('JSON export is idempotent', json.again === true);
+
+  // 3. PPTX export produces a valid ZIP whose slide1.xml has the title text.
+  const pptx = await page.evaluate(async () => {
+    const S = window.__slides;
+    const { unzip, utf8 } = await import('../js/zip.js');
+    const deck = S.model.newDeck('Deck PPTX');
+    deck.slides[0].elements[0].runs = [{ text: 'TITLE ALPHA' }];
+    deck.slides[1].elements.find((e) => e.role === 'body').runs = [{ text: 'bullet one', level: 0 }, { text: 'bullet two', level: 0 }];
+    deck.slides[1].notes = 'remember this';
+    const blob = await S.formats.deckToPptx(deck);
+    const map = await unzip(await blob.arrayBuffer());
+    const names = Object.keys(map);
+    const slide1 = utf8.decode(map['ppt/slides/slide1.xml']);
+    const ct = utf8.decode(map['[Content_Types].xml']);
+    const hasNotes = names.includes('ppt/notesSlides/notesSlide2.xml');
+    return {
+      hasPres: names.includes('ppt/presentation.xml'),
+      hasSlide1: names.includes('ppt/slides/slide1.xml'),
+      hasCt: names.includes('[Content_Types].xml'),
+      titleInSlide1: /TITLE ALPHA/.test(slide1),
+      ctValid: /presentationml\.slide\b/.test(ct),
+      hasNotes,
+      blobType: blob.type,
+    };
+  });
+  ok('PPTX contains presentation.xml', pptx.hasPres);
+  ok('PPTX contains slide1.xml', pptx.hasSlide1);
+  ok('PPTX contains [Content_Types].xml', pptx.hasCt);
+  ok('PPTX slide1.xml carries the title text', pptx.titleInSlide1);
+  ok('PPTX content-types declares slide parts', pptx.ctValid);
+  ok('PPTX emits a notes slide for noted slides', pptx.hasNotes);
+  ok('PPTX blob is application/zip', /zip/.test(pptx.blobType));
+
+  // 4. PPTX round-trip: export -> import recovers title + body text + notes.
+  const pptxRt = await page.evaluate(async () => {
+    const S = window.__slides;
+    const deck = S.model.newDeck('RT PPTX');
+    deck.slides[0].elements[0].runs = [{ text: 'Keynote Title' }];
+    const body = deck.slides[1].elements.find((e) => e.role === 'body');
+    body.runs = [{ text: 'Alpha point', level: 0, bold: true }, { text: 'Beta point', level: 1 }];
+    deck.slides[1].notes = 'two lines\nof notes';
+    const blob = await S.formats.deckToPptx(deck);
+    const back = await S.formats.pptxToDeck(await blob.arrayBuffer());
+    const t0 = back.slides[0].elements.map((e) => (e.runs || []).map((r) => r.text).join(' ')).join(' ');
+    const allText = back.slides.flatMap((s) => s.elements).flatMap((e) => (e.runs || []).map((r) => r.text)).join(' | ');
+    const notes = back.slides.map((s) => s.notes).join(' / ');
+    return { count: back.slides.length, t0, allText, notes };
+  });
+  ok('PPTX round-trip recovers slide count', pptxRt.count === 2);
+  ok('PPTX round-trip recovers title text', /Keynote Title/.test(pptxRt.t0));
+  ok('PPTX round-trip recovers body bullets', /Alpha point/.test(pptxRt.allText) && /Beta point/.test(pptxRt.allText));
+  ok('PPTX round-trip recovers notes', /two lines/.test(pptxRt.notes));
+
+  // 4b. PPTX round-trip carries an embedded image.
+  const pptxImg = await page.evaluate(async () => {
+    const S = window.__slides;
+    // 1x1 transparent PNG.
+    const png = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+    const deck = S.model.newDeck('Img Deck');
+    deck.slides[0].elements.push({ type: 'image', x: 0.2, y: 0.2, w: 0.4, h: 0.4, dataUrl: png, alt: 'dot' });
+    const blob = await S.formats.deckToPptx(deck);
+    const back = await S.formats.pptxToDeck(await blob.arrayBuffer());
+    const imgs = back.slides.flatMap((s) => s.elements).filter((e) => e.type === 'image');
+    return { n: imgs.length, isPng: imgs[0] && /^data:image\/png/.test(imgs[0].dataUrl) };
+  });
+  ok('PPTX round-trip carries an image element', pptxImg.n >= 1);
+  ok('PPTX round-trip image is a PNG data URL', pptxImg.isPng === true);
+
+  // 5. ODP round-trip recovers title + body + notes.
+  const odpRt = await page.evaluate(async () => {
+    const S = window.__slides;
+    const deck = S.model.newDeck('ODP Deck');
+    deck.slides[0].elements[0].runs = [{ text: 'Odf Title' }];
+    deck.slides[1].elements.find((e) => e.role === 'body').runs = [{ text: 'odf bullet', level: 0 }];
+    deck.slides[1].notes = 'odf note';
+    const blob = await S.formats.deckToOdp(deck);
+    const back = await S.formats.odpToDeck(await blob.arrayBuffer());
+    const allText = back.slides.flatMap((s) => s.elements).flatMap((e) => (e.runs || []).map((r) => r.text)).join(' | ');
+    return { count: back.slides.length, hasTitle: /Odf Title/.test(allText), hasBullet: /odf bullet/.test(allText), notes: back.slides.map((s) => s.notes).join('/') };
+  });
+  ok('ODP round-trip recovers slide count', odpRt.count === 2);
+  ok('ODP round-trip recovers title', odpRt.hasTitle);
+  ok('ODP round-trip recovers body', odpRt.hasBullet);
+  ok('ODP round-trip recovers notes', /odf note/.test(odpRt.notes));
+
+  // 6. Present mode: next/prev advances index; Esc exits.
+  const present = await page.evaluate(() => {
+    const el = window.__slides.el;
+    el.deck = window.__slides.model.newDeck('Present Deck');
+    el.current = 0; el._render();
+    el.startPresent();
+    const startIdx = el.presentIndex;
+    el.presentNext();
+    const afterNext = el.presentIndex;
+    el.presentPrev();
+    const afterPrev = el.presentIndex;
+    const overlayPresent = !!document.querySelector('.sl-present');
+    el.exitPresent();
+    const overlayGone = !document.querySelector('.sl-present');
+    return { startIdx, afterNext, afterPrev, overlayPresent, overlayGone, presenting: el.presenting };
+  });
+  ok('present mode renders an overlay', present.overlayPresent === true);
+  ok('present next advances the index', present.afterNext === present.startIdx + 1);
+  ok('present prev rewinds the index', present.afterPrev === present.startIdx);
+  ok('Esc exits present mode (overlay removed)', present.overlayGone === true && present.presenting === false);
+
+  // 6b. Present mode via keyboard (real keydown handlers).
+  const presentKeys = await page.evaluate(async () => {
+    const el = window.__slides.el;
+    el.startPresent();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    const idx = el.presentIndex;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    const gone = !document.querySelector('.sl-present');
+    return { idx, gone };
+  });
+  ok('ArrowRight advances in present mode', presentKeys.idx >= 1);
+  ok('Escape key exits present mode', presentKeys.gone === true);
+
+  // 7. PDF export: %PDF header, one page per slide.
+  const pdf = await page.evaluate(async () => {
+    const S = window.__slides;
+    const deck = S.model.newDeck('PDF Deck'); // 2 slides
+    const blob = S.formats.deckToPdf(deck, deck.title);
+    const buf = new Uint8Array(await blob.arrayBuffer());
+    const head = new TextDecoder('latin1').decode(buf.slice(0, 5));
+    const text = new TextDecoder('latin1').decode(buf);
+    const pageCount = (text.match(/\/Type \/Page\b/g) || []).length;
+    return { head, size: buf.length, pageCount, type: blob.type };
+  });
+  ok('PDF export starts with %PDF', pdf.head === '%PDF-');
+  ok('PDF export is non-empty', pdf.size > 500);
+  ok('PDF has one page per slide', pdf.pageCount === 2);
+  ok('PDF blob is application/pdf', pdf.type === 'application/pdf');
+
+  // 8. HTML export contains every slide's text and is self-contained.
+  const html = await page.evaluate(() => {
+    const S = window.__slides;
+    const deck = S.model.newDeck('HTML Deck');
+    deck.slides[0].elements[0].runs = [{ text: 'UNIQUE_TITLE_X' }];
+    deck.slides[1].elements.find((e) => e.role === 'body').runs = [{ text: 'UNIQUE_BODY_Y', level: 0 }];
+    const out = S.formats.deckToHtml(deck);
+    return {
+      hasTitle: out.includes('UNIQUE_TITLE_X'),
+      hasBody: out.includes('UNIQUE_BODY_Y'),
+      selfContained: out.includes('<script>') && !/src=["']http/.test(out) && !/href=["']http/.test(out),
+      navigable: /addEventListener\('keydown'/.test(out),
+      sections: (out.match(/<section/g) || []).length,
+    };
+  });
+  ok('HTML export contains all slide texts', html.hasTitle && html.hasBody);
+  ok('HTML export is self-contained (no remote refs)', html.selfContained);
+  ok('HTML export is keyboard-navigable', html.navigable);
+  ok('HTML export has one section per slide', html.sections === 2);
+
+  // 9. Determinism: two PPTX exports of the same deck are byte-identical.
+  const det = await page.evaluate(async () => {
+    const S = window.__slides;
+    const deck = S.model.normalizeDeck(S.model.newDeck('Det'));
+    const a = new Uint8Array(await (await S.formats.deckToPptx(deck)).arrayBuffer());
+    const b = new Uint8Array(await (await S.formats.deckToPptx(deck)).arrayBuffer());
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  });
+  ok('PPTX export is deterministic (byte-identical)', det === true);
+
+  ok('no page errors', errs.length === 0);
+  if (errs.length) console.log(errs);
+} finally { await browser.close(); server.close(); }
+console.log(fail ? `\n${fail} FAILURE(S)` : '\nSLIDES OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
New suite app at `magpie/edot/slides/` (`<edot-slides>`), built + verified headlessly (**45/45, SLIDES OK**). Authoring (rail, 5 layouts, in-place title/body with bold/italic + bullet levels, images, shapes, backgrounds, notes, themes), **present mode** (keys/click/swipe/counter/Esc), and a canonical JSON deck **core** with derived formats.

The deck format is a **portable, self-contained, versioned** artifact (images inline; no IndexedDB coupling) — IndexedDB is only the local cache, not the format's identity.

**Fidelity (honest — NOT 100%):**
| Format | Import | Export | Notes |
|---|---|---|---|
| JSON | ✓ | ✓ | lossless core |
| PPTX | best-effort | best-effort | titles/bullets/images/notes/order/positions; **drops** animations, transitions, charts, SmartArt, tables, exact theming, master/layout placeholders |
| ODP | best-effort | best-effort | title/body/notes/images/shapes |
| PDF/HTML/PNG | — | ✓ | terminal renders |
| Keynote `.key` | ✗ | ✗ | interop via PPTX/PDF |

Wired into the File menu (Slides ↗) + carries the system-wide login chip. edot smoke/e2e/mobile green; HTML validates. Build → `2026-06-23.j`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_