### PR TITLE
edot: DataObject wrapper + slides .edeck/fingerprint adoption

### DIFF
--- a/magpie/edot/js/data-object.js
+++ b/magpie/edot/js/data-object.js
@@ -1,0 +1,66 @@
+// data-object.js — a storage-independent identity + serialization wrapper.
+//
+// Every persisted thing in the suite is (or wraps to) a DataObject: a stable id,
+// a type, a SemVer body schema, metadata, the canonical SELF-CONTAINED body, and
+// a SHA-256 content fingerprint. Identity is content + id, NEVER storage location
+// — IndexedDB is just one cache among equals (a file, a GitHub commit, an
+// S3/WebDAV/Solid object, a sync server). See
+// docs/research/pre-enterprise-foundations.md §2.
+//
+// Isomorphic: uses Web Crypto (crypto.subtle / crypto.randomUUID), available in
+// browsers and Node 20+, so it can be unit-tested without a browser.
+
+// type -> file extension + media type. Extend as apps adopt the wrapper.
+const TYPES = {
+  doc:      { ext: 'edoc',  media: 'application/edot-doc+json' },
+  data:     { ext: 'edata', media: 'application/edot-data+json' },
+  deck:     { ext: 'edeck', media: 'application/edot-deck+json' },
+  calendar: { ext: 'ecal',  media: 'application/edot-calendar+json' },
+};
+
+export function typeInfo(type) { return TYPES[type] || { ext: 'json', media: 'application/json' }; }
+
+export function makeId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  // Deterministic-free fallback (very old runtimes only).
+  return 'id-' + Array.from({ length: 4 }, () => Math.floor(0x100000 * Math.abs(Math.sin(performance.now() + Math.random()))).toString(16)).join('');
+}
+
+// Deterministic JSON: object keys sorted recursively so identical content always
+// serializes to identical bytes (stable fingerprints). Array order is preserved.
+export function canonicalize(value) { return JSON.stringify(sortKeys(value)); }
+function sortKeys(v) {
+  if (Array.isArray(v)) return v.map(sortKeys);
+  if (v && typeof v === 'object') {
+    const out = {};
+    for (const k of Object.keys(v).sort()) out[k] = sortKeys(v[k]);
+    return out;
+  }
+  return v;
+}
+
+const enc = new TextEncoder();
+export async function fingerprint(input) {
+  const bytes = typeof input === 'string' ? enc.encode(input) : input;
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Wrap a body into a DataObject envelope. Does not compute the fingerprint
+// (that's async — see finalize()).
+export function wrap({ type, schemaVersion = '1.0.0', body, meta = {}, id = makeId() }) {
+  return { id, type, schemaVersion, meta: { title: '', ...meta }, body };
+}
+
+// Canonical bytes of the WHOLE envelope (what you store / transmit). Excludes the
+// fingerprint field itself.
+export function serialize(obj) {
+  return canonicalize({ id: obj.id, type: obj.type, schemaVersion: obj.schemaVersion, meta: obj.meta, body: obj.body });
+}
+
+// Content fingerprint = SHA-256 of the canonical BODY only — so the same content
+// fingerprints identically regardless of metadata/timestamps or storage venue.
+export function contentFingerprint(obj) { return fingerprint(canonicalize(obj.body)); }
+
+// Stamp the content fingerprint onto the envelope (e.g. before persisting/exporting).
+export async function finalize(obj) { return { ...obj, fingerprint: await contentFingerprint(obj) }; }

--- a/magpie/edot/run-tests.mjs
+++ b/magpie/edot/run-tests.mjs
@@ -18,6 +18,7 @@ const SUITES = [
   ['editor (smoke)', 'test-edot.mjs'],
   ['editor (e2e)', 'test-e2e.mjs'],
   ['editor (mobile)', 'test-mobile.mjs'],
+  ['data-object', 'test-data-object.mjs'],
   ['data', 'data/test-data.mjs'],
   ['slides', 'slides/test-slides.mjs'],
   ['slides (samples)', 'slides/test-samples.mjs'],

--- a/magpie/edot/slides/slides-app.js
+++ b/magpie/edot/slides/slides-app.js
@@ -15,6 +15,7 @@ import {
 } from './slides-model.js';
 import { saveDeck, loadDeck, listDecks, deleteDeck } from './slides-store.js';
 import * as fmt from './slides-formats.js';
+import { fingerprint, typeInfo } from '../js/data-object.js';
 
 const LAYOUT_LABELS = {
   title: 'Title', 'title-content': 'Title + Content', 'two-column': 'Two-Column',
@@ -131,9 +132,9 @@ export class EdotSlides extends HTMLElement {
       item('Open deck…', () => this.openLibrary()),
       item('Samples…', () => this.openSamples()),
       hr(),
-      item('Import file… (.json/.pptx/.odp)', () => this._fileInput.click()),
+      item('Import file… (.edeck/.json/.pptx/.odp)', () => this._fileInput.click()),
       hr(),
-      item('Export JSON', () => this.exportJson()),
+      item('Export deck (.edeck)', () => this.exportJson()),
       item('Export PPTX', () => this.exportPptx()),
       item('Export ODP', () => this.exportOdp()),
       item('Export PDF', () => this.exportPdf()),
@@ -143,7 +144,7 @@ export class EdotSlides extends HTMLElement {
     // shared hidden file input for imports.
     const file = document.createElement('input');
     file.type = 'file';
-    file.accept = '.json,.pptx,.odp,application/json';
+    file.accept = '.edeck,.json,.pptx,.odp,application/json';
     file.style.display = 'none';
     file.addEventListener('change', () => { if (file.files[0]) this.importFile(file.files[0]); file.value = ''; });
     this._fileInput = file;
@@ -664,7 +665,7 @@ export class EdotSlides extends HTMLElement {
   async importFile(file) {
     const name = (file.name || '').toLowerCase();
     try {
-      if (name.endsWith('.json')) {
+      if (name.endsWith('.json') || name.endsWith('.edeck')) {
         this.deck = fmt.jsonToDeck(await file.text());
       } else if (name.endsWith('.pptx')) {
         this.deck = await fmt.pptxToDeck(await file.arrayBuffer());
@@ -685,7 +686,14 @@ export class EdotSlides extends HTMLElement {
     }
   }
 
-  exportJson() { this._download(new Blob([fmt.deckToJson(this.deck)], { type: 'application/json' }), this._fname('json')); }
+  // The native deck is a portable, self-contained .edeck (JSON) — the canonical
+  // representation. Emit a SHA-256 content fingerprint like the other durable
+  // forms (storage-independent identity; see js/data-object.js).
+  async exportJson() {
+    const json = fmt.deckToJson(this.deck);
+    this._download(new Blob([json], { type: typeInfo('deck').media }), this._fname('edeck'));
+    try { const fp = await fingerprint(json); this._alert(`Exported .edeck · sha256 ${fp.slice(0, 12)}…`); } catch { /* crypto unavailable */ }
+  }
   async exportPptx() { this._download(await fmt.deckToPptx(this.deck), this._fname('pptx')); }
   async exportOdp() { this._download(await fmt.deckToOdp(this.deck), this._fname('odp')); }
   exportPdf() { this._download(fmt.deckToPdf(this.deck, this.deck.title), this._fname('pdf')); }

--- a/magpie/edot/test-data-object.mjs
+++ b/magpie/edot/test-data-object.mjs
@@ -1,0 +1,49 @@
+// test-data-object.mjs — pure-Node unit test for the DataObject wrapper
+// (no browser needed; Web Crypto is global in Node 20+).
+import { typeInfo, makeId, canonicalize, fingerprint, wrap, serialize, contentFingerprint, finalize } from './js/data-object.js';
+
+let fail = 0; const ok = (n, c) => { console.log(`${c ? '✅' : '❌'} ${n}`); if (!c) fail++; };
+
+// Deterministic canonicalization: key order doesn't matter.
+ok('canonicalize sorts keys deterministically',
+  canonicalize({ b: 1, a: { d: 2, c: 3 } }) === canonicalize({ a: { c: 3, d: 2 }, b: 1 }));
+ok('canonicalize preserves array order',
+  canonicalize({ xs: [3, 1, 2] }) === '{"xs":[3,1,2]}');
+
+// Fingerprint: stable + sensitive to content.
+const fpA = await fingerprint('hello world');
+ok('fingerprint matches known SHA-256("hello world")',
+  fpA === 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9');
+ok('fingerprint differs for different content', (await fingerprint('hello world!')) !== fpA);
+
+// typeInfo
+ok('deck type → .edeck + media type', typeInfo('deck').ext === 'edeck' && /edot-deck/.test(typeInfo('deck').media));
+ok('unknown type → json fallback', typeInfo('nope').ext === 'json');
+
+// makeId
+const ids = new Set(Array.from({ length: 100 }, () => makeId()));
+ok('makeId is unique across 100 calls', ids.size === 100);
+
+// Envelope + content fingerprint: identity is content, not metadata/venue.
+const body = { slides: [{ id: 's1', title: 'Hi' }], theme: 'ink' };
+const a = wrap({ type: 'deck', body, meta: { title: 'A', modifiedAt: 1 } });
+const b = wrap({ type: 'deck', body: { theme: 'ink', slides: [{ title: 'Hi', id: 's1' }] }, meta: { title: 'B-different', modifiedAt: 999 } });
+const cfA = await contentFingerprint(a);
+const cfB = await contentFingerprint(b);
+ok('content fingerprint ignores metadata/key-order (same body → same fp)', cfA === cfB);
+ok('content fingerprint changes when the body changes',
+  (await contentFingerprint(wrap({ type: 'deck', body: { ...body, theme: 'midnight' } }))) !== cfA);
+
+// Round-trip: serialize → parse recovers the body losslessly.
+const round = JSON.parse(serialize(a));
+ok('serialize round-trips the body', JSON.stringify(round.body) === JSON.stringify(sortBody(body)));
+ok('serialize carries id/type/schemaVersion', round.id === a.id && round.type === 'deck' && round.schemaVersion === '1.0.0');
+
+// finalize stamps the fingerprint.
+const fin = await finalize(a);
+ok('finalize stamps a 64-hex content fingerprint', /^[0-9a-f]{64}$/.test(fin.fingerprint) && fin.fingerprint === cfA);
+
+function sortBody(v) { return JSON.parse(canonicalize(v)); }
+
+console.log(fail ? `\n${fail} FAILURE(S)` : '\nDATA-OBJECT OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Continuing pre-Enterprise foundations.

1. **DataObject wrapper** (`js/data-object.js`, note §2) — isomorphic module: stable id, type, SemVer schema, deterministic canonical serialization, SHA-256 **content** fingerprint (ignores metadata/timestamps/storage venue), per-type extension + media type. Pure-Node unit test (12 checks, DATA-OBJECT OK; added to `run-tests.mjs`).
2. **Slides adopts it** — native export is now a portable **`.edeck`** (media type `application/edot-deck+json`) with a SHA-256 fingerprint shown on export, consistent with the other durable forms. Import accepts `.edeck` too. Bytes/schema unchanged → round-trip stays lossless; SLIDES OK + SAMPLES OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_