### PR TITLE
UA17: real terrain world — land, sea, coastlines, grounded cities

### DIFF
--- a/magpie/ua17/js/ua17-app.js
+++ b/magpie/ua17/js/ua17-app.js
@@ -1,7 +1,8 @@
 import * as THREE from '../vendor/three.module.min.js';
 import { createScene } from './ua17-scene.js';
 import { buildAircraft } from './ua17-aircraft.js';
-import { buildSky, buildSun, buildOcean, updateSky } from './ua17-sky.js';
+import { buildSky, buildSun, updateSky } from './ua17-sky.js';
+import { buildTerrain, buildWater, CITY_GROUND_Y } from './ua17-terrain.js';
 import { buildClouds } from './ua17-clouds.js';
 import { buildLondonSkyline, buildNycSkyline } from './ua17-buildings.js';
 import { buildRunway } from './ua17-airport.js';
@@ -64,7 +65,9 @@ async function main() {
   const sky = buildSky();
   scene.add(sky);
   scene.add(buildSun());
-  scene.add(buildOcean());
+  scene.add(buildTerrain());
+  const water = buildWater();
+  scene.add(water);
   const clouds = buildClouds(weather);
   scene.add(clouds.mesh);
   scene.add(buildLondonSkyline(londonData));
@@ -76,10 +79,13 @@ async function main() {
   const particles = createParticles(scene);
 
   // Long runways centred on each ground-roll, aligned to the (straight) path
-  // heading there, so climb-out and final approach line up with the tarmac
-  // and there's room to accelerate away / roll out to a full stop.
-  scene.add(buildRunway(LONDON_RUNWAY_Z, 0, 0, 900));
-  scene.add(buildRunway(NYC_RUNWAY_Z, 0, 0, 900));
+  // heading there, on the cities' flat coastal land plateau.
+  const lhrRunway = buildRunway(LONDON_RUNWAY_Z, 0, 0, 900);
+  lhrRunway.position.y = CITY_GROUND_Y + 0.6; // sit just proud of the land plateau
+  scene.add(lhrRunway);
+  const ewrRunway = buildRunway(NYC_RUNWAY_Z, 0, 0, 900);
+  ewrRunway.position.y = CITY_GROUND_Y + 0.6;
+  scene.add(ewrRunway);
 
   const aircraft = buildAircraft();
   scene.add(aircraft);
@@ -238,6 +244,7 @@ async function main() {
 
     const cloud = cloudAt(weather, t);
     updateSky(sky, scene.fog, cloud.total);
+    water.material.uniforms.time.value = clock.elapsedTime * 0.6;
     audio.setEngineIntensity(t);
 
     const newCaption = stageCaption(t);

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -9,6 +9,7 @@
 import * as THREE from '../vendor/three.module.min.js';
 import { LONDON_WORLD_Z, NYC_WORLD_Z } from './ua17-route.js';
 import { landmarkModel } from './ua17-landmarks.js';
+import { CITY_GROUND_Y } from './ua17-terrain.js';
 
 // Real footprints span a whole ~2km downtown; compress toward the centre so
 // they read as a skyline beside the path rather than a field it flies through.
@@ -203,21 +204,6 @@ function buildOneBuilding(b, index, isLandmark) {
   return group;
 }
 
-// A grounded pad under each skyline so it stands on land, not floating over sea.
-function groundPad(data) {
-  const xs = data.buildings.flatMap((b) => b.footprint.map((p) => p[0] * SKYLINE_SCALE));
-  const zs = data.buildings.flatMap((b) => b.footprint.map((p) => -p[1] * SKYLINE_SCALE));
-  const pad = 220;
-  const minX = Math.min(...xs) - pad, maxX = Math.max(...xs) + pad;
-  const minZ = Math.min(...zs) - pad, maxZ = Math.max(...zs) + pad;
-  const geo = new THREE.PlaneGeometry(maxX - minX, maxZ - minZ, 1, 1);
-  const mat = new THREE.MeshStandardMaterial({ color: 0x6a6f64, roughness: 0.95 });
-  const mesh = new THREE.Mesh(geo, mat);
-  mesh.rotation.x = -Math.PI / 2;
-  mesh.position.set((minX + maxX) / 2, -0.4, (minZ + maxZ) / 2);
-  return mesh;
-}
-
 // Radius (scaled units) of the dense downtown core we keep around the
 // centroid. Real footprints include sparse far-flung outliers that would
 // splay the "city" into a 900-wide band; trimming to the core lets us place
@@ -246,7 +232,6 @@ export function buildSkyline(data, worldZ, worldX = 0) {
   cx /= kept.length; cz /= kept.length;
 
   const inner = new THREE.Group();
-  inner.add(groundPad({ buildings: kept }));
   kept.forEach((b, i) => {
     const isLandmark = b.name && landmarkNames.has(b.name);
     inner.add(buildOneBuilding(b, i, isLandmark));
@@ -255,7 +240,8 @@ export function buildSkyline(data, worldZ, worldX = 0) {
 
   const shifted = new THREE.Group();
   shifted.add(inner);
-  shifted.position.set(worldX, 0, worldZ);
+  // Sit the city on the terrain's coastal land plateau (no floating grey slab).
+  shifted.position.set(worldX, CITY_GROUND_Y, worldZ);
   return shifted;
 }
 

--- a/magpie/ua17/js/ua17-terrain.js
+++ b/magpie/ua17/js/ua17-terrain.js
@@ -1,0 +1,130 @@
+// The world: an elevation-displaced terrain mesh (deep seabed → shallow
+// coastal shelf → beaches → land plateaus where the cities sit) plus a
+// translucent animated sea surface. Replaces the old flat tiled ocean +
+// floating city slabs. Colours come from height, so you get dark open ocean,
+// turquoise coasts and green land — a hint of the LHR→EWR crossing rather
+// than a dull repeating pattern.
+//
+// This is procedural (deterministic value-noise), not real bathymetry — a
+// true OSM+DEM terrain for the whole North Atlantic isn't feasible offline —
+// but it reads as land/sea/coast from the air, which is the point.
+
+import * as THREE from '../vendor/three.module.min.js';
+
+// Land masses sit under each city (and its runway). Keep these in sync with
+// the skyline offsets in ua17-buildings.js and runway z in ua17-route.js.
+const LANDS = [
+  { x: -330, z: -260, r: 1050 }, // London
+  { x: 330, z: 6300, r: 1250 },  // New York / Newark
+];
+export const CITY_GROUND_Y = 3; // flat plateau height the cities/runways sit on
+
+function hash2(x, z) {
+  const s = Math.sin(x * 127.1 + z * 311.7) * 43758.5453;
+  return s - Math.floor(s);
+}
+function vnoise(x, z) {
+  const xi = Math.floor(x), zi = Math.floor(z);
+  const xf = x - xi, zf = z - zi;
+  const a = hash2(xi, zi), b = hash2(xi + 1, zi), c = hash2(xi, zi + 1), d = hash2(xi + 1, zi + 1);
+  const u = xf * xf * (3 - 2 * xf), v = zf * zf * (3 - 2 * zf);
+  return a * (1 - u) * (1 - v) + b * u * (1 - v) + c * (1 - u) * v + d * u * v;
+}
+function fbm(x, z) {
+  let s = 0, a = 0.5, f = 1;
+  for (let i = 0; i < 4; i++) { s += a * vnoise(x * f, z * f); f *= 2.03; a *= 0.5; }
+  return s;
+}
+
+export function elevation(x, z) {
+  // Rolling seabed well below the surface.
+  let e = -58 + (fbm(x * 0.0018 + 3, z * 0.0018 + 7) - 0.5) * 44;
+  for (const L of LANDS) {
+    const d = Math.hypot(x - L.x, z - L.z) / L.r;
+    if (d >= 1) continue;
+    if (d < 0.42) {
+      e = CITY_GROUND_Y; // flat coastal plateau for the city + runway
+    } else {
+      const t = (d - 0.42) / 0.58; // 0 at plateau edge → 1 at the outer coast
+      const land = CITY_GROUND_Y * (1 - t) - 34 * t * t + (fbm(x * 0.02, z * 0.02) - 0.5) * 9;
+      e = Math.max(e, land);
+    }
+  }
+  return e;
+}
+
+function colorFor(e, out) {
+  // returns [r,g,b] land/sea colour ramp
+  let c;
+  if (e > 26) c = [0.46, 0.47, 0.44];        // high ground / rock
+  else if (e > 8) c = [0.34, 0.46, 0.28];    // grass
+  else if (e > 1.5) c = [0.55, 0.55, 0.36];  // meadow/edge
+  else if (e > -1) c = [0.78, 0.72, 0.5];    // beach sand
+  else if (e > -12) c = [0.16, 0.5, 0.55];   // turquoise shallows
+  else if (e > -34) c = [0.07, 0.32, 0.48];  // shelf
+  else c = [0.03, 0.15, 0.32];               // deep ocean
+  out.push(c[0], c[1], c[2]);
+}
+
+export function buildTerrain() {
+  const W = 3800, D = 8400, SX = 150, SZ = 320;
+  const geo = new THREE.PlaneGeometry(W, D, SX, SZ);
+  geo.rotateX(-Math.PI / 2);
+  // Center the plane over the route mid-point in z.
+  geo.translate(0, 0, 3000);
+  const pos = geo.attributes.position;
+  const colors = [];
+  for (let i = 0; i < pos.count; i++) {
+    const e = elevation(pos.getX(i), pos.getZ(i));
+    pos.setY(i, e);
+    colorFor(e, colors);
+  }
+  geo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geo.computeVertexNormals();
+  const mat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.96, metalness: 0.0 });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.renderOrder = 0;
+  return mesh;
+}
+
+const waterVert = `
+uniform float time;
+varying vec3 vWorld;
+void main() {
+  vec3 p = position;
+  float w = sin(p.x * 0.02 + time) * 0.6 + sin(p.z * 0.028 - time * 0.8) * 0.5;
+  p.y += w;
+  vWorld = (modelMatrix * vec4(p, 1.0)).xyz;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
+}`;
+
+const waterFrag = `
+uniform float time;
+varying vec3 vWorld;
+void main() {
+  // Large-scale colour variation so the open ocean isn't a flat tile.
+  float n = sin(vWorld.x * 0.0009) * cos(vWorld.z * 0.0007 + 1.3);
+  vec3 deep = vec3(0.04, 0.20, 0.40);
+  vec3 shallow = vec3(0.10, 0.42, 0.55);
+  vec3 col = mix(deep, shallow, 0.5 + 0.5 * n);
+  float sparkle = smoothstep(0.96, 1.0, sin(vWorld.x * 0.3 + time) * sin(vWorld.z * 0.3));
+  col += sparkle * 0.25;
+  gl_FragColor = vec4(col, 0.82);
+}`;
+
+export function buildWater() {
+  const geo = new THREE.PlaneGeometry(3800, 8400, 80, 160);
+  geo.rotateX(-Math.PI / 2);
+  geo.translate(0, 0, 3000);
+  const mat = new THREE.ShaderMaterial({
+    vertexShader: waterVert,
+    fragmentShader: waterFrag,
+    transparent: true,
+    depthWrite: false,
+    uniforms: { time: { value: 0 } },
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.position.y = 0;
+  mesh.renderOrder = 1;
+  return mesh;
+}

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // network-first with cache fallback for anything unexpected, so a live
 // update during development is still picked up when online.
 
-const CACHE = 'ua17-v4';
+const CACHE = 'ua17-v5';
 const CORE = [
   './',
   './index.html',
@@ -22,6 +22,7 @@ const CORE = [
   './js/ua17-aircraft.js',
   './js/ua17-airport.js',
   './js/ua17-sky.js',
+  './js/ua17-terrain.js',
   './js/ua17-clouds.js',
   './js/ua17-buildings.js',
   './js/ua17-landmarks.js',


### PR DESCRIPTION
Addresses the "glitchy floating structures / dull flat repeating ocean / flat landscape" feedback.

- Replaces the flat tiled ocean + floating grey city slabs with an **elevation-displaced terrain**: deep seabed → turquoise coastal shelf → beaches → green land plateaus under each city, coloured by height, with an animated translucent sea surface.
- **Fixes floating structures** — the city slab used to sit ~60 units above the sea; cities and runways now sit on the coastal land plateau.
- **Fixes the dull repeating ocean** — you climb out over the UK coastline, cross open ocean with depth-varied colour, and descend into a coastal New York.

Procedural (deterministic value-noise) terrain, not real bathymetry — a full OSM+DEM North Atlantic isn't feasible offline — but it reads as land/sea/coast from altitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_