### PR TITLE
edot: add the object/metadata index, wired into the editor library

### DIFF
--- a/magpie/edot/docs/research/pre-enterprise-foundations.md
+++ b/magpie/edot/docs/research/pre-enterprise-foundations.md
@@ -49,9 +49,9 @@ is a *replayed stream of operations*. If every mutation already flows through
 for **CRDT/OT sync**, push it to the **undo stack**, and emit an **audit event**.
 Build the spine before you must serialize it.
 
-- ⬜ `js/commands.js` — the registry (register/get/run/contributions, `when`, shortcuts).
-- ⬜ **Command palette** (`Mod+K`) — additive surface that lists+runs all commands. *Do this first*: it's low-risk (touches no existing wiring), it's a real Enterprise-grade UX feature, and authoring it forces enumerating the suite's **operation vocabulary** — which is exactly the alphabet collaboration will sync.
-- 🟡 Migrate existing actions: file-menu and suite-launcher commands first (stable ids → tests stay green), formatting toolbar later (it's the most test-heavy; migrate last, carefully).
+- ✅ `js/command-registry.js` — the registry (register/get/run/contributions, `when`, shortcuts) with no-op `onAudit`/`onPolicy` seams at `run()`.
+- ✅ **Command palette** (`Mod+K`) — additive surface that lists+runs all commands. Did this first: low-risk, a real Enterprise-grade UX feature, and authoring it forced enumerating the suite's **operation vocabulary** — exactly the alphabet collaboration will sync.
+- ✅ Migrate existing actions: the **File menu and suite-launcher items now run through `commands.run(id)`** (the audit/policy choke point), and **export commands are generated from the io format table** so the registry is the single source of truth for every export. ⬜ Formatting toolbar still renders independently (commands exist; rendering-*from-contributions* is the remaining, most test-heavy migration — do it last, carefully).
 
 ---
 
@@ -79,15 +79,21 @@ identity** — your own "storage ≠ format" point, made structural.
   object round-trips byte-identically anywhere.
 
 State:
-- ✅ Data object (SQLite/CSV-zip/N-Quads + SHA-256), slides deck (versioned,
-  self-contained JSON).
-- 🟡 Doc model (HTML core; no explicit id/version/fingerprint wrapper yet).
-- ⬜ A shared `js/data-object.js` (id/type/version/fingerprint/serialize) adopted
-  by every app; **slides `.edeck` extension + media type + fingerprint** (the
-  outstanding consistency item) is the template.
+- ✅ A shared `js/data-object.js` (id/type/schemaVersion/meta/body + deterministic
+  canonicalization + SHA-256 content fingerprint), unit-tested pure-Node.
+- ✅ Adopted across the flagships: **editor → `.edoc`** (canonical envelope around
+  the doc HTML, carrying the live doc's stable id, deterministic bytes, embedded
+  fingerprint; every other export — pdf/docx/md/html/txt — is now an explicit view
+  *derived from* it); **slides → `.edeck`** (the template) + media type +
+  fingerprint; **data** durable forms (SQLite/CSV-zip/N-Quads) route through the
+  **same shared `fingerprint()`** so there is one SHA-256 implementation suite-wide.
+- ✅ Calendar keeps **iCalendar (RFC 5545)** as its canonical/interop form (per-event
+  UIDs already self-identify); a JSON `.ecal` envelope would *reduce* interop, so
+  it's intentionally not wrapped.
 - ⬜ A tiny **object/metadata index** (id → type, title, version, fingerprint,
   timestamps) separate from each app's body store. This is the table ACLs, sync
   state, search, and retention will hang off. Local now; server-mirrored later.
+  **This is the next foundations build.**
 
 ---
 
@@ -148,10 +154,11 @@ governance: reserve the slots, ignore them losslessly until they're implemented.
 
 ## 5. Hygiene to clear in this phase (cheap; prevents carrying debt)
 
-- 🟡 **Consistency pass** — login chip on every app (mail lacks it), shared widgets
-  (tree/longpress/toolbar), one export+fingerprint convention, slides `.edeck`.
-  The apps drifted because parallel agents built them.
-- 🟡 **CI** — `run-tests.mjs` now runs all 11 suites with one command (this commit).
+- 🟡 **Consistency pass** — ✅ one export+fingerprint convention (shared
+  `data-object.js`/`fingerprint()` across editor/slides/data), ✅ slides `.edeck` /
+  editor `.edoc`. Still ⬜: login chip on every app (mail lacks it), full shared-widget
+  reuse (tree/longpress/toolbar). The apps drifted because parallel agents built them.
+- 🟡 **CI** — `run-tests.mjs` now runs all 12 suites with one command.
   Still ⬜: a CI **workflow** to run it on push — blocked by the App's missing
   `workflows` permission (per CLAUDE.md the E2E template needs a manual move into
   `.github/workflows/`). Hand-off item for danbri.
@@ -168,12 +175,12 @@ governance: reserve the slots, ignore them losslessly until they're implemented.
 
 ## 6. Sequencing (this phase)
 
-1. **`run-tests.mjs`** ✅ (green baseline; this commit).
-2. **Command registry + command palette** — the keystone; additive, low-risk first.
-3. **`data-object.js` + slides `.edeck`/fingerprint** — finish the object model on a template app.
-4. **Object/metadata index** + adopt `data-object` across apps.
-5. **Consistency + CSP + a11y/i18n** hygiene, in parallel.
-6. **Backend stub + capability API design** (no live services yet) — the bridge to the Enterprise phase.
+1. **`run-tests.mjs`** ✅ (green baseline; 12 suites).
+2. **Command registry + command palette** ✅, with the File menu + exports now routed through `run()`.
+3. **`data-object.js` + slides `.edeck`/editor `.edoc`/unified fingerprint** ✅ — object model adopted across the flagships.
+4. **Object/metadata index** ⬜ (next) + the remaining toolbar-from-contributions migration.
+5. **Consistency + CSP + a11y/i18n** hygiene, in parallel (consistency: fingerprint convention ✅; CSP/a11y ⬜).
+6. **Backend stub + capability API design** (no live services yet) — the bridge to the Enterprise phase. *Designed* in `backend-and-capabilities.md`.
 
 When these hold, "full OIDC, email, groups, groupware, governance" become
 *additions to a sound architecture* rather than rewrites. That is "pre-Enterprise-ready."

--- a/magpie/edot/js/edot-app.js
+++ b/magpie/edot/js/edot-app.js
@@ -20,7 +20,7 @@ import * as LO from './libreoffice-bridge.js';
 
 // Bump on each meaningful deploy. Shown in the footer so a stale cached build
 // is obvious (the stamp reflects the JS your browser actually loaded).
-const BUILD = '2026-06-24.n';
+const BUILD = '2026-06-24.o';
 
 const GH_TOKEN_KEY = 'edot.gh.token';
 const GH_LOGIN_KEY = 'edot.gh.login';     // cached @login for the connected token

--- a/magpie/edot/js/library.js
+++ b/magpie/edot/js/library.js
@@ -6,6 +6,8 @@
 // (e.g. some private-mode browsers). Documents are { id, title, html,
 // createdAt, updatedAt }.
 
+import { ObjectIndex } from './object-index.js';
+
 const DB = 'edot';
 const STORE = 'documents';
 const LS_KEY = 'edot.library.v1';
@@ -56,25 +58,34 @@ class LocalLibrary {
 }
 
 export class Library {
-  constructor(backend, kind) { this.backend = backend; this.kind = kind; }
+  // index: the suite-wide metadata index (object-index.js). The body store holds
+  // the document; the index records that it exists (id/type/title/timestamps) for
+  // future cross-app search, ACLs and sync. Keeping them in lockstep here means no
+  // app forgets to register what it persists.
+  constructor(backend, kind) { this.backend = backend; this.kind = kind; this.index = new ObjectIndex(); }
 
   static async create() {
     try { return new Library(await IdbLibrary.open(), 'IndexedDB'); }
     catch { return new Library(new LocalLibrary(), 'localStorage'); }
   }
 
+  _record(doc) {
+    this.index.upsert({ id: doc.id, type: 'doc', title: doc.title, createdAt: doc.createdAt, modifiedAt: doc.updatedAt });
+    return doc;
+  }
+
   async listDocs() { return this.backend.list(); }
   async getDoc(id) { return this.backend.get(id); }
-  async deleteDoc(id) { return this.backend.remove(id); }
+  async deleteDoc(id) { await this.backend.remove(id); this.index.remove(id); }
 
   // Create a new document record and return it.
   async createDoc(title, html) {
     const now = Date.now();
-    return this.backend.put({ id: uid(), title: title || 'Untitled document', html: html || '<p><br></p>', createdAt: now, updatedAt: now });
+    return this._record(await this.backend.put({ id: uid(), title: title || 'Untitled document', html: html || '<p><br></p>', createdAt: now, updatedAt: now }));
   }
 
   // Upsert an existing document (used by autosave).
   async saveDoc(doc) {
-    return this.backend.put({ ...doc, updatedAt: Date.now() });
+    return this._record(await this.backend.put({ ...doc, updatedAt: Date.now() }));
   }
 }

--- a/magpie/edot/js/object-index.js
+++ b/magpie/edot/js/object-index.js
@@ -1,0 +1,84 @@
+// object-index.js — a tiny, storage-independent metadata index over the suite's
+// DataObjects.
+//
+// It records WHAT exists — id, type, title, schema version, content fingerprint,
+// timestamps, venue — and NEVER the body. It is deliberately separate from each
+// app's body store (the editor library, the slides store, the SQLite engine):
+// this is the single table that ACLs, sync state, full-text search and retention
+// hang off in the Enterprise phase (see docs/research/pre-enterprise-foundations.md
+// §2 and the backend's /index job in backend-and-capabilities.md). It reserves the
+// governance seams (owner / labels / acl) and carries them losslessly until they
+// are implemented (§4) — the "extension islands pass through unharmed" discipline.
+//
+// Local now, server-mirrored later. Isomorphic + storage-injectable (a
+// localStorage-shaped { getItem, setItem }) so it unit-tests in pure Node.
+
+const KEY = 'edot.objectIndex.v1';
+
+// A localStorage-shaped in-memory store for Node/tests (and a private-mode fallback).
+export function memoryStore() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => { m.set(k, String(v)); },
+    removeItem: (k) => { m.delete(k); },
+  };
+}
+
+export class ObjectIndex {
+  // storage: a localStorage-shaped { getItem, setItem }. Defaults to localStorage
+  // in a browser, otherwise an in-memory store.
+  constructor(storage, key = KEY) {
+    this.storage = storage || (typeof localStorage !== 'undefined' ? localStorage : memoryStore());
+    this.key = key;
+    this._map = this._read();
+  }
+
+  _read() { try { return JSON.parse(this.storage.getItem(this.key) || '{}') || {}; } catch { return {}; } }
+  _write() { try { this.storage.setItem(this.key, JSON.stringify(this._map)); } catch { /* quota / blocked */ } }
+
+  // Insert or update an object's metadata. Only known fields are kept — the body
+  // never enters the index. A partial upsert preserves prior fields (so a bare
+  // { id, type, modifiedAt } touch doesn't wipe the title or fingerprint).
+  upsert(entry) {
+    if (!entry || !entry.id || !entry.type) throw new Error('index entry needs an id and a type');
+    const prev = this._map[entry.id] || {};
+    const modifiedAt = entry.modifiedAt ?? prev.modifiedAt ?? null;
+    const rec = {
+      id: entry.id,
+      type: entry.type,
+      title: entry.title ?? prev.title ?? '',
+      schemaVersion: entry.schemaVersion ?? prev.schemaVersion ?? null,
+      fingerprint: entry.fingerprint ?? prev.fingerprint ?? null,
+      venue: entry.venue ?? prev.venue ?? 'local',
+      createdAt: prev.createdAt ?? entry.createdAt ?? modifiedAt,
+      modifiedAt,
+      // Governance seams — reserved, carried through untouched until implemented (§4).
+      owner: entry.owner ?? prev.owner ?? null,
+      labels: entry.labels ?? prev.labels ?? null,
+      acl: entry.acl ?? prev.acl ?? null,
+    };
+    this._map[entry.id] = rec;
+    this._write();
+    return rec;
+  }
+
+  get(id) { return this._map[id] || null; }
+  has(id) { return Object.prototype.hasOwnProperty.call(this._map, id); }
+  remove(id) { const had = this.has(id); delete this._map[id]; this._write(); return had; }
+  get size() { return Object.keys(this._map).length; }
+
+  // All records, most-recently-modified first.
+  all() { return Object.values(this._map).sort((a, b) => (b.modifiedAt || 0) - (a.modifiedAt || 0)); }
+  byType(type) { return this.all().filter((r) => r.type === type); }
+
+  // Substring search over title / type / id (the metadata search the /index job
+  // will later do server-side over the full corpus).
+  search(query) {
+    const q = String(query || '').trim().toLowerCase();
+    if (!q) return this.all();
+    return this.all().filter((r) => `${r.title} ${r.type} ${r.id}`.toLowerCase().includes(q));
+  }
+
+  clear() { this._map = {}; this._write(); }
+}

