### PR TITLE
edot: register slide decks in the shared object index (cross-app)

### DIFF
--- a/magpie/edot/slides/slides-store.js
+++ b/magpie/edot/slides/slides-store.js
@@ -9,8 +9,15 @@
 // "core" (see slides-model.js) — everything else (PPTX / PDF / HTML / PNG) is
 // derived from it on demand.
 
+import { ObjectIndex } from '../js/object-index.js';
+
 const IDB_DB = 'edot-slides';
 const IDB_STORE = 'decks';
+
+// The suite-wide metadata index (same-origin localStorage, shared with the editor
+// and other apps). Decks register here so a future cross-app search/recents sees
+// them; the deck body stays in IndexedDB. See js/object-index.js.
+const index = new ObjectIndex();
 
 function idbOpen() {
   return new Promise((resolve, reject) => {
@@ -35,6 +42,7 @@ export async function saveDeck(deck) {
     tx.oncomplete = res;
     tx.onerror = () => rej(tx.error);
   });
+  index.upsert({ id: deck.id, type: 'deck', title: deck.title || 'Untitled deck', modifiedAt: deck.mtime || null });
   return deck.id;
 }
 
@@ -71,4 +79,5 @@ export async function deleteDeck(id) {
     tx.oncomplete = res;
     tx.onerror = () => rej(tx.error);
   });
+  index.remove(id);
 }

--- a/magpie/edot/slides/test-slides.mjs
+++ b/magpie/edot/slides/test-slides.mjs
@@ -77,6 +77,14 @@ try {
   ok('bullet bold flag persisted', built.bodyBold === true);
   ok('speaker notes persisted', built.notes === 'speak slowly');
 
+  // The deck registers in the suite-wide object index (same-origin localStorage,
+  // shared with the editor) — metadata only, never the slide body.
+  ok('saved deck is recorded in the shared object index', await page.evaluate((id) => {
+    const ix = JSON.parse(localStorage.getItem('edot.objectIndex.v1') || '{}');
+    const r = ix[id];
+    return !!r && r.type === 'deck' && r.title === 'Test Deck' && !('slides' in r) && !('body' in r);
+  }, built.id));
+
   // 1b. Edit a slide via the DOM editor (contenteditable) and confirm sync.
   const edited = await page.evaluate(() => {
     const el = window.__slides.el;


### PR DESCRIPTION
The object/metadata index becomes genuinely **cross-app**. Because every suite app is same-origin under `/magpie/edot/`, slides writes to the **same** localStorage-backed `ObjectIndex` as the editor:

- `saveDeck` upserts `{ id, type:'deck', title, modifiedAt }`; `deleteDeck` removes it. The deck body stays in IndexedDB — only metadata enters the index.
- A future global search / recents now sees both documents and decks.
- `test-slides.mjs`: assert a saved deck lands in `edot.objectIndex.v1` as type `deck` with no body. Slides + object-index suites green.

(The data workspace is a single SQLite workspace rather than a document collection, so it fits the index less naturally; its durable exports already fingerprint — left for later.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_