### PR TITLE
UA17: auto-frame skylines on climb/approach; denser closer cities

### DIFF
--- a/magpie/ua17/js/ua17-app.js
+++ b/magpie/ua17/js/ua17-app.js
@@ -51,7 +51,7 @@ function compass(deg) {
 
 async function main() {
   const canvas = document.getElementById('ua17-canvas');
-  const { scene, camera, renderer, updateCamera, resumeIdleDriftAfter, setOrbit } = createScene(canvas);
+  const { scene, camera, renderer, updateCamera, resumeIdleDriftAfter, setOrbit, setAutoFrame } = createScene(canvas);
   scene.fog = new THREE.Fog(0xdff2ff, 3200, 9200);
 
   const [weather, flightInfo, londonData, nycData, flightsSnapshot, elevation] = await Promise.all([
@@ -245,6 +245,19 @@ async function main() {
     }
 
     const t = state.t;
+    // Auto-frame the skyline: aim the camera at the actual city bearing during
+    // climb-out (London) and approach (New York), so the skyline swings into
+    // view whether it's ahead (far) or beside (close). Hands off in cruise.
+    const cf = t < 0.18 ? cities[0] : (t > 0.8 ? cities[1] : null);
+    if (cf) {
+      const p = flightCurve.getPointAt(t);
+      const fwd = flightCurve.getTangentAt(t);
+      let rel = Math.atan2(cf.x - p.x, cf.z - p.z) - Math.atan2(fwd.x, fwd.z);
+      rel = Math.atan2(Math.sin(rel), Math.cos(rel));
+      // Negated: in this camera convention a city on +x frames with negative yaw.
+      setAutoFrame(THREE.MathUtils.clamp(-rel, -0.95, 0.95));
+    } else setAutoFrame(null);
+
     updateAircraftPose(t, dt);
     updateClouds(dt);
     particles.update(dt);

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -141,7 +141,7 @@ function buildOneBuilding(b, index, isLandmark) {
   mat.map.needsUpdate = true;
   mat.map.repeat.set(Math.max(1, Math.round(span / 9)), Math.max(2, Math.round(H / 9)));
 
-  const roofMat = new THREE.MeshStandardMaterial({ color: 0x6c7075, roughness: 0.85 });
+  const roofMat = new THREE.MeshStandardMaterial({ color: 0x93999f, roughness: 0.85 });
   const base = scaledPoints(b.footprint, 1, cx, cz);
 
   // Clean box massing with setbacks — NO cone spires, antenna masts or red
@@ -153,7 +153,7 @@ function buildOneBuilding(b, index, isLandmark) {
     group.add(tierMesh(base, 0, H * 0.55, mat));
     group.add(tierMesh(scaledPoints(b.footprint, 0.86, cx, cz), H * 0.55, H * 0.82, mat));
     group.add(tierMesh(scaledPoints(b.footprint, 0.72, cx, cz), H * 0.82, H, mat));
-    const capMat = new THREE.MeshStandardMaterial({ color: 0x555a60, roughness: 0.8 });
+    const capMat = new THREE.MeshStandardMaterial({ color: 0x868d94, roughness: 0.8 });
     const cap = new THREE.Mesh(new THREE.BoxGeometry(span * 0.5, Math.max(2, H * 0.03), span * 0.42), capMat);
     cap.position.set(cx, H + Math.max(1, H * 0.015), cz);
     group.add(cap);
@@ -180,7 +180,7 @@ function buildOneBuilding(b, index, isLandmark) {
 // centroid. Real footprints include sparse far-flung outliers that would
 // splay the "city" into a 900-wide band; trimming to the core lets us place
 // a compact, recognisable skyline as a close flyby beside the path.
-const CORE_RADIUS = 260;
+const CORE_RADIUS = 170;
 
 export function buildSkyline(data, worldZ, worldX = 0) {
   // Centroid of the whole set.
@@ -223,8 +223,8 @@ export function buildSkyline(data, worldZ, worldX = 0) {
 // Close flyby: core spread is ~±CORE_RADIUS, so an offset of ~330 keeps the
 // nearest tower ~70 units off the path — a dramatic wall of towers beside the
 // wing without ever crossing the flight path.
-export const LONDON_WORLD_X = -330;
-export const NYC_WORLD_X = 330;
+export const LONDON_WORLD_X = -235;
+export const NYC_WORLD_X = 235;
 
 export function buildLondonSkyline(londonData) {
   return buildSkyline(londonData, LONDON_WORLD_Z, LONDON_WORLD_X);

--- a/magpie/ua17/js/ua17-scene.js
+++ b/magpie/ua17/js/ua17-scene.js
@@ -62,12 +62,21 @@ export function createScene(canvas) {
   let dragging = false;
   const last = { x: 0, y: 0 };
 
+  // Auto-framing: the app can request the camera gently aim toward a point of
+  // interest (a city) via setAutoFrame(yaw). It only takes effect when the
+  // user hasn't touched the view recently, so dragging always wins.
+  let autoYaw = null;
+  let lastInteract = -1e9;
+  function nowMs() { return (typeof performance !== 'undefined' ? performance.now() : 0); }
+  function setAutoFrame(yaw) { autoYaw = yaw; }
+
   canvas.style.touchAction = 'none';
 
   const DRAG_SPEED = 0.0038;
 
   function onPointerDown(e) {
     dragging = true;
+    lastInteract = nowMs();
     last.x = e.clientX;
     last.y = e.clientY;
     velocity.yaw = 0;
@@ -77,6 +86,7 @@ export function createScene(canvas) {
   }
   function onPointerMove(e) {
     if (!dragging) return;
+    lastInteract = nowMs();
     const dx = e.clientX - last.x;
     const dy = e.clientY - last.y;
     last.x = e.clientX;
@@ -129,6 +139,12 @@ export function createScene(canvas) {
       if (Math.abs(velocity.pitch) < 0.00004) velocity.pitch = 0;
     }
 
+    // Auto-frame toward a city when the user has been hands-off for a moment,
+    // so the skyline swings into view during climb-out/approach on its own.
+    if (!dragging && velocity.yaw === 0 && autoYaw !== null && (nowMs() - lastInteract) > 2500) {
+      orbit.yaw += (autoYaw - orbit.yaw) * (1 - Math.pow(0.06, dt));
+    }
+
     // Follow only the HORIZONTAL heading, smoothed hard — climb/descent pitch
     // and path wiggles never tilt or swing the frame.
     tmpFwd.set(tangent.x, 0, tangent.z);
@@ -174,5 +190,5 @@ export function createScene(canvas) {
     if (o.distance != null) orbit.distance = o.distance;
   }
 
-  return { scene, camera, renderer, updateCamera, resize, resumeIdleDriftAfter, setOrbit };
+  return { scene, camera, renderer, updateCamera, resize, resumeIdleDriftAfter, setOrbit, setAutoFrame };
 }

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // network-first with cache fallback for anything unexpected, so a live
 // update during development is still picked up when online.
 
-const CACHE = 'ua17-v7';
+const CACHE = 'ua17-v8';
 const CORE = [
   './',
   './index.html',


### PR DESCRIPTION
Committing to the "polished stylized, fully offline" direction (chosen over photoreal):

- **Camera auto-frames the skyline** — aims at the real city bearing during climb-out (London) and approach (New York) after a moment hands-off, so the skyline swings into view on its own (dragging still overrides). Now The Shard/London and an Empire-State-like Manhattan are the hero moments beside each runway.
- **Denser, closer cities** — tighter downtown core + closer offsets so the skyline reads as a proper close flyby, with verified safe clearance from the flight path.
- Lightened rooftop caps so short buildings don't read as dark flat panels.

Builds on the real-DEM terrain + filmic lighting from #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_