### PR TITLE
UA17: chill camera, cloud bursts, richer skyline, seatback IFE HUD

### DIFF
--- a/magpie/ua17/css/ua17.css
+++ b/magpie/ua17/css/ua17.css
@@ -76,37 +76,100 @@ html, body {
   justify-content: space-between;
 }
 
+/* Seatback-IFE royal-blue ribbon (FlightPath 3D aesthetic) */
 #ua17-topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: max(0.75rem, env(safe-area-inset-top)) 1rem 0.5rem;
-  background: linear-gradient(180deg, rgba(0,20,60,0.55), rgba(0,20,60,0));
+  padding: max(0.6rem, env(safe-area-inset-top)) 1rem 0.5rem;
+  padding-top: max(0.6rem, env(safe-area-inset-top));
+  background: linear-gradient(180deg, rgba(11,40,120,0.92) 0%, rgba(11,40,120,0.82) 70%, rgba(11,40,120,0));
+  font-family: 'Baloo 2', system-ui, sans-serif;
+  letter-spacing: 0.01em;
 }
 
-#ua17-route-label {
+#ua17-flight { display: flex; align-items: baseline; gap: 0.5rem; }
+#ua17-flight .fnum {
   color: #fff;
   font-weight: 800;
-  font-size: clamp(0.95rem, 3.6vw, 1.2rem);
-  text-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  font-size: clamp(1rem, 4vw, 1.35rem);
+  text-shadow: 0 2px 4px rgba(0,0,0,0.35);
 }
+#ua17-flight .route {
+  color: #bcd4ff;
+  font-weight: 700;
+  font-size: clamp(0.75rem, 2.8vw, 0.95rem);
+}
+#ua17-todest {
+  color: #fff;
+  font-size: clamp(0.8rem, 3vw, 1rem);
+  font-weight: 700;
+  text-align: right;
+}
+#ua17-todest #ua17-ttd { font-size: clamp(1rem, 4vw, 1.3rem); }
+.dim { color: #a8c2ee; font-weight: 600; }
 
 #ua17-caption {
+  position: absolute;
+  top: 4.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
   color: #fff;
   font-size: clamp(0.85rem, 3.2vw, 1.05rem);
-  text-shadow: 0 2px 4px rgba(0,0,0,0.4);
-  text-align: right;
+  font-weight: 700;
+  text-shadow: 0 2px 6px rgba(0,0,0,0.5);
+  background: rgba(11,40,120,0.5);
+  padding: 0.25rem 0.9rem;
+  border-radius: 999px;
 }
 
 #ua17-bottombar {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  padding: 0.5rem 1rem max(0.9rem, env(safe-area-inset-bottom));
-  background: linear-gradient(0deg, rgba(0,20,60,0.55), rgba(0,20,60,0));
+  gap: 0.55rem;
+  padding: 0.6rem 1rem max(0.9rem, env(safe-area-inset-bottom));
+  background: linear-gradient(0deg, rgba(11,40,120,0.9) 0%, rgba(11,40,120,0.8) 55%, rgba(11,40,120,0));
   pointer-events: auto;
 }
+
+#ua17-gauges {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.ua17-gauge {
+  flex: 1;
+  text-align: center;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(188,212,255,0.25);
+  border-radius: 0.7rem;
+  padding: 0.35rem 0.2rem;
+}
+.ua17-gauge .g-val {
+  color: #fff;
+  font-weight: 800;
+  font-size: clamp(1rem, 4.4vw, 1.5rem);
+  line-height: 1.05;
+  font-variant-numeric: tabular-nums;
+}
+.ua17-gauge .g-lbl {
+  color: #a8c2ee;
+  font-size: clamp(0.55rem, 2.2vw, 0.72rem);
+  font-weight: 600;
+  margin-top: 0.1rem;
+}
+
+#ua17-routerow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #dce7ff;
+  font-size: clamp(0.7rem, 2.7vw, 0.9rem);
+  font-variant-numeric: tabular-nums;
+}
+#ua17-routerow b { color: #fff; }
 
 #ua17-progress-track {
   position: relative;
