### PR TITLE
edot: pre-Enterprise foundations — suite test runner, foundations note, command registry + palette

### DIFF
--- a/magpie/edot/css/edot.css
+++ b/magpie/edot/css/edot.css
@@ -432,6 +432,22 @@ select.tbtn {
 .gh-steps li { margin: 0.25rem 0; }
 .gh-steps code { background: var(--bg); padding: 0 0.3em; border-radius: 3px; }
 .gh-tip { color: var(--muted); margin: 0.4rem 0 0; }
+/* Command palette (Mod+K) */
+.dialog.palette { width: min(36rem, 92vw); padding: 0; overflow: hidden; }
+.palette-input {
+  width: 100%; box-sizing: border-box; font: inherit; font-size: 1.05rem;
+  padding: 0.8em 1em; border: none; border-bottom: 1px solid var(--line);
+  background: var(--surface); color: var(--ink);
+}
+.palette-input:focus { outline: none; }
+.palette-list { list-style: none; margin: 0; padding: 0.3rem; max-height: 50vh; overflow: auto; }
+.palette-item { display: flex; align-items: center; gap: 0.6rem; padding: 0.5em 0.7em; border-radius: var(--radius); cursor: pointer; }
+.palette-item.active, .palette-item:hover { background: var(--accent); color: var(--accent-fg); }
+.palette-icon { width: 1.4em; flex: 0 0 auto; text-align: center; }
+.palette-title { flex: 1; }
+.palette-shortcut { font-size: 0.78rem; opacity: 0.7; font-variant-numeric: tabular-nums; }
+.palette-empty { padding: 0.8em 1em; color: var(--muted); }
+
 /* Build stamp in the status bar — a quick "am I on the latest deploy?" check. */
 .build-stamp { color: var(--muted); font-size: 0.7rem; opacity: 0.75; font-variant-numeric: tabular-nums; }
 

--- a/magpie/edot/docs/research/pre-enterprise-foundations.md
+++ b/magpie/edot/docs/research/pre-enterprise-foundations.md
@@ -1,0 +1,179 @@
+# Pre-Enterprise foundations — the decided architecture
+
+*Companion to `ui-architecture-deepdive.md`. That report surveyed the field; this
+note **decides** the foundations to put in place **before** the big Enterprise
+pushes (full OIDC, email, groups/groupware, governance). The rule for this phase:
+**consolidate, don't expand.** Lay the three things those pushes depend on, and
+harden what exists. No new apps until these land.*
+
+Status legend: ✅ done · 🟡 partial · ⬜ todo.
+
+---
+
+## 0. Why "before"
+
+Groupware, governance, and full identity are not features bolted onto the side —
+they are **properties of the data model and the operation model**. If the suite's
+objects aren't addressable and its mutations aren't a serializable stream, then
+co-editing, sharing, audit, and policy each become a rewrite. The cheap insurance
+is to shape three foundations now, while it's still first-party and local.
+
+The three foundations, and the Enterprise capability each unblocks:
+
+| Foundation | Unblocks |
+|---|---|
+| **1. Command/action registry** (operations as data) | co-editing op-stream, undo/redo, audit log, macros/plugins |
+| **2. Unified data-object + identity model** | sharing/ACLs, sync, versioning, DLP/retention, search |
+| **3. Decided collaboration model + thin backend** | real-time groupware, live OIDC/mail, the key service, presence |
+
+---
+
+## 1. Command / action registry — *operations as data*
+
+**Decision: build a `CommandRegistry` and make every user-meaningful mutation a
+registered command.** A command is data:
+
+```
+{ id: 'doc.format.bold', title: 'Bold', icon: '𝐁', group: 'format', order: 10,
+  shortcut: 'Mod+B', when: (ctx) => ctx.surface === 'editor',
+  run: (ctx, args) => … }
+```
+
+Surfaces (toolbar, menu, command palette, context menu) **render from
+contributions** (`registry.contributions(surface)` filtered by `when`, sorted by
+`group`/`order`) — the Eclipse/VS Code model from the deep-dive, not hand-wiring.
+
+**Why it's a groupware prerequisite, not just UI hygiene:** a co-editing session
+is a *replayed stream of operations*. If every mutation already flows through
+`registry.run(id, args)`, that call site is the natural place to: capture the op
+for **CRDT/OT sync**, push it to the **undo stack**, and emit an **audit event**.
+Build the spine before you must serialize it.
+
+- ⬜ `js/commands.js` — the registry (register/get/run/contributions, `when`, shortcuts).
+- ⬜ **Command palette** (`Mod+K`) — additive surface that lists+runs all commands. *Do this first*: it's low-risk (touches no existing wiring), it's a real Enterprise-grade UX feature, and authoring it forces enumerating the suite's **operation vocabulary** — which is exactly the alphabet collaboration will sync.
+- 🟡 Migrate existing actions: file-menu and suite-launcher commands first (stable ids → tests stay green), formatting toolbar later (it's the most test-heavy; migrate last, carefully).
+
+---
+
+## 2. Unified data-object + identity model
+
+**Decision: every persisted thing is a `DataObject` with a storage-independent
+identity** — your own "storage ≠ format" point, made structural.
+
+```
+{ id,                // stable, opaque (uuid); survives moves/renames
+  type,              // 'doc' | 'sheet'/'data' | 'deck' | 'calendar' | …
+  schemaVersion,     // SemVer of the body schema
+  meta: { title, createdAt, modifiedAt, owner?, labels? },
+  body,              // the canonical core (lossless, self-contained)
+  fingerprint }      // SHA-256(canonical-serialization(body))
+```
+
+- **Identity is content + id, never location.** IndexedDB is one cache; a file, a
+  GitHub commit, an S3/WebDAV/Solid object, or a sync server are equal venues.
+  (The durable data forms already fingerprint; generalize it.)
+- **Canonical serialization must be deterministic** (stable key order, no embedded
+  timestamps) so fingerprints are stable — we already learned this with zip
+  mod-times; apply suite-wide.
+- **Lossless self-contained body** (images inline, no external handles) so the
+  object round-trips byte-identically anywhere.
+
+State:
+- ✅ Data object (SQLite/CSV-zip/N-Quads + SHA-256), slides deck (versioned,
+  self-contained JSON).
+- 🟡 Doc model (HTML core; no explicit id/version/fingerprint wrapper yet).
+- ⬜ A shared `js/data-object.js` (id/type/version/fingerprint/serialize) adopted
+  by every app; **slides `.edeck` extension + media type + fingerprint** (the
+  outstanding consistency item) is the template.
+- ⬜ A tiny **object/metadata index** (id → type, title, version, fingerprint,
+  timestamps) separate from each app's body store. This is the table ACLs, sync
+  state, search, and retention will hang off. Local now; server-mirrored later.
+
+---
+
+## 3. Collaboration model + thin backend — *decide on paper, first*
+
+**Decision: local-first + CRDT, with a thin sync/services backend.** Rationale
+(from the local-first research): preserve offline/ownership/open-format strengths;
+CRDTs converge without a central authority and degrade gracefully when the network
+is absent. OT was rejected (needs a central transform authority and is harder to
+get right); pure server-authoritative was rejected (kills the local-first thesis).
+
+CRDTs are **not uniform across data types** — plan per body:
+
+| Body | Merge strategy |
+|---|---|
+| **Rich text (doc)** | sequence CRDT (RGA/Yjs/Automerge-text); the hard one |
+| **Spreadsheet/grid** | per-cell LWW or a map-CRDT keyed by stable cell id; **formulas recompute from merged values** (the DAG is deterministic) |
+| **Structured records (calendar, places, deck slides, settings)** | map/list CRDT with stable element ids (slides already have per-element ids — keep that) |
+| **Mail** | *not* CRDT — provider is the source of truth; sync = cache reconciliation |
+
+**Shape the data now to be merge-friendly:** stable ids on every element (slides
+✅), avoid array-index identity, avoid structures whose meaning depends on
+position. We don't implement CRDTs in this phase — we **stop making choices that
+preclude them.**
+
+**The thin backend** (one small trusted service) is the convergence point. It
+unblocks, in priority order:
+1. **Auth token-exchange proxy** → live OIDC for providers without browser-CORS token endpoints (the deep-dive's Tier-B providers).
+2. **Tier-2 key service** → OIDC-gated encrypted-backup unlock (`ENCRYPTED-BACKUP.md`).
+3. **CORS/relay proxies** → ICS calendar subscribe, the **IMAP/SMTP WebSocket proxy**, generic fetch relay.
+4. **Sync + presence** → the groupware engine (CRDT doc sync, awareness).
+5. **Search, audit, admin** → governance.
+
+⬜ Decide host (Cloudflare Worker / small container / self-host) and stub the
+**capability-scoped** API (the deep-dive's capability-security model: the service
+hands out unforgeable, narrowly-scoped grants, never ambient authority).
+
+---
+
+## 4. Identity, ACL & governance *seams* (leave the hooks, not the features)
+
+Don't build governance now — but leave the seams so it isn't a retrofit:
+
+- **Identity:** the OIDC `sub` is the principal. Objects carry `owner` (a `sub`);
+  the metadata index can later carry an ACL `{ principal → role }`. Groups come
+  later (a group is just a principal that expands to members).
+- **Audit:** the command registry's `run()` is the single choke point — every
+  governable action passes through it. Leave a no-op `audit(event)` hook there now.
+- **Policy/DLP/retention:** these are predicates over `{ object.meta, command, principal }`.
+  Leave a no-op `policy.check(command, object, principal)` gate at `run()` and at
+  export/share boundaries. Implement later; the call sites exist now.
+- **Sensitivity labels:** reserve `meta.labels` / `meta.classification`.
+
+This is the "extension islands pass through unharmed" discipline applied to
+governance: reserve the slots, ignore them losslessly until they're implemented.
+
+---
+
+## 5. Hygiene to clear in this phase (cheap; prevents carrying debt)
+
+- 🟡 **Consistency pass** — login chip on every app (mail lacks it), shared widgets
+  (tree/longpress/toolbar), one export+fingerprint convention, slides `.edeck`.
+  The apps drifted because parallel agents built them.
+- 🟡 **CI** — `run-tests.mjs` now runs all 11 suites with one command (this commit).
+  Still ⬜: a CI **workflow** to run it on push — blocked by the App's missing
+  `workflows` permission (per CLAUDE.md the E2E template needs a manual move into
+  `.github/workflows/`). Hand-off item for danbri.
+- ⬜ **Security** — suite-wide **CSP** (worknotes flagged its absence; test per app
+  — sql.js/MapLibre workers and the FINK sandbox need care), the auth
+  tokens-in-web-storage XSS caveat (documented; mitigate via the backend session
+  later), SBOM of the vendored libs.
+- ⬜ **A11y/i18n** — a WCAG-AA + screen-reader pass; **RTL chrome** (the new decks
+  test bidi *content*; verify the *UI* mirrors), locale formats.
+- ⬜ **Determinism** — make every canonical serialization reproducible (extend the
+  zip mod-time zeroing to PDF/DOCX/PPTX) so fingerprints are stable.
+
+---
+
+## 6. Sequencing (this phase)
+
+1. **`run-tests.mjs`** ✅ (green baseline; this commit).
+2. **Command registry + command palette** — the keystone; additive, low-risk first.
+3. **`data-object.js` + slides `.edeck`/fingerprint** — finish the object model on a template app.
+4. **Object/metadata index** + adopt `data-object` across apps.
+5. **Consistency + CSP + a11y/i18n** hygiene, in parallel.
+6. **Backend stub + capability API design** (no live services yet) — the bridge to the Enterprise phase.
+
+When these hold, "full OIDC, email, groups, groupware, governance" become
+*additions to a sound architecture* rather than rewrites. That is "pre-Enterprise-ready."

--- a/magpie/edot/edot.html
+++ b/magpie/edot/edot.html
@@ -159,6 +159,13 @@
     </div>
   </dialog>
 
+  <!-- Command palette (Mod+K) — runs any registered command -->
+  <dialog id="palette-dialog" class="dialog palette" aria-label="Command palette">
+    <input id="palette-input" class="palette-input" type="text" placeholder="Type a command…"
+           autocomplete="off" spellcheck="false" aria-label="Command palette">
+    <ul id="palette-list" class="palette-list"></ul>
+  </dialog>
+
   <!-- Save to GitHub (branch + pull request) -->
   <dialog id="github-dialog" class="dialog" aria-labelledby="github-dialog-title">
     <form method="dialog" class="dialog-head">

--- a/magpie/edot/js/command-registry.js
+++ b/magpie/edot/js/command-registry.js
@@ -1,0 +1,57 @@
+// command-registry.js — CommandRegistry: user actions as data.
+//
+// Surfaces (command palette, menus, toolbars) render from *contributions* rather
+// than being hand-wired, and every user-meaningful action flows through run() —
+// the single choke point where, in the Enterprise phase, collaboration ops,
+// undo/redo, audit logging and policy/DLP gates will hook in. Those seams are
+// present now as no-ops (see onAudit/onPolicy) so adding them later is not a
+// retrofit. See docs/research/pre-enterprise-foundations.md §1 and §4.
+//
+// A command is data:
+//   { id, title, icon?, group?, order?, shortcut?, keywords?,
+//     when?: (ctx) => boolean, run: (ctx, args) => any }
+
+export class CommandRegistry extends EventTarget {
+  constructor() { super(); this._cmds = new Map(); this._audit = null; this._policy = null; }
+
+  register(cmd) {
+    if (!cmd || !cmd.id || typeof cmd.run !== 'function') throw new Error('command needs an id and a run()');
+    this._cmds.set(cmd.id, { group: '', order: 100, keywords: '', ...cmd });
+    return this;
+  }
+  registerAll(list) { (list || []).forEach((c) => this.register(c)); return this; }
+
+  get(id) { return this._cmds.get(id); }
+  all() { return [...this._cmds.values()]; }
+  has(id) { return this._cmds.has(id); }
+
+  // Commands available in a context, honouring `when(ctx)`, sorted by group/order.
+  contributions(ctx = {}) {
+    return this.all()
+      .filter((c) => !c.when || c.when(ctx))
+      .sort((a, b) => (a.group || '').localeCompare(b.group || '') || (a.order - b.order) || a.title.localeCompare(b.title));
+  }
+
+  // Filter over title/keywords/id for a palette.
+  search(query, ctx = {}) {
+    const q = String(query || '').trim().toLowerCase();
+    const avail = this.contributions(ctx);
+    if (!q) return avail;
+    return avail.filter((c) => `${c.title} ${c.keywords} ${c.id}`.toLowerCase().includes(q));
+  }
+
+  // THE choke point. Governance seams live here (no-ops until the Enterprise phase).
+  run(id, ctx = {}, args) {
+    const cmd = this._cmds.get(id);
+    if (!cmd) throw new Error(`unknown command: ${id}`);
+    if (cmd.when && !cmd.when(ctx)) return false;
+    if (this._policy && this._policy(cmd, ctx, args) === false) return false; // policy/DLP gate (future)
+    const result = cmd.run(ctx, args);
+    if (this._audit) { try { this._audit({ id, at: Date.now(), ctx }); } catch { /* audit must never break the action */ } }
+    this.dispatchEvent(new CustomEvent('run', { detail: { id } }));
+    return result === undefined ? true : result;
+  }
+
+  onAudit(fn) { this._audit = fn; return this; }   // Enterprise: audit log
+  onPolicy(fn) { this._policy = fn; return this; } // Enterprise: policy/DLP/RBAC gate
+}

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -11,6 +11,8 @@ import { Attention } from './attention.js';
 import { resolveSourceUrl, filenameFromUrl } from './open-url.js';
 import { EXAMPLES } from './examples.js';
 import './tree.js';
+import { CommandRegistry } from './command-registry.js';
+import { COMMANDS, BLOCK_FORMATS, setBlockFormat, createLink, createSemantic } from './commands.js';
 import { GitHubRemote, commitViaPullRequest } from './git-remote.js';
 import { diffLines, diffStats, collapse } from './diff.js';
 import * as IO from './io.js';
@@ -18,7 +20,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-23.k';
+const BUILD = '2026-06-23.l';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token
@@ -66,6 +68,8 @@ class App {
     this._wireOpenDialog();
     this._wireGithubDialog();
     this._wireSourceDialog();
+    this._wireCommands();
+    this._wirePalette();
     this._wireGlobalKeys();
     this._wireDragDrop();
     this._reflectBackend();
@@ -224,12 +228,7 @@ class App {
     // window.open(...,'noopener'), which returns null and made the old fallback
     // also navigate THIS tab via location.href; a Back could then reload a stale
     // edot and drop the Calendar/Maps menu items. An anchor leaves this tab put.
-    const openApp = (path) => {
-      const a = document.createElement('a');
-      a.href = path; a.target = '_blank'; a.rel = 'noopener';
-      document.body.appendChild(a); a.click(); a.remove();
-      this.attention.arm('Back to edot', { once: true });
-    };
+    const openApp = (path) => this._launchApp(path);
     mi('mi-data', () => openApp('data/data.html'));
     mi('mi-slides', () => openApp('slides/slides.html'));
     mi('mi-mail', () => openApp('mail/mail.html'));
@@ -812,12 +811,110 @@ class App {
     return li;
   }
 
+  // Open a sibling suite app in a new tab without navigating this one.
+  _launchApp(path) {
+    const a = document.createElement('a');
+    a.href = path; a.target = '_blank'; a.rel = 'noopener';
+    document.body.appendChild(a); a.click(); a.remove();
+    this.attention.arm('Back to edot', { once: true });
+  }
+
+  // ---- command registry (the action vocabulary; see command-registry.js) ----
+  _wireCommands() {
+    const app = this;
+    const reg = new CommandRegistry();
+    reg.registerAll([
+      { id: 'doc.new', title: 'New document', icon: '📄', group: '1file', order: 1, shortcut: 'Mod+N', run: () => app.newDocument() },
+      { id: 'doc.open', title: 'Open…', icon: '📂', group: '1file', order: 2, keywords: 'examples research file url', run: () => app.openOpenDialog() },
+      { id: 'doc.mydocs', title: 'My documents', icon: '🗂', group: '1file', order: 3, shortcut: 'Mod+Shift+O', run: () => app.openLibrary() },
+      { id: 'doc.viewsource', title: 'View source', icon: '⟨⟩', group: '1file', order: 4, keywords: 'html markdown', run: () => app.openSourceDialog() },
+      { id: 'doc.github', title: 'Save to GitHub…', icon: '⎇', group: '1file', order: 5, keywords: 'commit pull request push', run: () => app.openGithubDialog() },
+      { id: 'doc.close', title: 'Close document', icon: '✕', group: '1file', order: 6, shortcut: 'Mod+W', run: () => app.closeDocument() },
+      { id: 'doc.find', title: 'Find…', icon: '🔍', group: '1file', order: 7, shortcut: 'Mod+F', run: () => app.findReplace.open(false) },
+      { id: 'doc.replace', title: 'Find & replace…', icon: '🔁', group: '1file', order: 8, shortcut: 'Mod+H', run: () => app.findReplace.open(true) },
+      { id: 'export.pdf', title: 'Export as PDF', icon: '⬇', group: '2export', order: 1, run: () => app.exportAs('pdf') },
+      { id: 'export.docx', title: 'Export as Word (.docx)', icon: '⬇', group: '2export', order: 2, run: () => app.exportAs('docx') },
+      { id: 'export.md', title: 'Export as Markdown', icon: '⬇', group: '2export', order: 3, run: () => app.exportAs('md') },
+      { id: 'export.html', title: 'Export as HTML', icon: '⬇', group: '2export', order: 4, run: () => app.exportAs('html') },
+      { id: 'insert.link', title: 'Insert link…', icon: '🔗', group: '4insert', run: () => createLink(app.announce) },
+      { id: 'insert.semantic', title: 'Tag semantic property (RDFa)…', icon: '🏷️', group: '4insert', run: () => createSemantic(app.announce) },
+      { id: 'app.data', title: 'Open Data workspace', icon: '▦', group: '5apps', run: () => app._launchApp('data/data.html') },
+      { id: 'app.slides', title: 'Open Slides', icon: '▤', group: '5apps', run: () => app._launchApp('slides/slides.html') },
+      { id: 'app.mail', title: 'Open Mail', icon: '✉', group: '5apps', run: () => app._launchApp('mail/mail.html') },
+      { id: 'app.calendar', title: 'Open Calendar', icon: '📅', group: '5apps', run: () => app._launchApp('calendar/calendar.html') },
+      { id: 'app.maps', title: 'Open Maps', icon: '🗺', group: '5apps', run: () => app._launchApp('maps/maps.html') },
+      { id: 'app.login', title: 'Sign in (OIDC)', icon: '👤', group: '5apps', run: () => app._launchApp('auth/login.html') },
+      { id: 'app.backup', title: 'Encrypted backup', icon: '🔒', group: '5apps', run: () => app._launchApp('backup/backup.html') },
+    ]);
+    // Formatting + block styles, sourced from the editing command module.
+    for (const [id, c] of Object.entries(COMMANDS)) {
+      reg.register({ id: `format.${id}`, title: c.label, group: '3format', order: 10, keywords: 'format', run: () => c.exec(), shortcut: c.key ? `Mod+${c.shift ? 'Shift+' : ''}${c.key.toUpperCase()}` : '' });
+    }
+    for (const b of BLOCK_FORMATS) {
+      reg.register({ id: `block.${b.value}`, title: b.label, group: '3format', order: 20, keywords: 'heading paragraph style', run: () => setBlockFormat(b.value) });
+    }
+    this.commands = reg;
+  }
+
+  // ---- command palette (Mod+K) — additive surface over the registry ----
+  _wirePalette() {
+    this.palette = document.getElementById('palette-dialog');
+    this.paletteInput = document.getElementById('palette-input');
+    this.paletteList = document.getElementById('palette-list');
+    if (!this.palette) return;
+    this.paletteInput.addEventListener('input', () => { this._paletteActive = 0; this._renderPalette(); });
+    this.paletteInput.addEventListener('keydown', (e) => this._paletteKey(e));
+    this.paletteList.addEventListener('click', (e) => { const li = e.target.closest('.palette-item'); if (li) this._runPalette(li.dataset.id); });
+  }
+
+  openPalette() {
+    if (!this.palette) return;
+    this.paletteInput.value = ''; this._paletteActive = 0;
+    this._renderPalette();
+    showModal(this.palette);
+    this.paletteInput.focus();
+  }
+
+  _renderPalette() {
+    const items = this.commands.search(this.paletteInput.value, { app: this, surface: 'editor' });
+    this._paletteItems = items;
+    if (this._paletteActive >= items.length) this._paletteActive = Math.max(0, items.length - 1);
+    this.paletteList.innerHTML = '';
+    if (!items.length) {
+      const li = document.createElement('li'); li.className = 'palette-empty'; li.textContent = 'No matching commands';
+      this.paletteList.appendChild(li); return;
+    }
+    items.forEach((c, i) => {
+      const li = document.createElement('li');
+      li.className = 'palette-item' + (i === this._paletteActive ? ' active' : '');
+      li.dataset.id = c.id; li.setAttribute('role', 'option');
+      li.innerHTML = `<span class="palette-icon">${esc(c.icon || '•')}</span><span class="palette-title">${esc(c.title)}</span>` +
+        (c.shortcut ? `<span class="palette-shortcut">${esc(c.shortcut)}</span>` : '');
+      this.paletteList.appendChild(li);
+    });
+  }
+
+  _paletteKey(e) {
+    const n = (this._paletteItems || []).length;
+    if (e.key === 'ArrowDown') { e.preventDefault(); this._paletteActive = n ? (this._paletteActive + 1) % n : 0; this._renderPalette(); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); this._paletteActive = n ? (this._paletteActive - 1 + n) % n : 0; this._renderPalette(); }
+    else if (e.key === 'Enter') { e.preventDefault(); const c = (this._paletteItems || [])[this._paletteActive]; if (c) this._runPalette(c.id); }
+    else if (e.key === 'Escape') { e.preventDefault(); this.palette.close(); }
+  }
+
+  _runPalette(id) {
+    this.palette.close();
+    try { this.commands.run(id, { app: this, surface: 'editor' }); }
+    catch (err) { this.announce(err.message || 'Command failed', { error: true }); }
+  }
+
   _wireGlobalKeys() {
     this._on(document, 'keydown', (e) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
       const k = e.key.toLowerCase();
-      if (k === 's') { e.preventDefault(); this.exportAs(this.lastExportExt); }
+      if (k === 'k' || (k === 'p' && e.shiftKey)) { e.preventDefault(); this.openPalette(); }
+      else if (k === 's') { e.preventDefault(); this.exportAs(this.lastExportExt); }
       else if (k === 'o' && e.shiftKey) { e.preventDefault(); this.openLibrary(); }
       else if (k === 'o') { e.preventDefault(); this.fileInput.click(); }
       else if (k === 'w') { e.preventDefault(); this.closeDocument(); }

--- a/magpie/edot/run-tests.mjs
+++ b/magpie/edot/run-tests.mjs
@@ -1,0 +1,59 @@
+// run-tests.mjs — run every edot suite's headless test in sequence and print a
+// single pass/fail summary. CI-readiness: one command for the whole suite.
+//
+//   node magpie/edot/run-tests.mjs            # all suites
+//   node magpie/edot/run-tests.mjs data mail  # only matching suites
+//
+// Each suite is its own Node script that launches headless Chromium, prints
+// ✅/❌ lines and exits non-zero on failure. We just orchestrate + tally.
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// [label, relative-path-from-this-file]
+const SUITES = [
+  ['editor (smoke)', 'test-edot.mjs'],
+  ['editor (e2e)', 'test-e2e.mjs'],
+  ['editor (mobile)', 'test-mobile.mjs'],
+  ['data', 'data/test-data.mjs'],
+  ['slides', 'slides/test-slides.mjs'],
+  ['slides (samples)', 'slides/test-samples.mjs'],
+  ['mail', 'mail/test-mail.mjs'],
+  ['calendar', 'calendar/test-calendar.mjs'],
+  ['maps', 'maps/test-maps.mjs'],
+  ['auth', 'auth/test-auth.mjs'],
+  ['backup', 'backup/test-backup.mjs'],
+];
+
+const filter = process.argv.slice(2);
+const suites = filter.length
+  ? SUITES.filter(([label, f]) => filter.some((q) => label.includes(q) || f.includes(q)))
+  : SUITES;
+
+function run(label, rel) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const child = spawn('node', [path.join(HERE, rel)], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let tail = '';
+    const grab = (buf) => { tail = (tail + buf.toString()).split('\n').filter(Boolean).slice(-1)[0] || tail; };
+    child.stdout.on('data', grab);
+    child.stderr.on('data', grab);
+    child.on('close', (code) => {
+      const secs = ((Date.now() - start) / 1000).toFixed(0);
+      const ok = code === 0;
+      console.log(`${ok ? '✅' : '❌'} ${label.padEnd(18)} ${String(secs).padStart(3)}s  ${tail.slice(0, 60)}`);
+      resolve({ label, ok });
+    });
+  });
+}
+
+console.log(`Running ${suites.length} suite(s)…\n`);
+const results = [];
+for (const [label, rel] of suites) results.push(await run(label, rel)); // sequential — each owns a browser
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} suites passed.`);
+if (failed.length) console.log('FAILED: ' + failed.map((r) => r.label).join(', '));
+process.exit(failed.length ? 1 : 0);

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -276,6 +276,26 @@ try {
   ok('Labels preference persists', await page.evaluate(() => localStorage.getItem('edot.toolbarLabels') === '1'));
   await page.click('.labels-toggle'); // back off
 
+  // Command palette (Mod+K): opens, filters, runs a command, closes on Escape.
+  await page.click('#editor');
+  await page.evaluate(() => { document.getElementById('editor').innerHTML = '<p>palette test body</p>'; window.__edot.editor.onChange(); });
+  await page.keyboard.press('Control+k');
+  await page.waitForTimeout(150);
+  ok('palette opens on Mod+K', await page.isVisible('#palette-input'));
+  ok('palette lists commands', (await page.$$('#palette-list .palette-item')).length > 5);
+  await page.fill('#palette-input', 'new document');
+  await page.waitForTimeout(100);
+  ok('palette filters to a match', (await page.$$('#palette-list .palette-item')).length >= 1 &&
+    /New document/i.test(await page.textContent('#palette-list')));
+  await page.keyboard.press('Enter'); // runs "New document"
+  await page.waitForTimeout(200);
+  ok('palette runs the command (new doc)', (await page.textContent('#stat-words')).startsWith('0'));
+  ok('palette closed after running', !(await page.isVisible('#palette-input')));
+  // Reopen and Escape closes it.
+  await page.keyboard.press('Control+k'); await page.waitForTimeout(120);
+  await page.keyboard.press('Escape'); await page.waitForTimeout(120);
+  ok('palette closes on Escape', !(await page.isVisible('#palette-input')));
+
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
 } finally { await b.close(); server.close(); }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:lucid": "playwright test tests/lucid-sdf.spec.js tests/dsl-parser.test.js tests/glsl-codegen.test.js",
     "test:lucid:unit": "playwright test tests/dsl-parser.test.js tests/glsl-codegen.test.js",
     "test:lucid:smoke": "playwright test tests/lucid-sdf.spec.js",
+    "test:edot": "node magpie/edot/run-tests.mjs",
     "test:debug": "playwright test --debug",
     "test:report": "playwright show-report",
     "server": "python -m http.server 8080",


### PR DESCRIPTION
Pre-Enterprise foundations work (goal: get pre-Enterprise-ready before full OIDC/email/groups/groupware/governance). Three commits:

1. **Suite test runner** (`run-tests.mjs` + `npm run test:edot`) — all 11 headless suites in one command; verified **11/11 green** baseline.
2. **Foundations design note** (`docs/research/pre-enterprise-foundations.md`) — the decided architecture: command registry as operation stream, unified storage-independent data-object + identity model with fingerprints, local-first CRDT collaboration + a thin capability-scoped backend, the governance seams to leave now, and the consolidation/CI/security/a11y hygiene for this phase.
3. **Command/action registry + command palette (Mod+K)** — the keystone. `command-registry.js` (register/run/contributions/search; `run()` is the single choke point with no-op audit + policy/DLP seams). Adopted additively in the editor: a palette over ~30 commands (file/nav, export, formatting, insert, suite launchers). Existing menus/toolbars/shortcuts untouched.

edot smoke/e2e/mobile green (e2e covers palette open/filter/run/close); HTML validates. Build → `2026-06-23.l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_