### PR TITLE
UA17: fix building proportions, floaters, rocket-climb, sun, HUD clip

### DIFF
--- a/magpie/ua17/css/ua17.css
+++ b/magpie/ua17/css/ua17.css
@@ -130,7 +130,8 @@ html, body {
   flex-direction: column;
   gap: 0.55rem;
   padding: 0.6rem 1rem max(0.9rem, env(safe-area-inset-bottom));
-  background: linear-gradient(0deg, rgba(11,40,120,0.9) 0%, rgba(11,40,120,0.8) 55%, rgba(11,40,120,0));
+  /* Nearly opaque so 3D geometry (runways, towers) can't bleed up through the panel. */
+  background: linear-gradient(0deg, rgba(11,40,120,0.99) 0%, rgba(11,40,120,0.97) 70%, rgba(11,40,120,0.75) 92%, rgba(11,40,120,0));
   pointer-events: auto;
 }
 

--- a/magpie/ua17/js/ua17-aircraft.js
+++ b/magpie/ua17/js/ua17-aircraft.js
@@ -183,9 +183,11 @@ export function buildAircraft() {
   const fuse = new THREE.Mesh(fuselageGeometry(fuseLen, fuseR), bodyMat);
   group.add(fuse);
 
-  const cockpit = new THREE.Mesh(new THREE.SphereGeometry(fuseR * 0.6, 14, 10, 0, Math.PI * 2, 0, Math.PI / 2), glassMat);
-  cockpit.scale.set(1, 0.7, 1.5);
-  cockpit.position.set(0, fuseR * 0.3, fuseLen / 2 + 1.2);
+  // Cockpit windows: a small dark band set back from the nose (not a big black
+  // sphere at the very tip, which read as a "black blob nose").
+  const cockpit = new THREE.Mesh(new THREE.SphereGeometry(fuseR * 0.42, 14, 10, 0, Math.PI * 2, 0, Math.PI / 2), glassMat);
+  cockpit.scale.set(0.85, 0.55, 1.1);
+  cockpit.position.set(0, fuseR * 0.5, fuseLen / 2 - 1.4);
   group.add(cockpit);
 
   // Main wings: swept, tapered, gentle dihedral, with upturned winglets —
@@ -242,18 +244,19 @@ export function buildAircraft() {
   const landingGear = makeLandingGear(fuseR);
   group.add(landingGear);
 
-  // Nav lights: red/green wingtip beacons (static) + a blinking white tail
-  // strobe (toggled from the animation loop via userData.beacon).
+  // Nav lights: tiny red/green wingtip beacons + a small blinking tail beacon.
+  // Kept very small so they don't read as stray floating dots at distance.
   const navMat = (color) => new THREE.MeshBasicMaterial({ color });
-  const navGeo = new THREE.SphereGeometry(0.22, 8, 6);
+  const navGeo = new THREE.SphereGeometry(0.11, 6, 5);
   const redLight = new THREE.Mesh(navGeo, navMat(0xff2a2a));
-  redLight.position.set(18.6, 0, -3.6);
+  redLight.position.set(18.4, 0, -3.6);
   wingL.add(redLight);
   const greenLight = new THREE.Mesh(navGeo, navMat(0x2aff6a));
-  greenLight.position.set(18.6, 0, -3.6);
+  greenLight.position.set(18.4, 0, -3.6);
   wingR.add(greenLight);
-  const beacon = new THREE.Mesh(new THREE.SphereGeometry(0.28, 8, 6), navMat(0xffffff));
-  beacon.position.set(0, fuseR * 1.05 + 6.6, -fuseLen / 2 + 1.4);
+  // Small tail-fin beacon (blinks via userData.beacon in the loop).
+  const beacon = new THREE.Mesh(new THREE.SphereGeometry(0.16, 6, 5), navMat(0xff5555));
+  beacon.position.set(0, fuseR * 0.65 + 6.6, -fuseLen / 2 + 1.4);
   group.add(beacon);
 
   group.traverse((o) => { if (o.isMesh) { o.castShadow = false; o.receiveShadow = false; } });

--- a/magpie/ua17/js/ua17-app.js
+++ b/magpie/ua17/js/ua17-app.js
@@ -263,7 +263,14 @@ async function main() {
     const pos = flightCurve.getPointAt(t);
     aircraft.position.copy(pos);
 
+    // Orient from a PITCH-DAMPENED heading: the flight path climbs/descends
+    // steeply at toy scale, and a nose-up airliner reads as a launching
+    // rocket. Flatten the vertical component of the heading used for
+    // orientation (position still follows the true path) so the plane keeps a
+    // gentle, airliner-like attitude.
     forward.copy(flightCurve.getTangentAt(t)).normalize();
+    forward.y *= 0.32;
+    forward.normalize();
     right.crossVectors(worldUp, forward).normalize();
     if (right.lengthSq() < 1e-6) right.set(1, 0, 0);
     up.crossVectors(forward, right).normalize();
@@ -301,7 +308,7 @@ async function main() {
     const remMi = Math.round(TOTAL_MI * rem);
     const remKm = Math.round(TOTAL_KM * rem);
     ttdEl.textContent = fmtHM(TOTAL_MIN * rem);
-    dtdEl.textContent = `· ${remMi.toLocaleString()} mi`;
+    dtdEl.textContent = ''; // distance shown in the bottom row; keep top ribbon short so it never clips
 
     const altFt = Math.max(0, Math.round((aircraft.position.y / CRUISE_ALT) * CRUISE_FT / 100) * 100);
     altEl.textContent = altFt.toLocaleString();

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -114,7 +114,9 @@ function footprintMetrics(footprint) {
 
 function buildOneBuilding(b, index, isLandmark) {
   const group = new THREE.Group();
-  const H = b.height;
+  // CRITICAL: scale height by the SAME factor as the footprint, or towers come
+  // out ~3x too thin and read as needles/cones instead of buildings.
+  const H = b.height * SKYLINE_SCALE;
   const { cx, cz, w, d } = footprintMetrics(b.footprint);
   const span = Math.max(w, d);
 
@@ -135,69 +137,39 @@ function buildOneBuilding(b, index, isLandmark) {
     emissive: color,
     emissiveIntensity: fam.emissive,
   });
-  // Tile the facade: ~1 texture tile per storey vertically, a couple across.
+  // Tile the facade: rows of windows up the height, a couple of bays across.
   mat.map.needsUpdate = true;
-  mat.map.repeat.set(Math.max(1, Math.round(span / 12)), Math.max(2, Math.round(H / 24)));
+  mat.map.repeat.set(Math.max(1, Math.round(span / 9)), Math.max(2, Math.round(H / 9)));
 
   const roofMat = new THREE.MeshStandardMaterial({ color: 0x6c7075, roughness: 0.85 });
   const base = scaledPoints(b.footprint, 1, cx, cz);
 
-  if (H > 95 || isLandmark) {
-    // Tall tower: two setbacks + a slender tapered crown.
-    group.add(tierMesh(base, 0, H * 0.6, mat));
-    group.add(tierMesh(scaledPoints(b.footprint, 0.8, cx, cz), H * 0.6, H * 0.85, mat));
-    group.add(tierMesh(scaledPoints(b.footprint, 0.58, cx, cz), H * 0.85, H, mat));
-    // Spire (square tapered) + antenna mast + red aircraft-warning light.
-    const spireLen = THREE.MathUtils.clamp(H * 0.18, 12, 60);
-    const spire = new THREE.Mesh(new THREE.ConeGeometry(span * 0.16, spireLen, 4), mat);
-    spire.rotation.y = Math.PI / 4;
-    spire.position.set(cx, H + spireLen / 2, cz);
-    group.add(spire);
-    const mastLen = spireLen * 0.9;
-    const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 0.7, mastLen, 6), roofMat);
-    mast.position.set(cx, H + spireLen + mastLen / 2, cz);
-    group.add(mast);
-    const redLight = new THREE.Mesh(new THREE.SphereGeometry(1.1, 8, 6), new THREE.MeshBasicMaterial({ color: 0xff3b3b }));
-    redLight.position.set(cx, H + spireLen + mastLen, cz);
-    group.add(redLight);
-    if (isLandmark) group.add(beacon(H + spireLen + mastLen));
-  } else if (H > 45) {
-    // Mid-rise: a single setback + rooftop mechanical penthouse.
-    group.add(tierMesh(base, 0, H * 0.9, mat));
-    group.add(tierMesh(scaledPoints(b.footprint, 0.82, cx, cz), H * 0.9, H, mat));
-    const box = new THREE.Mesh(new THREE.BoxGeometry(span * 0.4, 6, span * 0.34), roofMat);
-    box.position.set(cx, H + 3, cz);
+  // Clean box massing with setbacks — NO cone spires, antenna masts or red
+  // warning-light spheres (those made the towers read as needles/cones with
+  // floating red dots, and the tall masts looked like "cones hanging on
+  // strings"). A flat roof cap + a small mechanical box is all a tower needs.
+  if (H > 55 || isLandmark) {
+    // Tall tower: two gentle setbacks (kept wide so it stays a tower, not a spike).
+    group.add(tierMesh(base, 0, H * 0.55, mat));
+    group.add(tierMesh(scaledPoints(b.footprint, 0.86, cx, cz), H * 0.55, H * 0.82, mat));
+    group.add(tierMesh(scaledPoints(b.footprint, 0.72, cx, cz), H * 0.82, H, mat));
+    const capMat = new THREE.MeshStandardMaterial({ color: 0x555a60, roughness: 0.8 });
+    const cap = new THREE.Mesh(new THREE.BoxGeometry(span * 0.5, Math.max(2, H * 0.03), span * 0.42), capMat);
+    cap.position.set(cx, H + Math.max(1, H * 0.015), cz);
+    group.add(cap);
+  } else if (H > 22) {
+    // Mid-rise: single slight setback + a low rooftop mechanical penthouse.
+    group.add(tierMesh(base, 0, H * 0.92, mat));
+    group.add(tierMesh(scaledPoints(b.footprint, 0.9, cx, cz), H * 0.92, H, mat));
+    const box = new THREE.Mesh(new THREE.BoxGeometry(span * 0.42, Math.max(1.5, H * 0.06), span * 0.36), roofMat);
+    box.position.set(cx, H + Math.max(0.8, H * 0.03), cz);
     group.add(box);
-    // A rooftop antenna on some.
-    if (hash(index, 11) > 0.6) {
-      const a = new THREE.Mesh(new THREE.CylinderGeometry(0.4, 0.4, 16, 6), roofMat);
-      a.position.set(cx, H + 8 + 8, cz);
-      group.add(a);
-    }
   } else {
-    // Low-rise: flat roof + parapet, and sometimes a classic water tower.
+    // Low-rise: flat roof + a thin parapet lip.
     group.add(tierMesh(base, 0, H, mat));
-    const parapet = new THREE.Mesh(new THREE.BoxGeometry(span * 0.5, 2.5, span * 0.42), roofMat);
-    parapet.position.set(cx, H + 1, cz);
+    const parapet = new THREE.Mesh(new THREE.BoxGeometry(span * 0.62, 1.2, span * 0.54), roofMat);
+    parapet.position.set(cx, H + 0.6, cz);
     group.add(parapet);
-    if (hash(index, 5) > 0.55) {
-      const tank = new THREE.Group();
-      const legMat = new THREE.MeshStandardMaterial({ color: 0x4a4640, roughness: 0.8 });
-      const barrel = new THREE.Mesh(new THREE.CylinderGeometry(3, 3, 6, 10), new THREE.MeshStandardMaterial({ color: 0x8a6a4a, roughness: 0.85 }));
-      barrel.position.y = 9;
-      tank.add(barrel);
-      const cap = new THREE.Mesh(new THREE.ConeGeometry(3.3, 2.4, 10), new THREE.MeshStandardMaterial({ color: 0x6f5238, roughness: 0.85 }));
-      cap.position.y = 13.2;
-      tank.add(cap);
-      for (let l = 0; l < 4; l++) {
-        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.25, 0.25, 6, 4), legMat);
-        const ang = (l / 4) * Math.PI * 2;
-        leg.position.set(Math.cos(ang) * 2.2, 3, Math.sin(ang) * 2.2);
-        tank.add(leg);
-      }
-      tank.position.set(cx + (hash(index, 9) - 0.5) * span * 0.3, H, cz + (hash(index, 13) - 0.5) * span * 0.3);
-      group.add(tank);
-    }
   }
 
   group.traverse((o) => { if (o.isMesh) o.name = b.name || 'building'; });

--- a/magpie/ua17/js/ua17-sky.js
+++ b/magpie/ua17/js/ua17-sky.js
@@ -53,11 +53,17 @@ export function buildSun() {
   g.addColorStop(1, 'rgba(255,240,180,0)');
   ctx.fillStyle = g;
   ctx.fillRect(0, 0, 256, 256);
+  // A bright solid core so it reads as the sun, wrapped in a big soft halo —
+  // otherwise the small sprite looked like a stray floating white ball.
+  ctx.fillStyle = 'rgba(255,252,235,1)';
+  ctx.beginPath();
+  ctx.arc(128, 128, 34, 0, Math.PI * 2);
+  ctx.fill();
   const tex = new THREE.CanvasTexture(c);
   const mat = new THREE.SpriteMaterial({ map: tex, color: 0xffffff, transparent: true, depthWrite: false, blending: THREE.AdditiveBlending });
   const sprite = new THREE.Sprite(mat);
-  sprite.scale.set(1400, 1400, 1);
-  sprite.position.set(-4000, 3200, -3000);
+  sprite.scale.set(2600, 2600, 1);
+  sprite.position.set(-3200, 5200, -5200); // high in the sky, clearly the sun
   return sprite;
 }
 

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // network-first with cache fallback for anything unexpected, so a live
 // update during development is still picked up when online.
 
-const CACHE = 'ua17-v5';
+const CACHE = 'ua17-v6';
 const CORE = [
   './',
   './index.html',


### PR DESCRIPTION
Fixes driven by an objective blind multi-agent image assessment (describers saw the screenshots with no context; separate assessors judged the descriptions against the spec). Addresses the confirmed P0 defects:

- **Buildings were ~3× too thin** (heights left in raw metres while footprints were scaled 0.36×) → scale height by the same factor. Towers now read as buildings, not needles/cones.
- **Removed** cone spires, tall antenna masts and red warning-light spheres (the "cones on strings" + floating red dots) and floating water towers. Clean box massing with gentle setbacks.
- **Aircraft** oriented from a pitch-dampened heading so a steep climb no longer looks like a rocket; smaller set-back cockpit; tiny nav lights.
- **Sun** given a bright core + halo, placed high (no longer a stray white ball).
- **HUD**: distance dropped from the top ribbon so its text never clips; near-opaque bottom panel so 3D geometry can't bleed through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_