### PR TITLE
edot: lock in export determinism with re-export byte-equality guards

### DIFF
--- a/magpie/edot/docs/research/pre-enterprise-foundations.md
+++ b/magpie/edot/docs/research/pre-enterprise-foundations.md
@@ -168,8 +168,10 @@ governance: reserve the slots, ignore them losslessly until they're implemented.
   later), SBOM of the vendored libs.
 - ⬜ **A11y/i18n** — a WCAG-AA + screen-reader pass; **RTL chrome** (the new decks
   test bidi *content*; verify the *UI* mirrors), locale formats.
-- ⬜ **Determinism** — make every canonical serialization reproducible (extend the
-  zip mod-time zeroing to PDF/DOCX/PPTX) so fingerprints are stable.
+- 🟡 **Determinism** — the codecs embed no dates/random and zip mod-times are
+  zeroed; re-export byte-equality is now a **regression guard** for `.edoc`/`.docx`/
+  `.pdf` (editor e2e) and `.pptx` (slides). ⬜ Still extend the guard to `.odp`/PDF
+  metadata edge cases and the data N-Quads/CSV forms.
 
 ---
 

--- a/magpie/edot/test-e2e.mjs
+++ b/magpie/edot/test-e2e.mjs
@@ -344,6 +344,18 @@ try {
     !('body' in window.__edot.library.index.get(window.__edot.doc.id)) &&
     !('html' in window.__edot.library.index.get(window.__edot.doc.id))));
 
+  // Determinism (foundations §5): exporting the SAME document twice yields
+  // byte-identical output, so content fingerprints are stable. The codecs embed
+  // no dates/random and zip mod-times are zeroed; this is the regression guard.
+  for (const [label, menu] of [['edoc', 'Save as edot document'], ['docx', 'Save as Word'], ['pdf', 'Save as PDF']]) {
+    await page.click('#menu-button');
+    const [x1] = await Promise.all([page.waitForEvent('download'), page.click(`text=${menu}`)]);
+    await page.click('#menu-button');
+    const [x2] = await Promise.all([page.waitForEvent('download'), page.click(`text=${menu}`)]);
+    const [a1, a2] = [await readFile(await x1.path()), await readFile(await x2.path())];
+    ok(`${label} export is deterministic (byte-identical re-export)`, a1.length === a2.length && Buffer.compare(a1, a2) === 0);
+  }
+
   ok('no page errors', errs.length === 0);
   if (errs.length) console.log(errs);
 } finally { await b.close(); server.close(); }


### PR DESCRIPTION
Foundations §5: stable content fingerprints require reproducible serialization. The codecs already embed no dates/random and the zip layer zeroes mod-times, so exports are deterministic today — this adds the **regression guard** so they stay so.

- `test-e2e.mjs`: exporting the same document twice yields byte-identical output for **`.edoc`, `.docx` and `.pdf`**. (Slides already guards `.pptx` determinism.)
- `pre-enterprise-foundations.md`: §5 determinism marked 🟡 — guarded for `.edoc`/`.docx`/`.pdf`/`.pptx`; `.odp` and the data N-Quads/CSV forms still to cover.

Test/doc-only; no app-code change. Editor e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMhAZcyx1SQV54bAG1piM)_