--- a/magpie/edot/run-tests.mjs
+++ b/magpie/edot/run-tests.mjs
@@ -19,6 +19,7 @@ const SUITES = [
   ['editor (e2e)', 'test-e2e.mjs'],
   ['editor (mobile)', 'test-mobile.mjs'],
   ['data-object', 'test-data-object.mjs'],
+  ['object-index', 'test-object-index.mjs'],
   ['data', 'data/test-data.mjs'],
   ['slides', 'slides/test-slides.mjs'],
   ['slides (samples)', 'slides/test-samples.mjs'],

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -325,6 +325,25 @@ try {
   ok('File-menu action flows through run() (audit fired)', await page.evaluate(() => (window.__audit || []).includes('doc.mydocs')));
   await page.keyboard.press('Escape'); await page.waitForTimeout(100);
 
+  // Object/metadata index: saving a document registers it in the suite-wide index
+  // (id/type/title) — the body store and the index stay in lockstep.
+  await page.evaluate(() => window.__edot.newDocument());
+  await page.waitForTimeout(150);
+  await page.fill('#doc-title', 'Indexed Doc');
+  await page.click('#editor');
+  await page.keyboard.type('content for the index');
+  await page.waitForTimeout(800); // autosave -> saveDoc -> index.upsert
+  ok('saved doc is recorded in the object index', await page.evaluate(() => {
+    const id = window.__edot.doc.id;
+    const rec = window.__edot.library.index.get(id);
+    return !!rec && rec.type === 'doc' && rec.title === 'Indexed Doc';
+  }));
+  ok('index search finds the doc by title', await page.evaluate(() =>
+    window.__edot.library.index.search('indexed').some((r) => r.title === 'Indexed Doc')));
+  ok('index never stores the document body', await page.evaluate(() =>
+    !('body' in window.__edot.library.index.get(window.__edot.doc.id)) &&
+    !('html' in window.__edot.library.index.get(window.__edot.doc.id))));
+
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
 } finally { await b.close(); server.close(); }

--- a/magpie/edot/test-object-index.mjs
+++ b/magpie/edot/test-object-index.mjs
@@ -1,0 +1,58 @@
+// test-object-index.mjs — pure-Node unit test for the object/metadata index
+// (storage-injectable; no browser needed).
+import { ObjectIndex, memoryStore } from './js/object-index.js';
+
+let fail = 0; const ok = (n, c) => { console.log(`${c ? '✅' : '❌'} ${n}`); if (!c) fail++; };
+
+const store = memoryStore();
+const ix = new ObjectIndex(store);
+
+// upsert validates id + type.
+let threw = false; try { ix.upsert({ title: 'no id' }); } catch { threw = true; }
+ok('upsert requires id and type', threw);
+
+// Basic insert + retrieve.
+const a = ix.upsert({ id: 'd1', type: 'doc', title: 'Alpha', modifiedAt: 100, fingerprint: 'f1' });
+ok('upsert returns the stored record', a.id === 'd1' && a.type === 'doc' && a.title === 'Alpha');
+ok('get retrieves by id', ix.get('d1')?.title === 'Alpha');
+ok('has/size reflect inserts', ix.has('d1') && ix.size === 1);
+
+// Body never enters the index (only known fields are kept).
+const b = ix.upsert({ id: 'd2', type: 'doc', title: 'Beta', modifiedAt: 200, body: { html: '<p>secret</p>' } });
+ok('the body is not stored in the index', !('body' in b));
+
+// Governance seams default to null and are reserved.
+ok('governance seams default null', b.owner === null && b.labels === null && b.acl === null);
+
+// Partial upsert preserves prior fields (a bare touch keeps title + fingerprint).
+ix.upsert({ id: 'd1', type: 'doc', modifiedAt: 300 });
+ok('partial upsert preserves title', ix.get('d1').title === 'Alpha');
+ok('partial upsert preserves fingerprint', ix.get('d1').fingerprint === 'f1');
+ok('partial upsert preserves createdAt', ix.get('d1').createdAt === 100);
+ok('partial upsert updates modifiedAt', ix.get('d1').modifiedAt === 300);
+
+// Ordering: most-recently-modified first.
+ix.upsert({ id: 'd3', type: 'deck', title: 'Gamma', modifiedAt: 50 });
+ok('all() sorts newest first', ix.all().map((r) => r.id).join(',') === 'd1,d2,d3');
+
+// byType + search.
+ok('byType filters', ix.byType('deck').length === 1 && ix.byType('doc').length === 2);
+ok('search matches title', ix.search('beta').map((r) => r.id).join() === 'd2');
+ok('search matches type', ix.search('deck').map((r) => r.id).join() === 'd3');
+ok('empty search returns all', ix.search('').length === 3);
+
+// remove.
+ok('remove reports it removed', ix.remove('d2') === true && !ix.has('d2'));
+ok('remove of a missing id reports false', ix.remove('nope') === false);
+
+// Persistence: a fresh index over the SAME store sees the data (separate of any
+// app body store).
+const ix2 = new ObjectIndex(store);
+ok('a new index over the same store reloads records', ix2.size === 2 && ix2.get('d1')?.title === 'Alpha');
+
+// clear.
+ix2.clear();
+ok('clear empties the index and persists', ix2.size === 0 && new ObjectIndex(store).size === 0);
+
+console.log(fail ? `\n${fail} FAILURE(S)` : '\nOBJECT-INDEX OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Foundations §2 — the next open item: a tiny, storage-independent metadata index over the suite's DataObjects. It's the table ACLs, sync state, search and retention will hang off in the Enterprise phase (backend `/index` job). It records *what exists* (id / type / title / schemaVersion / fingerprint / timestamps / venue) and **never the body**, separate from each app's body store.

- **js/object-index.js** — `ObjectIndex` (upsert/get/remove/all/byType/search/clear), isomorphic + storage-injectable. Partial upsert preserves prior fields; governance seams (owner/labels/acl) reserved and carried through untouched until implemented (§4). `memoryStore()` for Node/fallback.
- **js/library.js** — the editor library keeps the index in lockstep: create/save register the doc, delete removes it.
- **test-object-index.mjs** — 19 pure-Node checks (validation, body-never-stored, partial-upsert preservation, ordering, search, persistence). Added to `run-tests.mjs` (**13 suites**).
- **test-e2e.mjs** — saving a doc records it in `library.index`; search finds it by title; the index never stores the body. **Full suite 13/13 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_