### PR TITLE
UA17: de-rocket the aircraft; remove floating slabs (clean building extrusions)

### DIFF
--- a/magpie/ua17/js/ua17-aircraft.js
+++ b/magpie/ua17/js/ua17-aircraft.js
@@ -90,16 +90,22 @@ function wingPrism(span, rootChord, tipChord, sweep, thickness) {
 // of the previous cylinder-with-sphere-caps "pill" silhouette.
 function fuselageGeometry(length, radius) {
   const half = length / 2;
+  const r = radius;
+  // y runs along the fuselage axis; the +half end is the NOSE. The nose is
+  // BLUNT/rounded (stays near full radius close to the tip) — a pointed nose
+  // is exactly what made this read as a rocket. The tail tapers to a normal
+  // cone.
   const profile = [
-    [0.0, -half - 3.4],
-    [radius * 0.25, -half - 1.6],
-    [radius * 0.85, -half],
-    [radius, -half + 5],
-    [radius, half - 12],
-    [radius * 0.94, half - 6],
-    [radius * 0.7, half - 2],
-    [radius * 0.32, half + 0.6],
-    [0.0, half + 2.4],
+    [0.0, -half - 3.0],       // tail cone tip
+    [r * 0.34, -half - 1.3],
+    [r * 0.72, -half + 0.8],
+    [r, -half + 4.5],         // reach full radius
+    [r, half - 5.5],          // constant cabin
+    [r * 0.99, half - 3.4],
+    [r * 0.92, half - 1.8],   // still 92% radius near the tip = blunt nose
+    [r * 0.7, half - 0.4],
+    [r * 0.36, half + 0.9],
+    [0.0, half + 1.6],        // short rounded nose tip
   ].map(([x, y]) => new THREE.Vector2(x, y));
   const geo = new THREE.LatheGeometry(profile, 28);
   geo.rotateX(Math.PI / 2);
@@ -179,7 +185,8 @@ export function buildAircraft() {
   const glassMat = new THREE.MeshStandardMaterial({ color: 0x17222e, roughness: 0.1, metalness: 0.7 });
   const tailMat = new THREE.MeshStandardMaterial({ map: tailTexture(), roughness: 0.4, metalness: 0.15, side: THREE.DoubleSide });
 
-  const fuseLen = 34, fuseR = 2.5;
+  // Chunkier, shorter proportions read as a friendly airliner, not a needle.
+  const fuseLen = 30, fuseR = 3.1;
   const fuse = new THREE.Mesh(fuselageGeometry(fuseLen, fuseR), bodyMat);
   group.add(fuse);
 
@@ -190,10 +197,11 @@ export function buildAircraft() {
   cockpit.position.set(0, fuseR * 0.5, fuseLen / 2 - 1.4);
   group.add(cockpit);
 
-  // Main wings: swept, tapered, gentle dihedral, with upturned winglets —
-  // the single biggest cue that separates "toy silhouette" from "airliner".
-  const wingGeo = wingPrism(16, 7.5, 2.6, 3.6, 0.45);
-  const { group: wings, right: wingR, left: wingL } = mirroredPair(wingGeo, wingMat, fuseR * 0.85, -0.6, 0.5, 0.06);
+  // Main wings: large chord + moderate sweep so they're clearly visible from
+  // the side (small swept-back wings were invisible edge-on, leaving a
+  // rocket-like tube). Gentle dihedral + upturned winglets.
+  const wingGeo = wingPrism(17.5, 10, 3.4, 2.6, 0.55);
+  const { group: wings, right: wingR, left: wingL } = mirroredPair(wingGeo, wingMat, fuseR * 0.8, -0.8, 1.5, 0.06);
   group.add(wings);
 
   const wingletGeo = wingPrism(2.6, 2.3, 0.7, 1.3, 0.28);

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -149,35 +149,18 @@ function buildOneBuilding(b, index, isLandmark) {
   mat.map.needsUpdate = true;
   mat.map.repeat.set(Math.max(1, Math.round(span / 9)), Math.max(2, Math.round(H / 9)));
 
-  const roofMat = new THREE.MeshStandardMaterial({ color: 0xb2b7bd, roughness: 0.8 });
   const base = scaledPoints(b.footprint, 1, cx, cz);
 
-  // Clean box massing with setbacks — NO cone spires, antenna masts or red
-  // warning-light spheres (those made the towers read as needles/cones with
-  // floating red dots, and the tall masts looked like "cones hanging on
-  // strings"). A flat roof cap + a small mechanical box is all a tower needs.
-  if (H > 55 || isLandmark) {
-    // Tall tower: two gentle setbacks (kept wide so it stays a tower, not a spike).
-    group.add(tierMesh(base, 0, H * 0.55, mat));
-    group.add(tierMesh(scaledPoints(b.footprint, 0.86, cx, cz), H * 0.55, H * 0.82, mat));
-    group.add(tierMesh(scaledPoints(b.footprint, 0.72, cx, cz), H * 0.82, H, mat));
-    const capMat = new THREE.MeshStandardMaterial({ color: 0xa7adb4, roughness: 0.75 });
-    const cap = new THREE.Mesh(new THREE.BoxGeometry(span * 0.5, Math.max(2, H * 0.03), span * 0.42), capMat);
-    cap.position.set(cx, H + Math.max(1, H * 0.015), cz);
-    group.add(cap);
-  } else if (H > 22) {
-    // Mid-rise: single slight setback + a low rooftop mechanical penthouse.
-    group.add(tierMesh(base, 0, H * 0.92, mat));
-    group.add(tierMesh(scaledPoints(b.footprint, 0.9, cx, cz), H * 0.92, H, mat));
-    const box = new THREE.Mesh(new THREE.BoxGeometry(span * 0.42, Math.max(1.5, H * 0.06), span * 0.36), roofMat);
-    box.position.set(cx, H + Math.max(0.8, H * 0.03), cz);
-    group.add(box);
-  } else {
-    // Low-rise: flat roof + a thin parapet lip.
-    group.add(tierMesh(base, 0, H, mat));
-    const parapet = new THREE.Mesh(new THREE.BoxGeometry(span * 0.62, 1.2, span * 0.54), roofMat);
-    parapet.position.set(cx, H + 0.6, cz);
-    group.add(parapet);
+  // ONE clean extrusion of the REAL footprint to full height. No scaled
+  // setback tiers (they self-intersect on concave footprints and leave flat
+  // floating slabs) and no detached roof boxes/caps (those became the
+  // "floating slabs"). Tall towers get a single centred crown BOX — box
+  // geometry can't self-intersect, so it never produces stray slabs.
+  group.add(tierMesh(base, 0, H, mat));
+  if (H > 60) {
+    const crown = new THREE.Mesh(new THREE.BoxGeometry(span * 0.46, H * 0.14, span * 0.4), mat);
+    crown.position.set(cx, H + H * 0.07, cz);
+    group.add(crown);
   }
 
   group.traverse((o) => { if (o.isMesh) o.name = b.name || 'building'; });

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // Everything is still precached on install, so the whole experience works
 // fully offline (airplane mode, or from a zip) after one online visit.
 
-const CACHE = 'ua17-v9';
+const CACHE = 'ua17-v10';
 const CORE = [
   './',
   './index.html',


### PR DESCRIPTION
From a fresh on-device grab (not stale cache):
- **Aircraft looked like a rocket** — the fuselage lathe profile tapered to a *point* at the nose. Blunted/rounded the nose, shortened + fattened the body, enlarged the wings with less sweep so they read from the side. Now a chunky airliner.
- **Floating dark slabs** — buildings used scaled setback tiers that self-intersect on concave OSM footprints (leaving flat slabs) + detached roof-cap boxes. Replaced with one clean extrusion of the real footprint + a single centred crown box on tall towers (can't self-intersect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_