@@ -209,15 +272,16 @@ html, body {
 #ua17-hint {
   position: fixed;
   left: 50%;
-  bottom: 7.5rem;
+  top: 45%;
   transform: translateX(-50%);
   color: #fff;
   font-size: 0.9rem;
-  background: rgba(0,0,0,0.35);
-  padding: 0.4rem 0.9rem;
+  background: rgba(11,40,120,0.6);
+  padding: 0.45rem 1rem;
   border-radius: 999px;
   pointer-events: none;
-  animation: ua17-fade 5s ease forwards;
+  white-space: nowrap;
+  animation: ua17-fade 6s ease forwards;
 }
 @keyframes ua17-fade {
   0%, 55% { opacity: 1; }

--- a/magpie/ua17/index.html
+++ b/magpie/ua17/index.html
@@ -20,17 +20,38 @@
 </div>
 
 <div id="ua17-hud" class="ua17-hidden">
+  <!-- Seatback-style royal-blue status ribbon (à la FlightPath 3D) -->
   <div id="ua17-topbar">
-    <div id="ua17-route-label">UA17</div>
-    <div id="ua17-caption">Ready for take-off!</div>
+    <div id="ua17-flight">
+      <span class="fnum">UA 17</span>
+      <span id="ua17-route-label" class="route">LHR → EWR</span>
+    </div>
+    <div id="ua17-todest">
+      <span id="ua17-ttd">–:––</span> to go
+      <span id="ua17-dtd" class="dim"></span>
+    </div>
   </div>
 
+  <div id="ua17-caption">Ready for take-off!</div>
+
   <div id="ua17-bottombar">
+    <div id="ua17-gauges">
+      <div class="ua17-gauge"><div class="g-val" id="ua17-alt">0</div><div class="g-lbl">Altitude · ft</div></div>
+      <div class="ua17-gauge"><div class="g-val" id="ua17-gs">0</div><div class="g-lbl">Ground speed · mph</div></div>
+      <div class="ua17-gauge"><div class="g-val" id="ua17-temp">–</div><div class="g-lbl">Outside temp</div></div>
+    </div>
+
     <div id="ua17-progress-track">
       <div id="ua17-progress-fill"></div>
       <div id="ua17-progress-plane">✈️</div>
       <input id="ua17-scrubber" type="range" min="0" max="1000" value="0" step="1" aria-label="Flight progress">
     </div>
+    <div id="ua17-routerow">
+      <span><b>LHR</b> <span id="ua17-clock-o">10:25</span></span>
+      <span id="ua17-dist" class="dim"></span>
+      <span><span id="ua17-clock-d">13:45</span> <b>EWR</b></span>
+    </div>
+
     <div id="ua17-controls">
       <button id="ua17-playpause" class="ua17-btn" aria-label="Pause">⏸</button>
       <button id="ua17-replay" class="ua17-btn ua17-hidden">🔁 Fly again!</button>

--- a/magpie/ua17/js/ua17-airport.js
+++ b/magpie/ua17/js/ua17-airport.js
@@ -6,24 +6,28 @@ import * as THREE from '../vendor/three.module.min.js';
 
 function runwayTexture() {
   const c = document.createElement('canvas');
-  c.width = 128; c.height = 1024;
+  c.width = 128; c.height = 2048;
   const ctx = c.getContext('2d');
-  ctx.fillStyle = '#3a3d40';
+  ctx.fillStyle = '#34373a';
   ctx.fillRect(0, 0, c.width, c.height);
   // edge lines
   ctx.fillStyle = '#e7e9ec';
   ctx.fillRect(6, 0, 5, c.height);
   ctx.fillRect(c.width - 11, 0, 5, c.height);
   // dashed centreline
-  for (let y = 20; y < c.height - 20; y += 46) ctx.fillRect(c.width / 2 - 3, y, 6, 26);
-  // threshold bars at both ends (a runway is approached/departed from either end)
+  for (let y = 40; y < c.height - 40; y += 60) ctx.fillRect(c.width / 2 - 3, y, 6, 32);
+  // threshold "piano key" bars at both ends
   const threshold = (y0) => {
-    for (let i = 0; i < 5; i++) ctx.fillRect(16 + i * 20, y0, 12, 34);
+    for (let i = 0; i < 5; i++) ctx.fillRect(16 + i * 20, y0, 12, 44);
   };
-  threshold(18);
-  threshold(c.height - 52);
+  threshold(26);
+  threshold(c.height - 70);
+  // touchdown-zone aiming markers a little in from each threshold
+  const aim = (y0) => { ctx.fillRect(30, y0, 14, 60); ctx.fillRect(c.width - 44, y0, 14, 60); };
+  aim(120); aim(c.height - 180);
   const tex = new THREE.CanvasTexture(c);
   tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 8;
   return tex;
 }
 
@@ -72,16 +76,16 @@ function edgeLights(length, width) {
   return group;
 }
 
-export function buildRunway(worldZ, headingRad, worldX = 0) {
+export function buildRunway(worldZ, headingRad, worldX = 0, length = 900) {
   const group = new THREE.Group();
-  const length = 260, width = 34;
+  const width = 40;
 
   const apron = new THREE.Mesh(
-    new THREE.PlaneGeometry(width * 5, length * 1.6),
-    new THREE.MeshStandardMaterial({ color: 0x7a8066, roughness: 0.95 }),
+    new THREE.PlaneGeometry(width * 6, length * 1.25),
+    new THREE.MeshStandardMaterial({ color: 0x6f7560, roughness: 0.96 }),
   );
   apron.rotation.x = -Math.PI / 2;
-  apron.position.y = -0.3;
+  apron.position.y = -0.35;
   group.add(apron);
 
   const strip = new THREE.Mesh(
@@ -89,13 +93,22 @@ export function buildRunway(worldZ, headingRad, worldX = 0) {
     new THREE.MeshStandardMaterial({ map: runwayTexture(), roughness: 0.9 }),
   );
   strip.rotation.x = -Math.PI / 2;
-  strip.position.y = -0.15;
+  strip.position.y = -0.12;
   group.add(strip);
+
+  // A parallel taxiway alongside, for that "real airport" read.
+  const taxiway = new THREE.Mesh(
+    new THREE.PlaneGeometry(width * 0.55, length * 0.9),
+    new THREE.MeshStandardMaterial({ color: 0x40474b, roughness: 0.95 }),
+  );
+  taxiway.rotation.x = -Math.PI / 2;
+  taxiway.position.set(width * 1.5, -0.14, 0);
+  group.add(taxiway);
 
   group.add(edgeLights(length, width));
 
   const term = terminal();
-  term.position.set(width * 1.8, 0, -length * 0.15);
+  term.position.set(width * 2.6, 0, -length * 0.12);
   group.add(term);
 
   group.rotation.y = headingRad;

--- a/magpie/ua17/js/ua17-app.js
+++ b/magpie/ua17/js/ua17-app.js
@@ -6,10 +6,37 @@ import { buildClouds } from './ua17-clouds.js';
 import { buildLondonSkyline, buildNycSkyline } from './ua17-buildings.js';
 import { buildRunway } from './ua17-airport.js';
 import { buildOtherFlights } from './ua17-flights.js';
+import { createParticles } from './ua17-particles.js';
 import { createAudio } from './ua17-audio.js';
-import { flightCurve, loadWeather, loadFlightInfo, cloudAt, stageCaption } from './ua17-route.js';
+import { flightCurve, loadWeather, loadFlightInfo, cloudAt, stageCaption, LONDON_RUNWAY_Z, NYC_RUNWAY_Z, CRUISE_ALT } from './ua17-route.js';
 
-const FLIGHT_DURATION = 95; // seconds for one full LHR -> EWR playthrough
+const FLIGHT_DURATION = 100; // seconds for one full LHR -> EWR playthrough
+
+// Speed profile along the journey fraction t: slow on the runway at both ends
+// (accelerate from a stop / decelerate to a stop) and quick at cruise. Its
+// value is a multiplier on the base rate; it never hits zero mid-flight so
+// the plane always keeps rolling, then clamps to a full stop exactly at t=1.
+function flightSpeed(t) {
+  return 0.32 + 1.15 * Math.sin(Math.PI * THREE.MathUtils.clamp(t, 0, 1));
+}
+
+// Real-world figures for the seatback-IFE data panel. LHR 10:25 BST -> EWR
+// 13:45 EDT is 8h20 gate-to-gate; great-circle ~3452 mi / 5556 km.
+const TOTAL_MIN = 500;
+const TOTAL_MI = 3452;
+const TOTAL_KM = 5556;
+const DEP_LOCAL_MIN = 10 * 60 + 25; // BST clock at the departure gate
+const TZ_DIFF_MIN = 5 * 60;         // BST is 5h ahead of EDT
+const CRUISE_FT = 38000;            // FL380 at the path's cruise altitude
+
+function fmtHM(totalMin) {
+  const m = Math.max(0, Math.round(totalMin));
+  return `${Math.floor(m / 60)}:${String(m % 60).padStart(2, '0')}`;
+}
+function fmtClock(minsOfDay) {
+  const m = ((Math.round(minsOfDay) % 1440) + 1440) % 1440;
+  return `${Math.floor(m / 60)}:${String(m % 60).padStart(2, '0')}`;
+}
 
 async function fetchJson(rel) {
   const res = await fetch(new URL(rel, import.meta.url));
@@ -23,7 +50,7 @@ function compass(deg) {
 
 async function main() {
   const canvas = document.getElementById('ua17-canvas');
-  const { scene, camera, renderer, updateCamera, resumeIdleDriftAfter } = createScene(canvas);
+  const { scene, camera, renderer, updateCamera, resumeIdleDriftAfter, setOrbit } = createScene(canvas);
   scene.fog = new THREE.Fog(0xdff2ff, 3200, 9200);
 
   const [weather, flightInfo, londonData, nycData, flightsSnapshot] = await Promise.all([
@@ -38,19 +65,21 @@ async function main() {
   scene.add(sky);
   scene.add(buildSun());
   scene.add(buildOcean());
-  scene.add(buildClouds(weather));
+  const clouds = buildClouds(weather);
+  scene.add(clouds.mesh);
   scene.add(buildLondonSkyline(londonData));
   scene.add(buildNycSkyline(nycData));
 
   const otherFlights = buildOtherFlights(flightsSnapshot);
   scene.add(otherFlights.group);
 
-  // Runways aligned with the path's own heading at each end, so climb-out
-  // and final approach both line up with a real strip of tarmac.
-  const startHeading = Math.atan2(-flightCurve.getTangentAt(0.01).x, -flightCurve.getTangentAt(0.01).z);
-  const endHeading = Math.atan2(-flightCurve.getTangentAt(0.99).x, -flightCurve.getTangentAt(0.99).z);
-  scene.add(buildRunway(flightCurve.getPointAt(0.002).z, startHeading));
-  scene.add(buildRunway(flightCurve.getPointAt(0.998).z, endHeading));
+  const particles = createParticles(scene);
+
+  // Long runways centred on each ground-roll, aligned to the (straight) path
+  // heading there, so climb-out and final approach line up with the tarmac
+  // and there's room to accelerate away / roll out to a full stop.
+  scene.add(buildRunway(LONDON_RUNWAY_Z, 0, 0, 900));
+  scene.add(buildRunway(NYC_RUNWAY_Z, 0, 0, 900));
 
   const aircraft = buildAircraft();
   scene.add(aircraft);
@@ -70,8 +99,17 @@ async function main() {
   const routeLabel = document.getElementById('ua17-route-label');
   const hint = document.getElementById('ua17-hint');
   const flightInfoEl = document.getElementById('ua17-flightinfo');
+  // Seatback data-panel elements.
+  const ttdEl = document.getElementById('ua17-ttd');
+  const dtdEl = document.getElementById('ua17-dtd');
+  const altEl = document.getElementById('ua17-alt');
+  const gsEl = document.getElementById('ua17-gs');
+  const tempEl = document.getElementById('ua17-temp');
+  const distEl = document.getElementById('ua17-dist');
+  const clockOEl = document.getElementById('ua17-clock-o');
+  const clockDEl = document.getElementById('ua17-clock-d');
 
-  routeLabel.textContent = `${flightInfo.flightNumber} · ${flightInfo.departure.iata} → ${flightInfo.arrival.iata}`;
+  routeLabel.textContent = `${flightInfo.departure.iata} → ${flightInfo.arrival.iata}`;
 
   const state = { t: 0, playing: false, started: false, scrubbing: false };
   // Headless-playtest hook, matching the trees/tanks-for-the-trees.html
@@ -80,6 +118,9 @@ async function main() {
   window.__ua17 = {
     state,
     jumpTo: (t) => { state.t = THREE.MathUtils.clamp(t, 0, 1); },
+    setOrbit,
+    activeParticles: () => particles.group.children.filter((c) => c.visible).length,
+    poppedClusters: () => clouds.clusters.filter((c) => c.popped).length,
     screenPosFor: (instanceId) => {
       const f = otherFlights.flightsByInstance[instanceId];
       if (!f) return null;
@@ -111,6 +152,11 @@ async function main() {
   replayBtn.addEventListener('click', () => {
     state.t = 0;
     replayBtn.classList.add('ua17-hidden');
+    // Restore any clouds we popped last time round so there's something to
+    // fly through again.
+    for (const cluster of clouds.clusters) {
+      if (cluster.popped) { cluster.popped = false; cluster.dissolve = 1; clouds.setClusterScale(cluster, 1); }
+    }
     setPlaying(true);
     audio.chime(880);
   });
@@ -147,9 +193,9 @@ async function main() {
     ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
     ndc.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
     raycaster.setFromCamera(ndc, camera);
-    const hits = raycaster.intersectObject(otherFlights.mesh, false);
-    if (!hits.length || hits[0].instanceId == null) return;
-    const f = otherFlights.flightsByInstance[hits[0].instanceId];
+    const hits = raycaster.intersectObjects(otherFlights.sprites, false);
+    if (!hits.length) return;
+    const f = hits[0].object.userData.info;
     if (!f) return;
     const altFt = Math.round(f.altitude_m * 3.281 / 100) * 100;
     flightInfoEl.innerHTML = `<strong>${f.callsign || 'Unknown flight'}</strong><br>${altFt.toLocaleString()} ft · heading ${compass(f.heading)}`;
@@ -176,7 +222,7 @@ async function main() {
     const dt = Math.min(0.05, clock.getDelta());
 
     if (state.started && state.playing && !state.scrubbing) {
-      state.t = Math.min(1, state.t + dt / FLIGHT_DURATION);
+      state.t = Math.min(1, state.t + (dt / FLIGHT_DURATION) * flightSpeed(state.t));
       if (state.t >= 1 && state.playing) {
         setPlaying(false);
         replayBtn.classList.remove('ua17-hidden');
@@ -186,6 +232,9 @@ async function main() {
 
     const t = state.t;
     updateAircraftPose(t, dt);
+    updateClouds(dt);
+    particles.update(dt);
+    updateFlightData(t, dt);
 
     const cloud = cloudAt(weather, t);
     updateSky(sky, scene.fog, cloud.total);
@@ -214,14 +263,16 @@ async function main() {
     basisMat.makeBasis(right, up, forward);
     targetQuat.setFromRotationMatrix(basisMat);
 
-    const t2 = THREE.MathUtils.clamp(t + 0.003, 0, 1);
+    // Very gentle bank into turns — the path is nearly straight, and heavy
+    // banking read as "lurching". Keep it subtle and smoothed.
+    const t2 = THREE.MathUtils.clamp(t + 0.004, 0, 1);
     const forward2 = flightCurve.getTangentAt(t2).normalize();
     const turn = right.dot(forward2.clone().sub(forward));
-    const targetBank = THREE.MathUtils.clamp(-turn * 55, -0.5, 0.5);
+    const targetBank = THREE.MathUtils.clamp(-turn * 16, -0.14, 0.14);
     bankQuat.setFromAxisAngle(localZ, targetBank);
     targetQuat.multiply(bankQuat);
 
-    aircraft.quaternion.slerp(targetQuat, 0.06);
+    aircraft.quaternion.slerp(targetQuat, 0.05);
 
     // Gear down near the ground (taxi/climb-out and final approach/touchdown),
     // gear up once safely climbed away — both ends get a "real airport" feel.
@@ -229,6 +280,57 @@ async function main() {
     aircraft.userData.beacon.visible = Math.floor(clock.elapsedTime * 2) % 2 === 0;
 
     updateCamera(pos, forward, dt);
+  }
+
+  // Live seatback flight-data readout, derived from the plane's state and the
+  // real schedule/distance. Throttled to a few updates a second (it's data,
+  // it doesn't need to tick every frame) and formatted like FlightPath 3D.
+  let dataAccum = 1;
+  function updateFlightData(t, dt) {
+    dataAccum += dt;
+    if (dataAccum < 0.2) return;
+    dataAccum = 0;
+    const rem = 1 - t;
+    const remMi = Math.round(TOTAL_MI * rem);
+    const remKm = Math.round(TOTAL_KM * rem);
+    ttdEl.textContent = fmtHM(TOTAL_MIN * rem);
+    dtdEl.textContent = `· ${remMi.toLocaleString()} mi`;
+
+    const altFt = Math.max(0, Math.round((aircraft.position.y / CRUISE_ALT) * CRUISE_FT / 100) * 100);
+    altEl.textContent = altFt.toLocaleString();
+
+    let gs = Math.round(flightSpeed(t) * 380); // ~560 mph at cruise, less on the roll
+    if (t <= 0.002 || t >= 0.999) gs = 0;      // stopped on the runway
+    gsEl.textContent = gs;
+
+    const c = Math.max(-60, Math.round(15 - 6.5 * (altFt / 3281))); // ISA lapse from altitude
+    tempEl.textContent = `${c}°C`;
+
+    distEl.textContent = `${remMi.toLocaleString()} mi · ${remKm.toLocaleString()} km`;
+    const originMin = DEP_LOCAL_MIN + t * TOTAL_MIN;
+    clockOEl.textContent = fmtClock(originMin);
+    clockDEl.textContent = fmtClock(originMin - TZ_DIFF_MIN);
+  }
+
+  // Pop any cloud cluster the plane flies into: spawn a glittering burst and
+  // shrink that cluster's puffs away over a fraction of a second.
+  const planePos = new THREE.Vector3();
+  function updateClouds(dt) {
+    planePos.copy(aircraft.position);
+    for (const cluster of clouds.clusters) {
+      if (cluster.popped) {
+        if (cluster.dissolve > 0) {
+          cluster.dissolve = Math.max(0, cluster.dissolve - dt * 4);
+          clouds.setClusterScale(cluster, cluster.dissolve);
+        }
+        continue;
+      }
+      if (planePos.distanceTo(cluster.center) < cluster.radius + 14) {
+        cluster.popped = true;
+        particles.burst(cluster.center, cluster.gate ? 1.15 : 0.9);
+        audio.chime(cluster.gate ? 784 : 660);
+      }
+    }
   }
 
   tick();

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -1,49 +1,61 @@
-// Extrudes the real OSM building footprints (data/buildings-*.json, fetched
-// by tools/fetch-buildings.mjs) into a skyline at each end of the route.
-// Every footprint and height comes from real data; the glass-window texture,
-// realistic material tones and landmark tapering are stylised on top of it.
+// Turns the real OSM building footprints (data/buildings-*.json, fetched by
+// tools/fetch-buildings.mjs) into a proper-looking skyline: every footprint
+// and height is real, but on top of that each tower gets architectural
+// detailing — stepped setbacks, tapered crowns, spires + antennas on the
+// tallest, rooftop mechanical boxes, the odd water tower, and floor-banded
+// glass/stone/concrete facades. The goal is "a city skyline", not "extruded
+// rectangles".
 
 import * as THREE from '../vendor/three.module.min.js';
 import { LONDON_WORLD_Z, NYC_WORLD_Z } from './ua17-route.js';
 
-// Muted glass/stone tones instead of candy pastels — reads as "city", not "toy blocks".
-const PALETTE = [0x8fa3ad, 0x9aa7ad, 0xb7ada0, 0x8a97a6, 0xa3a89c, 0x9fadb8, 0x87909c];
+// Real footprints span a whole ~2km downtown; compress toward the centre so
+// they read as a skyline beside the path rather than a field it flies through.
+const SKYLINE_SCALE = 0.32;
 
-let sharedWindowTexture = null;
-function windowTexture() {
-  if (sharedWindowTexture) return sharedWindowTexture;
+// Facade families. Glass towers are cool + a touch reflective; stone/concrete
+// are warmer/matte. A mild self-colour emissive stops any face going black on
+// the shadow side (a distant building is only a few px, so a dark-average
+// material minifies to a silhouette).
+const FAMILIES = [
+  { name: 'glass', colors: [0x6f97b5, 0x5f8fb0, 0x7fa9c0, 0x88b7c9, 0x6aa0a8], roughness: 0.25, metalness: 0.5, emissive: 0.16 },
+  { name: 'steel', colors: [0x9fb0bb, 0x8ea1ad, 0xaab6bd], roughness: 0.4, metalness: 0.4, emissive: 0.14 },
+  { name: 'concrete', colors: [0xb7b9b4, 0xa7aaa4, 0xc3c2ba], roughness: 0.75, metalness: 0.05, emissive: 0.16 },
+  { name: 'stone', colors: [0xcabaa0, 0xbfae93, 0xd3c4a8], roughness: 0.8, metalness: 0.04, emissive: 0.18 },
+];
+
+let sharedFacade = null;
+function facadeTexture() {
+  if (sharedFacade) return sharedFacade;
   const c = document.createElement('canvas');
-  c.width = 128; c.height = 256;
+  c.width = 64; c.height = 128;
   const ctx = c.getContext('2d');
-  // A LIGHT base with thin dark mullion lines (rather than dark glass with
-  // light windows) keeps the texture's average brightness high — at
-  // real-world viewing distance a building is only a few pixels across, so
-  // a dark-average texture minifies down to a near-black silhouette
-  // regardless of the material's own colour tint.
-  ctx.fillStyle = '#e4e8ea';
+  // Light spandrel base with darker mullions + floor lines, sparse lit windows.
+  ctx.fillStyle = '#dfe4e6';
   ctx.fillRect(0, 0, c.width, c.height);
-  const cols = 4, rows = 9;
-  const padX = 6, padY = 8;
-  const cw = (c.width - padX * (cols + 1)) / cols;
-  const ch = (c.height - padY * (rows + 1)) / rows;
-  for (let r = 0; r < rows; r++) {
+  const cols = 5, floors = 16;
+  const cw = c.width / cols, fh = c.height / floors;
+  for (let f = 0; f < floors; f++) {
     for (let col = 0; col < cols; col++) {
-      const lit = Math.random() < 0.15;
-      ctx.fillStyle = lit ? 'rgba(255,224,150,0.95)' : `rgba(120,140,150,${0.3 + Math.random() * 0.25})`;
-      const x = padX + col * (cw + padX);
-      const y = padY + r * (ch + padY);
-      ctx.fillRect(x, y, cw, ch);
+      const x = col * cw, y = f * fh;
+      // window glass
+      const lit = Math.random() < 0.10;
+      ctx.fillStyle = lit ? 'rgba(255,226,150,0.95)' : `rgba(120,140,152,${0.4 + Math.random() * 0.25})`;
+      ctx.fillRect(x + 1.5, y + 1.5, cw - 3, fh - 3);
     }
   }
+  // darker floor lines for a stronger horizontal rhythm
+  ctx.fillStyle = 'rgba(70,80,88,0.5)';
+  for (let f = 0; f <= floors; f++) ctx.fillRect(0, f * fh - 0.5, c.width, 1);
   const tex = new THREE.CanvasTexture(c);
   tex.wrapS = THREE.RepeatWrapping;
   tex.wrapT = THREE.RepeatWrapping;
   tex.colorSpace = THREE.SRGBColorSpace;
-  sharedWindowTexture = tex;
+  sharedFacade = tex;
   return tex;
 }
 
-function beacon(height) {
+function beacon(height, color = 0xffe0a0) {
   const c = document.createElement('canvas');
   c.width = c.height = 64;
   const ctx = c.getContext('2d');
@@ -53,77 +65,138 @@ function beacon(height) {
   ctx.fillStyle = g;
   ctx.fillRect(0, 0, 64, 64);
   const tex = new THREE.CanvasTexture(c);
-  const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false, blending: THREE.AdditiveBlending }));
-  sprite.scale.set(26, 26, 1);
-  sprite.position.y = height + 10;
+  const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, color, transparent: true, depthWrite: false, blending: THREE.AdditiveBlending }));
+  sprite.scale.set(24, 24, 1);
+  sprite.position.y = height + 8;
   return sprite;
 }
 
-// The real OSM footprints span ~1.5-2.5km across (a whole downtown), which
-// dwarfs our ~7000-unit stylised route. Compress the whole layout toward its
-// own centre so it reads as a dense skyline sitting beside the flight path
-// instead of a city-sized field the path cannot help but fly through.
-const SKYLINE_SCALE = 0.32;
+// Deterministic-ish hash so a given building always looks the same.
+function hash(i, salt) { return Math.abs(Math.sin((i + 1) * 12.9898 + salt * 78.233)) % 1; }
 
-// Pinches a building's cross-section in toward its own centreline as it
-// rises — turns a flat-topped box into a tapered spire, which is what makes
-// a landmark tower (Shard/Empire State-style) actually read as a landmark
-// instead of just "the biggest box".
-function taperTop(geo, height, topScale) {
-  const pos = geo.attributes.position;
-  let cx = 0, cz = 0;
-  for (let i = 0; i < pos.count; i++) { cx += pos.getX(i); cz += pos.getZ(i); }
-  cx /= pos.count; cz /= pos.count;
-  for (let i = 0; i < pos.count; i++) {
-    const y = pos.getY(i);
-    const f = THREE.MathUtils.lerp(1, topScale, THREE.MathUtils.clamp(y / height, 0, 1));
-    pos.setX(i, cx + (pos.getX(i) - cx) * f);
-    pos.setZ(i, cz + (pos.getZ(i) - cz) * f);
-  }
-  pos.needsUpdate = true;
-  geo.computeVertexNormals();
-}
-
-function buildingMesh(b, index, isLandmark) {
-  const shape = new THREE.Shape();
-  b.footprint.forEach(([x, z], i) => {
+function scaledPoints(footprint, factor, cx, cz) {
+  return footprint.map(([x, z]) => {
     const sx = x * SKYLINE_SCALE, sz = -z * SKYLINE_SCALE;
-    if (i === 0) shape.moveTo(sx, sz); else shape.lineTo(sx, sz);
+    return [cx + (sx - cx) * factor, cz + (sz - cz) * factor];
   });
-  const geo = new THREE.ExtrudeGeometry(shape, { depth: b.height, bevelEnabled: false, steps: isLandmark ? 6 : 1 });
-  geo.rotateX(-Math.PI / 2);
-  if (isLandmark) taperTop(geo, b.height, 0.42);
-
-  const color = isLandmark ? 0xd9b877 : PALETTE[index % PALETTE.length];
-  const mat = new THREE.MeshStandardMaterial({
-    map: windowTexture(),
-    color,
-    roughness: isLandmark ? 0.3 : 0.65,
-    // Low metalness + a mild self-colour emissive: at low metalness/high
-    // gloss a building on the shadow side of the sun went near-black from a
-    // lot of viewing angles (reads as a broken silhouette, not "beautiful").
-    // The emissive tint keeps its colour/window texture legible everywhere.
-    metalness: isLandmark ? 0.3 : 0.05,
-    emissive: color,
-    emissiveIntensity: isLandmark ? 0.32 : 0.28,
-  });
-  mat.map.repeat.set(2, Math.max(2, Math.round(b.height / 40)));
-  const mesh = new THREE.Mesh(geo, mat);
-  mesh.name = b.name || 'building';
-  return mesh;
 }
 
-// A grounded pad under each skyline — otherwise the towers read as blocks
-// floating disconnected over open ocean rather than a city standing on land.
+function shapeFrom(points) {
+  const s = new THREE.Shape();
+  points.forEach(([x, z], i) => (i ? s.lineTo(x, z) : s.moveTo(x, z)));
+  return s;
+}
+
+function tierMesh(points, from, to, mat) {
+  const geo = new THREE.ExtrudeGeometry(shapeFrom(points), { depth: to - from, bevelEnabled: false });
+  geo.rotateX(-Math.PI / 2);
+  geo.translate(0, from, 0);
+  return new THREE.Mesh(geo, mat);
+}
+
+function footprintMetrics(footprint) {
+  let cx = 0, cz = 0;
+  const pts = footprint.map(([x, z]) => [x * SKYLINE_SCALE, -z * SKYLINE_SCALE]);
+  let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
+  for (const [x, z] of pts) { cx += x; cz += z; minX = Math.min(minX, x); maxX = Math.max(maxX, x); minZ = Math.min(minZ, z); maxZ = Math.max(maxZ, z); }
+  cx /= pts.length; cz /= pts.length;
+  return { cx, cz, w: maxX - minX, d: maxZ - minZ };
+}
+
+function buildOneBuilding(b, index, isLandmark) {
+  const group = new THREE.Group();
+  const H = b.height;
+  const { cx, cz, w, d } = footprintMetrics(b.footprint);
+  const span = Math.max(w, d);
+
+  const fam = isLandmark ? FAMILIES[0] : FAMILIES[Math.floor(hash(index, 3) * FAMILIES.length)];
+  const color = isLandmark ? 0xdcc487 : fam.colors[Math.floor(hash(index, 7) * fam.colors.length)];
+  const mat = new THREE.MeshStandardMaterial({
+    map: facadeTexture().clone(),
+    color,
+    roughness: fam.roughness,
+    metalness: fam.metalness,
+    emissive: color,
+    emissiveIntensity: fam.emissive,
+  });
+  // Tile the facade: ~1 texture tile per storey vertically, a couple across.
+  mat.map.needsUpdate = true;
+  mat.map.repeat.set(Math.max(1, Math.round(span / 12)), Math.max(2, Math.round(H / 24)));
+
+  const roofMat = new THREE.MeshStandardMaterial({ color: 0x6c7075, roughness: 0.85 });
+  const base = scaledPoints(b.footprint, 1, cx, cz);
+
+  if (H > 95 || isLandmark) {
+    // Tall tower: two setbacks + a slender tapered crown.
+    group.add(tierMesh(base, 0, H * 0.6, mat));
+    group.add(tierMesh(scaledPoints(b.footprint, 0.8, cx, cz), H * 0.6, H * 0.85, mat));
+    group.add(tierMesh(scaledPoints(b.footprint, 0.58, cx, cz), H * 0.85, H, mat));
+    // Spire (square tapered) + antenna mast + red aircraft-warning light.
+    const spireLen = THREE.MathUtils.clamp(H * 0.18, 12, 60);
+    const spire = new THREE.Mesh(new THREE.ConeGeometry(span * 0.16, spireLen, 4), mat);
+    spire.rotation.y = Math.PI / 4;
+    spire.position.set(cx, H + spireLen / 2, cz);
+    group.add(spire);
+    const mastLen = spireLen * 0.9;
+    const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 0.7, mastLen, 6), roofMat);
+    mast.position.set(cx, H + spireLen + mastLen / 2, cz);
+    group.add(mast);
+    const redLight = new THREE.Mesh(new THREE.SphereGeometry(1.1, 8, 6), new THREE.MeshBasicMaterial({ color: 0xff3b3b }));
+    redLight.position.set(cx, H + spireLen + mastLen, cz);
+    group.add(redLight);
+    if (isLandmark) group.add(beacon(H + spireLen + mastLen));
+  } else if (H > 45) {
+    // Mid-rise: a single setback + rooftop mechanical penthouse.
+    group.add(tierMesh(base, 0, H * 0.9, mat));
+    group.add(tierMesh(scaledPoints(b.footprint, 0.82, cx, cz), H * 0.9, H, mat));
+    const box = new THREE.Mesh(new THREE.BoxGeometry(span * 0.4, 6, span * 0.34), roofMat);
+    box.position.set(cx, H + 3, cz);
+    group.add(box);
+    // A rooftop antenna on some.
+    if (hash(index, 11) > 0.6) {
+      const a = new THREE.Mesh(new THREE.CylinderGeometry(0.4, 0.4, 16, 6), roofMat);
+      a.position.set(cx, H + 8 + 8, cz);
+      group.add(a);
+    }
+  } else {
+    // Low-rise: flat roof + parapet, and sometimes a classic water tower.
+    group.add(tierMesh(base, 0, H, mat));
+    const parapet = new THREE.Mesh(new THREE.BoxGeometry(span * 0.5, 2.5, span * 0.42), roofMat);
+    parapet.position.set(cx, H + 1, cz);
+    group.add(parapet);
+    if (hash(index, 5) > 0.55) {
+      const tank = new THREE.Group();
+      const legMat = new THREE.MeshStandardMaterial({ color: 0x4a4640, roughness: 0.8 });
+      const barrel = new THREE.Mesh(new THREE.CylinderGeometry(3, 3, 6, 10), new THREE.MeshStandardMaterial({ color: 0x8a6a4a, roughness: 0.85 }));
+      barrel.position.y = 9;
+      tank.add(barrel);
+      const cap = new THREE.Mesh(new THREE.ConeGeometry(3.3, 2.4, 10), new THREE.MeshStandardMaterial({ color: 0x6f5238, roughness: 0.85 }));
+      cap.position.y = 13.2;
+      tank.add(cap);
+      for (let l = 0; l < 4; l++) {
+        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.25, 0.25, 6, 4), legMat);
+        const ang = (l / 4) * Math.PI * 2;
+        leg.position.set(Math.cos(ang) * 2.2, 3, Math.sin(ang) * 2.2);
+        tank.add(leg);
+      }
+      tank.position.set(cx + (hash(index, 9) - 0.5) * span * 0.3, H, cz + (hash(index, 13) - 0.5) * span * 0.3);
+      group.add(tank);
+    }
+  }
+
+  group.traverse((o) => { if (o.isMesh) o.name = b.name || 'building'; });
+  return group;
+}
+
+// A grounded pad under each skyline so it stands on land, not floating over sea.
 function groundPad(data) {
   const xs = data.buildings.flatMap((b) => b.footprint.map((p) => p[0] * SKYLINE_SCALE));
   const zs = data.buildings.flatMap((b) => b.footprint.map((p) => -p[1] * SKYLINE_SCALE));
   const pad = 220;
   const minX = Math.min(...xs) - pad, maxX = Math.max(...xs) + pad;
   const minZ = Math.min(...zs) - pad, maxZ = Math.max(...zs) + pad;
-  const w = maxX - minX, d = maxZ - minZ;
-  const geo = new THREE.PlaneGeometry(w, d, 1, 1);
-  const mat = new THREE.MeshStandardMaterial({ color: 0x6b6f66, roughness: 0.95 });
+  const geo = new THREE.PlaneGeometry(maxX - minX, maxZ - minZ, 1, 1);
+  const mat = new THREE.MeshStandardMaterial({ color: 0x6a6f64, roughness: 0.95 });
   const mesh = new THREE.Mesh(geo, mat);
   mesh.rotation.x = -Math.PI / 2;
   mesh.position.set((minX + maxX) / 2, -0.4, (minZ + maxZ) / 2);
@@ -133,27 +206,21 @@ function groundPad(data) {
 export function buildSkyline(data, worldZ, worldX = 0) {
   const group = new THREE.Group();
   const sorted = [...data.buildings].sort((a, b) => b.height - a.height);
-  const landmarkNames = new Set(sorted.slice(0, 3).map((b) => b.name));
+  const landmarkNames = new Set(sorted.slice(0, 3).map((b) => b.name).filter(Boolean));
 
   group.add(groundPad(data));
-
   data.buildings.forEach((b, i) => {
-    const isLandmark = landmarkNames.has(b.name) && b.name;
-    const mesh = buildingMesh(b, i, isLandmark);
-    group.add(mesh);
-    if (isLandmark) mesh.add(beacon(b.height));
+    const isLandmark = b.name && landmarkNames.has(b.name);
+    group.add(buildOneBuilding(b, i, isLandmark));
   });
 
-  group.position.z = worldZ;
-  group.position.x = worldX;
+  group.position.set(worldX, 0, worldZ);
   return group;
 }
 
-// Landmark buildings tend to sit right at the origin of their own footprint
-// data, which is also roughly where the flight path passes overhead during
-// climb-out/approach. Offset each skyline sideways so the plane flies PAST
-// the skyline (a nice sightseeing view) rather than straight through the
-// tallest tower.
+// Landmarks sit at their footprint origin, roughly under the flight path;
+// offset each skyline sideways so the plane flies PAST the city (sightseeing)
+// rather than through the tallest tower.
 const LONDON_WORLD_X = -420;
 const NYC_WORLD_X = 450;
 

--- a/magpie/ua17/js/ua17-clouds.js
+++ b/magpie/ua17/js/ua17-clouds.js
@@ -4,7 +4,13 @@
 // proportional to that band's real cloud-cover percentage. Denser real cloud
 // cover along a stretch of the route → visibly denser clouds there.
 //
+// In addition to that scenery, a line of "gate" puffs sits right on the
+// flight path at cruise so the plane actually flies THROUGH clouds — each
+// gate pops in a glittering burst (see ua17-particles.js) on contact.
+//
 // One InstancedMesh for the whole field (hundreds of puffs, one draw call).
+// buildClouds returns { mesh, clusters, setClusterScale } so the app can
+// detect a hit (plane within a cluster's radius) and dissolve that cluster.
 
 import * as THREE from '../vendor/three.module.min.js';
 import { flightCurve } from './ua17-route.js';
@@ -17,21 +23,18 @@ const BANDS = [
 const PUFFS_PER_CLUSTER = 5;
 
 export function buildClouds(weather) {
-  // detail=2 + smooth shading reads as a soft puff; detail=1 + flat shading
-  // looked like a faceted grey rock under directional light.
   const puffGeo = new THREE.IcosahedronGeometry(1, 2);
-  // Slightly transparent: the free-look camera can end up close to (or
-  // briefly inside) a puff, and translucent cloud reads as "flying through
-  // it" rather than a jarring opaque wall filling the screen.
-  const puffMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 1, metalness: 0, transparent: true, opacity: 0.88 });
+  const puffMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 1, metalness: 0, transparent: true, opacity: 0.9 });
 
-  // First pass: gather all puff transforms so we can size the InstancedMesh exactly.
-  const transforms = [];
   const worldUp = new THREE.Vector3(0, 1, 0);
   const tangent = new THREE.Vector3();
   const right = new THREE.Vector3();
   const point = new THREE.Vector3();
 
+  // clusterSpecs: {center, scale, gate} — gates sit on the path to be punched.
+  const clusterSpecs = [];
+
+  // 1) Scenery clusters, off to the sides, density from the real weather.
   for (const wp of weather.waypoints) {
     const t = THREE.MathUtils.clamp(wp.t, 0.02, 0.98);
     point.copy(flightCurve.getPointAt(t));
@@ -43,50 +46,79 @@ export function buildClouds(weather) {
       const pct = wp.cloud[band.key] ?? 0;
       const clusterCount = Math.round((pct / 100) * band.maxClusters);
       for (let c = 0; c < clusterCount; c++) {
-        // Keep a clear-ish corridor right around the flight path/chase-camera
-        // orbit radius so puffs read as scenery, not a wall the camera keeps
-        // clipping into: bias lateral placement away from the centreline.
-        const minLateral = 55;
+        const minLateral = 70;
         const lateral = (minLateral + Math.random() * (band.spread - minLateral)) * (Math.random() < 0.5 ? -1 : 1);
         const along = (Math.random() * 2 - 1) * 180;
-        const clusterCenter = point.clone()
-          .addScaledVector(tangent, along)
-          .addScaledVector(right, lateral);
-        // Bands sit relative to the path's OWN altitude at this point in the
-        // journey (not a fixed cruise height) — otherwise a "low" cloud band
-        // ends up right on top of the camera during the low-altitude climb
-        // and descent, which reads as a giant white wall filling the screen.
-        // Bands that would fall below the ground/ocean during climb/descent
-        // are simply skipped rather than dragged up to intrude on the view.
         const bandY = point.y + band.yOffset + (Math.random() * 2 - 1) * 40;
         if (bandY < 20) continue;
-        clusterCenter.y = bandY;
-
-        const clusterScale = THREE.MathUtils.lerp(28, 52, Math.random());
-        for (let p = 0; p < PUFFS_PER_CLUSTER; p++) {
-          const off = new THREE.Vector3(
-            (Math.random() * 2 - 1) * clusterScale * 0.8,
-            (Math.random() * 0.6) * clusterScale * 0.4,
-            (Math.random() * 2 - 1) * clusterScale * 0.8,
-          );
-          const pos = clusterCenter.clone().add(off);
-          const scale = clusterScale * THREE.MathUtils.lerp(0.5, 1.0, Math.random());
-          transforms.push({ pos, scale });
-        }
+        const center = point.clone().addScaledVector(tangent, along).addScaledVector(right, lateral);
+        center.y = bandY;
+        clusterSpecs.push({ center, scale: THREE.MathUtils.lerp(30, 54, Math.random()), gate: false });
       }
     }
   }
 
-  const mesh = new THREE.InstancedMesh(puffGeo, puffMat, Math.max(1, transforms.length));
+  // 2) Gate clusters ON the path at cruise, spaced along the journey — these
+  // are the ones the plane flies through and pops.
+  const GATES = 14;
+  for (let i = 0; i < GATES; i++) {
+    const t = THREE.MathUtils.lerp(0.16, 0.82, i / (GATES - 1));
+    point.copy(flightCurve.getPointAt(t));
+    tangent.copy(flightCurve.getTangentAt(t)).normalize();
+    right.crossVectors(worldUp, tangent).normalize();
+    if (right.lengthSq() < 1e-6) right.set(1, 0, 0);
+    const center = point.clone()
+      .addScaledVector(right, (Math.random() * 2 - 1) * 14)
+      .addScaledVector(tangent, (Math.random() * 2 - 1) * 40);
+    center.y = point.y + (Math.random() * 2 - 1) * 12;
+    clusterSpecs.push({ center, scale: THREE.MathUtils.lerp(24, 34, Math.random()), gate: true });
+  }
+
+  // Build per-instance transforms and remember which belong to each cluster.
+  const instances = []; // {pos, scale, rot}
+  const clusters = [];
+  for (const spec of clusterSpecs) {
+    const ids = [];
+    for (let p = 0; p < PUFFS_PER_CLUSTER; p++) {
+      const off = new THREE.Vector3(
+        (Math.random() * 2 - 1) * spec.scale * 0.8,
+        (Math.random() * 0.6) * spec.scale * 0.4,
+        (Math.random() * 2 - 1) * spec.scale * 0.8,
+      );
+      ids.push(instances.length);
+      instances.push({
+        pos: spec.center.clone().add(off),
+        scale: spec.scale * THREE.MathUtils.lerp(0.5, 1.0, Math.random()),
+        rot: new THREE.Euler(Math.random() * Math.PI, Math.random() * Math.PI, 0),
+      });
+    }
+    clusters.push({ center: spec.center.clone(), radius: spec.scale * 1.25, gate: spec.gate, popped: false, dissolve: 1, instanceIds: ids });
+  }
+
+  const mesh = new THREE.InstancedMesh(puffGeo, puffMat, Math.max(1, instances.length));
   const dummy = new THREE.Object3D();
-  transforms.forEach((tr, i) => {
-    dummy.position.copy(tr.pos);
-    dummy.scale.setScalar(tr.scale);
-    dummy.rotation.set(Math.random() * Math.PI, Math.random() * Math.PI, 0);
+  instances.forEach((it, i) => {
+    dummy.position.copy(it.pos);
+    dummy.scale.setScalar(it.scale);
+    dummy.rotation.copy(it.rot);
     dummy.updateMatrix();
     mesh.setMatrixAt(i, dummy.matrix);
   });
   mesh.instanceMatrix.needsUpdate = true;
-  mesh.count = transforms.length;
-  return mesh;
+  mesh.count = instances.length;
+
+  // Rescale one cluster's puffs (used to shrink a cluster away as it pops).
+  function setClusterScale(cluster, factor) {
+    for (const id of cluster.instanceIds) {
+      const it = instances[id];
+      dummy.position.copy(it.pos);
+      dummy.scale.setScalar(it.scale * factor);
+      dummy.rotation.copy(it.rot);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(id, dummy.matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  return { mesh, clusters, setClusterScale };
 }

--- a/magpie/ua17/js/ua17-flights.js
+++ b/magpie/ua17/js/ua17-flights.js
@@ -1,72 +1,75 @@
 // "Other flights" — a real one-off ADS-B snapshot of North Atlantic traffic
 // (data/flights-snapshot.json, from OpenSky Network) rendered as small
-// distant aircraft with contrails scattered through the cruise portion of
-// the sky. Real longitude/altitude/heading drive placement; tapping one
-// (see ua17-app.js) shows its real altitude/heading/callsign. This is
-// flavour ("we're not alone up here!"), not a literal shared-coordinate sim.
+// camera-facing plane blips scattered through the cruise sky. Real
+// longitude/altitude/heading drive placement; tapping one (see ua17-app.js)
+// shows its real altitude/heading/callsign. Flavour ("we're not alone up
+// here!"), not a literal shared-coordinate sim.
+//
+// Billboarded sprites (not flat 3D cut-outs): a top-down aircraft cut-out
+// lying flat in the world is edge-on and invisible from a side chase camera,
+// and nearly impossible to tap — a camera-facing sprite always reads as a
+// plane and is easy to hit.
 
 import * as THREE from '../vendor/three.module.min.js';
 import { flightCurve, CRUISE_ALT } from './ua17-route.js';
 
-// A tiny top-down aircraft silhouette (fuselage sliver + delta wings + tail)
-// as one merged geometry — reads as "a plane", not just a dot, even distant.
-function silhouetteGeometry() {
-  const shape = new THREE.Shape();
-  shape.moveTo(0, 3.2); // nose
-  shape.lineTo(0.3, 1.6);
-  shape.lineTo(3.2, -0.6); // right wingtip
-  shape.lineTo(0.5, -0.2);
-  shape.lineTo(0.9, -2.4); // right tailplane tip
-  shape.lineTo(0.22, -1.7);
-  shape.lineTo(0, -2.0);
-  shape.lineTo(-0.22, -1.7);
-  shape.lineTo(-0.9, -2.4); // left tailplane tip
-  shape.lineTo(-0.5, -0.2);
-  shape.lineTo(-3.2, -0.6); // left wingtip
-  shape.lineTo(-0.3, 1.6);
-  shape.closePath();
-  // A slight extrusion (rather than a flat ShapeGeometry) gives it real
-  // faces to catch light from different angles — a flat cutout reads as a
-  // paper silhouette that goes invisible edge-on and looks papery face-on.
-  const geo = new THREE.ExtrudeGeometry(shape, { depth: 0.35, bevelEnabled: false });
-  geo.rotateX(-Math.PI / 2); // lay flat, nose along +Z
-  return geo;
-}
-
-function contrailTexture() {
+function planeSpriteTexture() {
   const c = document.createElement('canvas');
-  c.width = 64; c.height = 256;
+  c.width = c.height = 128;
   const ctx = c.getContext('2d');
-  const g = ctx.createLinearGradient(0, 0, 0, 256);
-  g.addColorStop(0, 'rgba(255,255,255,0.85)');
-  g.addColorStop(1, 'rgba(255,255,255,0)');
-  ctx.fillStyle = g;
-  ctx.fillRect(0, 0, 64, 256);
-  return new THREE.CanvasTexture(c);
+  ctx.translate(64, 64);
+  ctx.fillStyle = '#f4f7fa';
+  ctx.strokeStyle = 'rgba(40,60,90,0.5)';
+  ctx.lineWidth = 2;
+  // top-down airliner: fuselage + swept wings + tailplane
+  const body = () => {
+    ctx.beginPath();
+    ctx.moveTo(0, -46);            // nose
+    ctx.quadraticCurveTo(7, -20, 6, 20);
+    ctx.lineTo(4, 40);
+    ctx.lineTo(-4, 40);
+    ctx.lineTo(-6, 20);
+    ctx.quadraticCurveTo(-7, -20, 0, -46);
+    ctx.closePath();
+  };
+  const wings = () => {
+    ctx.beginPath();
+    ctx.moveTo(5, -6); ctx.lineTo(52, 20); ctx.lineTo(52, 27); ctx.lineTo(4, 12); ctx.closePath();
+    ctx.moveTo(-5, -6); ctx.lineTo(-52, 20); ctx.lineTo(-52, 27); ctx.lineTo(-4, 12); ctx.closePath();
+  };
+  const tail = () => {
+    ctx.beginPath();
+    ctx.moveTo(4, 30); ctx.lineTo(20, 44); ctx.lineTo(20, 48); ctx.lineTo(3, 40); ctx.closePath();
+    ctx.moveTo(-4, 30); ctx.lineTo(-20, 44); ctx.lineTo(-20, 48); ctx.lineTo(-3, 40); ctx.closePath();
+  };
+  wings(); ctx.fill(); ctx.stroke();
+  tail(); ctx.fill(); ctx.stroke();
+  body(); ctx.fill(); ctx.stroke();
+  // blue winglet accents (nod to the United livery on the reference screens)
+  ctx.fillStyle = '#2b5fbf';
+  ctx.fillRect(49, 18, 5, 10);
+  ctx.fillRect(-54, 18, 5, 10);
+  const tex = new THREE.CanvasTexture(c);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
 }
 
 export function buildOtherFlights(snapshot) {
   const { flights, bbox } = snapshot;
-  const geo = silhouetteGeometry();
-  const mat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.35, emissive: 0x9aa4ac, emissiveIntensity: 0.5, side: THREE.DoubleSide });
-  const mesh = new THREE.InstancedMesh(geo, mat, Math.max(1, flights.length));
-  mesh.name = 'ua17-other-flights';
+  const group = new THREE.Group();
+  const tex = planeSpriteTexture();
 
-  const contrailGeo = new THREE.PlaneGeometry(1, 1);
-  const contrailMat = new THREE.MeshBasicMaterial({ map: contrailTexture(), transparent: true, depthWrite: false, opacity: 0.55 });
-  const contrails = new THREE.InstancedMesh(contrailGeo, contrailMat, Math.max(1, flights.length));
-
-  const dummy = new THREE.Object3D();
   const worldUp = new THREE.Vector3(0, 1, 0);
   const tangent = new THREE.Vector3();
   const right = new THREE.Vector3();
   const point = new THREE.Vector3();
-  const positions = []; // world position per instance, kept for tap-metadata callouts
-
   const lonSpan = Math.max(1e-6, bbox.lomax - bbox.lomin);
   const latSpan = Math.max(1e-6, bbox.lamax - bbox.lamin);
 
-  flights.forEach((f, i) => {
+  const sprites = [];
+  const meta = [];
+
+  flights.forEach((f) => {
     const u = THREE.MathUtils.clamp((f.lon - bbox.lomin) / lonSpan, 0, 1);
     const v = THREE.MathUtils.clamp((f.lat - bbox.lamin) / latSpan, 0, 1);
     const t = THREE.MathUtils.lerp(0.12, 0.88, u);
@@ -76,39 +79,24 @@ export function buildOtherFlights(snapshot) {
     right.crossVectors(worldUp, tangent).normalize();
     if (right.lengthSq() < 1e-6) right.set(1, 0, 0);
 
-    const lateral = (v - 0.5) * 1400;
-    const altOffset = (f.altitude_m - 11000) / 12; // metres -> scene units, gentle spread
-    const scatterZ = (Math.random() * 2 - 1) * 250;
-
-    const pos = point.clone()
-      .addScaledVector(right, lateral)
-      .addScaledVector(tangent, scatterZ);
+    const lateral = (v - 0.5) * 1500;
+    const altOffset = (f.altitude_m - 11000) / 10;
+    const scatterZ = (Math.random() * 2 - 1) * 260;
+    const pos = point.clone().addScaledVector(right, lateral).addScaledVector(tangent, scatterZ);
     pos.y = CRUISE_ALT + altOffset;
-    positions.push({ pos: pos.clone(), altitude_m: f.altitude_m, heading: f.heading, callsign: f.callsign });
 
-    const scale = THREE.MathUtils.lerp(5.5, 8.5, Math.random());
-    const headingRad = THREE.MathUtils.degToRad(f.heading || 0);
-
-    dummy.position.copy(pos);
-    dummy.scale.setScalar(scale);
-    dummy.rotation.set(0, headingRad, 0);
-    dummy.updateMatrix();
-    mesh.setMatrixAt(i, dummy.matrix);
-
-    // Contrail: a vertical-facing streak trailing behind, along -heading.
-    dummy.position.copy(pos).addScaledVector(new THREE.Vector3(Math.sin(headingRad), 0, Math.cos(headingRad)), -scale * 2.2);
-    dummy.scale.set(scale * 1.1, scale * 4.4, 1);
-    dummy.rotation.set(0, headingRad, 0);
-    dummy.updateMatrix();
-    contrails.setMatrixAt(i, dummy.matrix);
+    const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false, opacity: 0.96 });
+    mat.rotation = THREE.MathUtils.degToRad((f.heading || 0) + 180);
+    const sprite = new THREE.Sprite(mat);
+    sprite.position.copy(pos);
+    const s = THREE.MathUtils.lerp(16, 26, Math.random());
+    sprite.scale.set(s, s, 1);
+    const info = { pos: pos.clone(), altitude_m: f.altitude_m, heading: f.heading, callsign: f.callsign };
+    sprite.userData.info = info;
+    group.add(sprite);
+    sprites.push(sprite);
+    meta.push(info);
   });
-  mesh.instanceMatrix.needsUpdate = true;
-  mesh.count = flights.length;
-  contrails.instanceMatrix.needsUpdate = true;
-  contrails.count = flights.length;
 
-  const group = new THREE.Group();
-  group.add(contrails);
-  group.add(mesh);
-  return { group, mesh, flightsByInstance: positions };
+  return { group, sprites, flightsByInstance: meta };
 }

--- a/magpie/ua17/js/ua17-particles.js
+++ b/magpie/ua17/js/ua17-particles.js
@@ -1,0 +1,144 @@
+// Glittering cloud-burst effect (Sonic-ring style): when the plane flies
+// through a cloud cluster it pops in a shower of expanding rings and
+// twinkling stars. A small pooled set of sprites is recycled, so bursts are
+// allocation-free after startup and cheap on a phone.
+
+import * as THREE from '../vendor/three.module.min.js';
+
+function ringTexture() {
+  const c = document.createElement('canvas');
+  c.width = c.height = 128;
+  const ctx = c.getContext('2d');
+  ctx.translate(64, 64);
+  // a soft glowing ring (annulus) via a stroked circle with blur-ish gradient
+  const grad = ctx.createRadialGradient(0, 0, 40, 0, 0, 60);
+  grad.addColorStop(0, 'rgba(255,255,255,0)');
+  grad.addColorStop(0.6, 'rgba(255,255,255,0.95)');
+  grad.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = grad;
+  ctx.beginPath();
+  ctx.arc(0, 0, 60, 0, Math.PI * 2);
+  ctx.arc(0, 0, 34, 0, Math.PI * 2, true);
+  ctx.fill();
+  return new THREE.CanvasTexture(c);
+}
+
+function starTexture() {
+  const c = document.createElement('canvas');
+  c.width = c.height = 128;
+  const ctx = c.getContext('2d');
+  ctx.translate(64, 64);
+  // four-point sparkle: two crossed soft diamonds + a bright core
+  const glow = ctx.createRadialGradient(0, 0, 0, 0, 0, 24);
+  glow.addColorStop(0, 'rgba(255,255,255,1)');
+  glow.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = glow;
+  ctx.beginPath(); ctx.arc(0, 0, 24, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = 'rgba(255,255,255,0.95)';
+  const spike = (len, w) => { ctx.beginPath(); ctx.moveTo(0, -len); ctx.lineTo(w, 0); ctx.lineTo(0, len); ctx.lineTo(-w, 0); ctx.closePath(); ctx.fill(); };
+  spike(58, 10);
+  ctx.rotate(Math.PI / 2);
+  spike(58, 10);
+  return new THREE.CanvasTexture(c);
+}
+
+const SPARKLE_COLORS = [0xffffff, 0xfff3a0, 0x9fe4ff, 0xffc0e6, 0xc6ffcf];
+
+export function createParticles(scene) {
+  const group = new THREE.Group();
+  group.renderOrder = 5;
+  scene.add(group);
+
+  const ringTex = ringTexture();
+  const starTex = starTexture();
+  const pool = [];
+  const POOL_RINGS = 30;
+  const POOL_STARS = 90;
+
+  function makeSprite(tex, kind) {
+    const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false, blending: THREE.AdditiveBlending, opacity: 0 });
+    const s = new THREE.Sprite(mat);
+    s.visible = false;
+    s.userData = { kind, life: 0, maxLife: 1, vel: new THREE.Vector3(), spin: 0 };
+    group.add(s);
+    pool.push(s);
+    return s;
+  }
+  for (let i = 0; i < POOL_RINGS; i++) makeSprite(ringTex, 'ring');
+  for (let i = 0; i < POOL_STARS; i++) makeSprite(starTex, 'star');
+
+  function grab(kind) {
+    for (const s of pool) if (!s.visible && s.userData.kind === kind) return s;
+    return null; // pool exhausted — skip (bursts are brief, this is rare)
+  }
+
+  function burst(center, scaleHint = 1) {
+    // Expanding rings.
+    const rings = 3;
+    for (let i = 0; i < rings; i++) {
+      const s = grab('ring');
+      if (!s) break;
+      s.visible = true;
+      s.position.copy(center);
+      const col = new THREE.Color(SPARKLE_COLORS[(i + 1) % SPARKLE_COLORS.length]);
+      s.material.color.copy(col);
+      s.material.opacity = 0.9;
+      const base = (14 + i * 8) * scaleHint;
+      s.scale.setScalar(base * 0.4);
+      s.userData.life = 0;
+      s.userData.maxLife = 0.7 + i * 0.12;
+      s.userData.grow = base * 3.4;
+      s.userData.startScale = base * 0.4;
+      s.userData.vel.set(0, 0, 0);
+      s.userData.spin = 0;
+    }
+    // Twinkling stars flung outward.
+    const stars = 16;
+    for (let i = 0; i < stars; i++) {
+      const s = grab('star');
+      if (!s) break;
+      s.visible = true;
+      s.position.copy(center);
+      s.material.color.set(SPARKLE_COLORS[Math.floor((i * 2654435761) % SPARKLE_COLORS.length)]);
+      s.material.opacity = 1;
+      const sc = (6 + (i % 4) * 2) * scaleHint;
+      s.scale.setScalar(sc);
+      const theta = (i / stars) * Math.PI * 2 + (i % 3);
+      const phi = ((i * 97) % 100) / 100 * Math.PI - Math.PI / 2;
+      const speed = (55 + (i % 5) * 18) * scaleHint;
+      s.userData.vel.set(
+        Math.cos(theta) * Math.cos(phi) * speed,
+        (0.4 + Math.abs(Math.sin(phi))) * speed,
+        Math.sin(theta) * Math.cos(phi) * speed,
+      );
+      s.userData.life = 0;
+      s.userData.maxLife = 0.85 + (i % 4) * 0.12;
+      s.userData.startScale = sc;
+      s.userData.grow = 0;
+      s.userData.spin = 0;
+    }
+  }
+
+  function update(dt) {
+    for (const s of pool) {
+      if (!s.visible) continue;
+      const u = s.userData;
+      u.life += dt;
+      const p = u.life / u.maxLife;
+      if (p >= 1) { s.visible = false; s.material.opacity = 0; continue; }
+      if (u.kind === 'ring') {
+        s.scale.setScalar(u.startScale + u.grow * p);
+        s.material.opacity = 0.9 * (1 - p) * (1 - p);
+      } else {
+        s.position.addScaledVector(u.vel, dt);
+        u.vel.y -= 60 * dt; // gentle gravity so stars arc and rain down
+        u.vel.multiplyScalar(Math.pow(0.5, dt)); // air drag
+        s.material.opacity = Math.min(1, 2.2 * (1 - p));
+        const twinkle = 0.8 + 0.4 * Math.sin(u.life * 30 + s.id);
+        s.scale.setScalar(u.startScale * (0.7 + 0.5 * (1 - p)) * twinkle);
+      }
+    }
+  }
+
+  return { burst, update, group };
+}

--- a/magpie/ua17/js/ua17-route.js
+++ b/magpie/ua17/js/ua17-route.js
@@ -14,24 +14,45 @@ export const CRUISE_ALT = 420;
 export const LONDON_WORLD_Z = -260;
 export const NYC_WORLD_Z = 6300;
 
+// Runway centres (z) and the fixed heading of each strip. The path's ground
+// segments run straight along +z at these z ranges, so the runways line up.
+export const LONDON_RUNWAY_Z = -470;
+export const NYC_RUNWAY_Z = 6430;
+
+// The path is deliberately almost dead-straight in x (only a whisper of lateral
+// drift) so cruise feels calm and never lurches side-to-side. Both ends have a
+// long, level GROUND ROLL along the runway: the plane accelerates from a stop,
+// rotates and climbs; then on arrival it flares, touches down and rolls out to
+// a full stop (see the speed profile in ua17-app.js). y is height, z is along-track.
 const CONTROL_POINTS = [
-  [0, 4, -420],
-  [6, 10, -340],
-  [-16, 130, -120],
-  [30, 300, 320],
-  [-40, 380, 950],
-  [70, 415, 1800],
-  [-60, 430, 2650],
-  [50, 410, 3500],
-  [-30, 420, 4350],
-  [40, 395, 5100],
-  [-10, 260, 5650],
-  [10, 120, 6050],
-  [0, 28, 6250],
-  [0, 4, 6360],
+  // London: stopped at the runway threshold, then ground roll + rotate + climb
+  [0, 3, -690],
+  [0, 3, -600],
+  [0, 3, -500],
+  [0, 4, -410],
+  [0, 12, -350],
+  [0, 90, -270],
+  [0, 250, -110],
+  [0, 370, 150],
+  // Cruise — barely-there lateral drift keeps it alive without weaving
+  [5, 415, 720],
+  [-5, 424, 1500],
+  [5, 420, 2300],
+  [-5, 423, 3100],
+  [5, 420, 3900],
+  [-5, 423, 4700],
+  [3, 418, 5300],
+  // Descent, flare, touchdown, long roll-out to a full stop at Newark
+  [0, 330, 5760],
+  [0, 180, 6050],
+  [0, 55, 6250],
+  [0, 5, 6360],
+  [0, 3, 6470],
+  [0, 3, 6580],
+  [0, 3, 6690],
 ].map((p) => new THREE.Vector3(...p));
 
-export const flightCurve = new THREE.CatmullRomCurve3(CONTROL_POINTS, false, 'catmullrom', 0.4);
+export const flightCurve = new THREE.CatmullRomCurve3(CONTROL_POINTS, false, 'catmullrom', 0.3);
 
 export async function loadWeather() {
   const res = await fetch(new URL('../data/weather.json', import.meta.url));

--- a/magpie/ua17/js/ua17-scene.js
+++ b/magpie/ua17/js/ua17-scene.js
@@ -42,17 +42,26 @@ export function createScene(canvas) {
   resize();
 
   // --- Drag-to-orbit chase camera (pointer events, page-gesture-safe) ---
-  const orbit = { yaw: 0, pitch: 0.2, distance: 105, height: 0 };
+  //
+  // Design goals after playtest feedback ("lurching is bad, make it chill"):
+  //  • The orbit frame is LEVEL (built from world-up + the plane's *horizontal*
+  //    heading), never from the plane's banked/pitched body axes — so the
+  //    horizon stays put and banking the plane doesn't roll the whole view.
+  //  • The heading the camera follows is heavily smoothed, so small path
+  //    wiggles don't swing the camera.
+  //  • Drag maps intuitively: drag right → look right. Gentle speed, strong
+  //    damping, and NO idle auto-drift (auto-motion reads as un-chill).
+  const orbit = { yaw: 0, pitch: 0.22, distance: 110 };
   const velocity = { yaw: 0, pitch: 0 };
   let dragging = false;
-  let last = { x: 0, y: 0 };
-  let idleDrift = true;
+  const last = { x: 0, y: 0 };
 
   canvas.style.touchAction = 'none';
 
+  const DRAG_SPEED = 0.0038;
+
   function onPointerDown(e) {
     dragging = true;
-    idleDrift = false;
     last.x = e.clientX;
     last.y = e.clientY;
     velocity.yaw = 0;
@@ -66,11 +75,11 @@ export function createScene(canvas) {
     const dy = e.clientY - last.y;
     last.x = e.clientX;
     last.y = e.clientY;
-    const s = 0.006;
-    orbit.yaw -= dx * s;
-    orbit.pitch = THREE.MathUtils.clamp(orbit.pitch + dy * s, -0.05, 0.6);
-    velocity.yaw = -dx * s;
-    velocity.pitch = dy * s;
+    // drag right → view swings right; drag down → look down toward the plane.
+    orbit.yaw += dx * DRAG_SPEED;
+    orbit.pitch = THREE.MathUtils.clamp(orbit.pitch - dy * DRAG_SPEED, -0.05, 0.75);
+    velocity.yaw = dx * DRAG_SPEED;
+    velocity.pitch = -dy * DRAG_SPEED;
     e.preventDefault();
   }
   function onPointerUp(e) {
@@ -94,52 +103,70 @@ export function createScene(canvas) {
 
   const tmpFwd = new THREE.Vector3();
   const tmpRight = new THREE.Vector3();
-  const tmpUp = new THREE.Vector3();
   const worldUp = new THREE.Vector3(0, 1, 0);
   const basis = new THREE.Matrix4();
   const localOffset = new THREE.Vector3();
   const camPos = new THREE.Vector3();
-  const lookTarget = new THREE.Vector3();
+  const lookTarget = new THREE.Vector3(0, 0, 1);
+  const smoothedHeading = new THREE.Vector3(0, 0, 1); // horizontal, heavily damped
 
   function updateCamera(aircraftPos, tangent, dt) {
-    if (!dragging) {
-      if (velocity.yaw !== 0 || velocity.pitch !== 0) {
-        orbit.yaw += velocity.yaw;
-        orbit.pitch = THREE.MathUtils.clamp(orbit.pitch + velocity.pitch, -0.05, 0.6);
-        velocity.yaw *= 0.92;
-        velocity.pitch *= 0.92;
-        if (Math.abs(velocity.yaw) < 0.00005) velocity.yaw = 0;
-        if (Math.abs(velocity.pitch) < 0.00005) velocity.pitch = 0;
-      } else if (idleDrift) {
-        orbit.yaw += dt * 0.03; // gentle ambient orbit so the view stays alive if nobody touches it
-      }
+    // Coast the released-drag momentum, with strong damping so it settles
+    // quickly and calmly (no long spins). No idle auto-drift.
+    if (!dragging && (velocity.yaw !== 0 || velocity.pitch !== 0)) {
+      orbit.yaw += velocity.yaw;
+      orbit.pitch = THREE.MathUtils.clamp(orbit.pitch + velocity.pitch, -0.05, 0.75);
+      const damp = Math.pow(0.86, dt * 60);
+      velocity.yaw *= damp;
+      velocity.pitch *= damp;
+      if (Math.abs(velocity.yaw) < 0.00004) velocity.yaw = 0;
+      if (Math.abs(velocity.pitch) < 0.00004) velocity.pitch = 0;
     }
 
-    tmpFwd.copy(tangent).normalize();
-    tmpRight.crossVectors(worldUp, tmpFwd).normalize();
+    // Follow only the HORIZONTAL heading, smoothed hard — climb/descent pitch
+    // and path wiggles never tilt or swing the frame.
+    tmpFwd.set(tangent.x, 0, tangent.z);
+    if (tmpFwd.lengthSq() < 1e-6) tmpFwd.set(0, 0, 1);
+    tmpFwd.normalize();
+    smoothedHeading.lerp(tmpFwd, 1 - Math.pow(0.05, dt)); // ~slow catch-up
+    smoothedHeading.y = 0;
+    if (smoothedHeading.lengthSq() < 1e-6) smoothedHeading.set(0, 0, 1);
+    smoothedHeading.normalize();
+
+    // Level orbit basis: right = up × forward, up = world up (no roll ever).
+    tmpRight.crossVectors(worldUp, smoothedHeading).normalize();
     if (tmpRight.lengthSq() < 1e-6) tmpRight.set(1, 0, 0);
-    tmpUp.crossVectors(tmpFwd, tmpRight).normalize();
-    basis.makeBasis(tmpRight, tmpUp, tmpFwd);
+    basis.makeBasis(tmpRight, worldUp, smoothedHeading);
 
     const dist = orbit.distance;
     localOffset.set(
       dist * Math.sin(orbit.yaw) * Math.cos(orbit.pitch),
-      dist * Math.sin(orbit.pitch) + 8,
+      dist * Math.sin(orbit.pitch) + 12,
       -dist * Math.cos(orbit.yaw) * Math.cos(orbit.pitch),
     );
     localOffset.applyMatrix4(basis);
 
     camPos.copy(aircraftPos).add(localOffset);
-    camera.position.lerp(camPos, 1 - Math.pow(0.001, dt));
+    // Gentle position follow — smooth, never snappy.
+    camera.position.lerp(camPos, 1 - Math.pow(0.03, dt));
 
-    lookTarget.copy(aircraftPos).addScaledVector(tmpFwd, 6);
-    const currentLook = lookTarget.clone();
-    camera.lookAt(currentLook);
+    // Look a little ahead of and above the plane, also smoothed.
+    tmpFwd.copy(aircraftPos).addScaledVector(smoothedHeading, 8);
+    tmpFwd.y += 4;
+    lookTarget.lerp(tmpFwd, 1 - Math.pow(0.02, dt));
+    camera.lookAt(lookTarget);
   }
 
-  function resumeIdleDriftAfter(seconds) {
-    setTimeout(() => { idleDrift = true; }, seconds * 1000);
+  // Kept for API compatibility with the app bootstrap; idle auto-drift was
+  // removed (it read as un-chill), so this is now a no-op.
+  function resumeIdleDriftAfter() {}
+
+  // Debug/testing: nudge the look-around orbit directly.
+  function setOrbit(o) {
+    if (o.yaw != null) orbit.yaw = o.yaw;
+    if (o.pitch != null) orbit.pitch = THREE.MathUtils.clamp(o.pitch, -0.05, 0.75);
+    if (o.distance != null) orbit.distance = o.distance;
   }
 
-  return { scene, camera, renderer, updateCamera, resize, resumeIdleDriftAfter };
+  return { scene, camera, renderer, updateCamera, resize, resumeIdleDriftAfter, setOrbit };
 }

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // network-first with cache fallback for anything unexpected, so a live
 // update during development is still picked up when online.
 
-const CACHE = 'ua17-v2';
+const CACHE = 'ua17-v3';
 const CORE = [
   './',
   './index.html',
@@ -25,6 +25,7 @@ const CORE = [
   './js/ua17-clouds.js',
   './js/ua17-buildings.js',
   './js/ua17-flights.js',
+  './js/ua17-particles.js',
   './js/ua17-audio.js',
   './vendor/three.module.min.js',
   './data/weather.json',


### PR DESCRIPTION
Polish pass responding to feedback (crude visuals, lurching controls, "extruded box" cities, seatback-app feel).

- **Chill camera**: level-horizon orbit decoupled from the plane's bank, fixed the reversed drag direction, heavy damping, removed idle drift — no more lurching.
- **Calm route + graceful runways**: near-straight path, long runways, and an accelerate-from-stop / decelerate-to-a-full-stop speed profile.
- **Cloud bursts**: Sonic-style glittering ring + star particles when the plane flies through clouds.
- **Richer skyline**: real footprints now get setbacks, tapered spires + antennas, rooftop mechanicals, water towers, and floor-banded glass/stone facades.
- **Seatback IFE HUD (FlightPath 3D style)**: royal-blue ribbon with live time & distance to destination, altitude, ground speed, outside temp, and local clocks at LHR/EWR.
- **Other flights**: camera-facing plane sprites (visible from the side, tappable) instead of edge-on cut-outs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_