### PR TITLE
edot: adopt DataObject in the editor (.edoc) and unify fingerprints

### DIFF
--- a/magpie/edot/data/data-workspace.js
+++ b/magpie/edot/data/data-workspace.js
@@ -13,6 +13,7 @@ import { DataEngine, safeIdent, quoteId } from './data-engine.js';
 import { parseCsv, coerce, toCsv } from './csv.js';
 import { tablesToNquads, nquadsToTables } from './nquads.js';
 import { zipSync, unzip, utf8 } from '../js/zip.js';
+import { fingerprint } from '../js/data-object.js';
 import { holdLabel, consumedPeek } from '../js/longpress.js';
 import './grid-component.js';
 import './sheet-component.js';
@@ -447,11 +448,10 @@ export class EdotData extends HTMLElement {
   async _emit(bytes, filename, mime) {
     download(new Blob([bytes], { type: mime }), filename);
     let fp = '';
-    try {
-      const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-      const digest = await crypto.subtle.digest('SHA-256', view);
-      fp = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
-    } catch { /* crypto.subtle needs a secure context */ }
+    // Shared SHA-256 helper — one fingerprint implementation across the suite
+    // (editor .edoc, slides .edeck, and these durable data forms). See js/data-object.js.
+    try { fp = await fingerprint(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)); }
+    catch { /* crypto.subtle needs a secure context */ }
     this._lastFingerprint = fp;
     this._toast(`Exported ${filename}${fp ? ` · sha256 ${fp.slice(0, 12)}…` : ''}`);
     return fp;

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -20,7 +20,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-23.l';
+const BUILD = '2026-06-24.m';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token
@@ -832,6 +832,7 @@ class App {
       { id: 'doc.close', title: 'Close document', icon: '✕', group: '1file', order: 6, shortcut: 'Mod+W', run: () => app.closeDocument() },
       { id: 'doc.find', title: 'Find…', icon: '🔍', group: '1file', order: 7, shortcut: 'Mod+F', run: () => app.findReplace.open(false) },
       { id: 'doc.replace', title: 'Find & replace…', icon: '🔁', group: '1file', order: 8, shortcut: 'Mod+H', run: () => app.findReplace.open(true) },
+      { id: 'export.edoc', title: 'Export as edot document (.edoc)', icon: '⬇', group: '2export', order: 0, keywords: 'canonical native data object', run: () => app.exportAs('edoc') },
       { id: 'export.pdf', title: 'Export as PDF', icon: '⬇', group: '2export', order: 1, run: () => app.exportAs('pdf') },
       { id: 'export.docx', title: 'Export as Word (.docx)', icon: '⬇', group: '2export', order: 2, run: () => app.exportAs('docx') },
       { id: 'export.md', title: 'Export as Markdown', icon: '⬇', group: '2export', order: 3, run: () => app.exportAs('md') },
@@ -1005,7 +1006,7 @@ class App {
     try {
       const html = this.editor.getContent();
       const title = this.titleInput.value.trim() || 'Untitled document';
-      const blob = await IO.exportDocument(html, title, ext);
+      const blob = await IO.exportDocument(html, title, ext, { id: this.doc?.id });
       IO.downloadBlob(blob, `${sanitizeFilename(title)}.${ext}`);
       this.lastExportExt = ext;
       this.announce(`Saved as .${ext}`);

--- a/magpie/edot/js/io.js
+++ b/magpie/edot/js/io.js
@@ -9,9 +9,42 @@ import { htmlToDocument, documentToHtml, documentCss } from './io-html.js';
 import { htmlToDocx, docxToHtml } from './io-docx.js';
 import { htmlToPdf } from './io-pdf.js';
 import * as LO from './libreoffice-bridge.js';
+import { wrap, finalize, canonicalize, typeInfo } from './data-object.js';
+
+// The .edoc is the editor's CANONICAL representation: a self-contained DataObject
+// envelope around the document HTML. Every OTHER export (pdf/docx/md/html/txt) is
+// a view DERIVED from this same content — so the core form is explicit and all
+// reps follow from it (see docs/research/pre-enterprise-foundations.md §2). The
+// bytes are deterministic (sorted keys) and carry an embedded SHA-256 content
+// fingerprint, so a committed .edoc verifies and round-trips. Listed first below
+// so it leads the export menu.
+async function wrapEdoc(html, title, opts = {}) {
+  const obj = wrap({
+    type: 'doc',
+    body: { html: normalize(html) },
+    meta: { title: title || '' },
+    ...(opts.id ? { id: opts.id } : {}),
+  });
+  return canonicalize(await finalize(obj)); // includes fingerprint; stable bytes
+}
+
+function unwrapEdoc(text) {
+  let obj;
+  try { obj = JSON.parse(text); } catch { throw new Error('.edoc is not valid JSON'); }
+  if (!obj || obj.type !== 'doc' || !obj.body || typeof obj.body.html !== 'string') {
+    throw new Error('Not an edot document (.edoc): missing a doc body');
+  }
+  return obj.body.html;
+}
 
 // Native handlers keyed by extension.
 const NATIVE = {
+  edoc: {
+    label: 'edot document (.edoc)',
+    accept: '.edoc,application/edot-doc+json',
+    import: async (file) => unwrapEdoc(await file.text()),
+    export: async (html, title, opts) => new Blob([await wrapEdoc(html, title, opts)], { type: typeInfo('doc').media }),
+  },
   txt: {
     label: 'Plain text',
     accept: '.txt,text/plain',
@@ -111,10 +144,10 @@ export async function importFile(file) {
 }
 
 /** Produce a downloadable Blob in the requested format. */
-export async function exportDocument(html, title, ext) {
+export async function exportDocument(html, title, ext, opts = {}) {
   const native = NATIVE[ext];
   if (native) {
-    const blob = await native.export(normalize(html), title);
+    const blob = await native.export(normalize(html), title, opts);
     return blob;
   }
   // WASM-only export: build a docx natively, then convert it.

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -55,6 +55,25 @@ try {
   const [dl2] = await Promise.all([page.waitForEvent('download'), page.click('text=Save as Word')]);
   ok('DOCX download filename ends .docx', /\.docx$/.test(dl2.suggestedFilename()));
 
+  // .edoc — the canonical DataObject form: a self-contained envelope with a
+  // SHA-256 content fingerprint, carrying the live doc's stable id, that
+  // round-trips back into the editor losslessly.
+  await page.click('#menu-button');
+  const [dl3] = await Promise.all([page.waitForEvent('download'), page.click('text=Save as edot document')]);
+  ok('edoc download filename ends .edoc', /\.edoc$/.test(dl3.suggestedFilename()));
+  const edocText = await readFile(await dl3.path(), 'utf8');
+  const edoc = JSON.parse(edocText);
+  ok('edoc envelope is a doc with body.html', edoc.type === 'doc' && typeof edoc.body?.html === 'string');
+  ok('edoc carries a 64-hex content fingerprint', /^[0-9a-f]{64}$/.test(edoc.fingerprint || ''));
+  ok('edoc id matches the live document id', edoc.id === await page.evaluate(() => window.__edot.doc.id));
+  ok('edoc bytes are deterministic (sorted keys)', edocText.startsWith('{"body":'));
+  // Re-import the exact bytes through the file input and confirm content returns.
+  await page.evaluate(() => window.__edot.newDocument());
+  await page.waitForTimeout(150);
+  await page.setInputFiles('#file-input', { name: dl3.suggestedFilename(), mimeType: 'application/edot-doc+json', buffer: Buffer.from(edocText) });
+  await page.waitForTimeout(300);
+  ok('reimported .edoc restores the document text', /Hello office world/.test(await page.textContent('#editor')));
+
   // New document via menu, then switch back via library dialog.
   await page.click('#menu-button'); await page.click('#mi-new'); await page.waitForTimeout(300);
   ok('new doc resets word count', (await page.textContent('#stat-words')).startsWith('0'));


### PR DESCRIPTION
Extends the storage-independent identity model from the slides `.edeck` template to the flagship editor and data workspace (pre-Enterprise foundations §2).

- **io.js** — new canonical `.edoc` native format: a self-contained DataObject envelope around the document HTML, deterministic (sorted-key) bytes, embedded SHA-256 content fingerprint. Every other export (pdf/docx/md/html/txt) is now an explicit *view derived from* this core representation. Carries the live doc's stable library id (threaded through `exportDocument`), round-trips losslessly. Auto-surfaces in the export menu + import-accept; kept out of the git text save-back path to avoid id churn in diffs.
- **edot-app.js** — `exportAs` passes `{ id }`; `export.edoc` command leads the export group.
- **data-workspace.js** — `_emit` routes through the shared `fingerprint()` helper, so editor / slides / durable data forms share one SHA-256 implementation.
- **test-e2e.mjs** — `.edoc` round-trip test (envelope shape, 64-hex fingerprint, id match, deterministic bytes, lossless re-import). Full suite **12/12 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_