### PR TITLE
UA17: render-polish (grounding shadows, atmosphere, softer runway)

### DIFF
--- a/magpie/ua17/js/ua17-airport.js
+++ b/magpie/ua17/js/ua17-airport.js
@@ -8,17 +8,18 @@ function runwayTexture() {
   const c = document.createElement('canvas');
   c.width = 128; c.height = 2048;
   const ctx = c.getContext('2d');
-  ctx.fillStyle = '#34373a';
+  // Mid-grey asphalt (not near-black) so the runway doesn't visually dominate
+  // the whole scene, with softer off-white markings.
+  ctx.fillStyle = '#565a5f';
   ctx.fillRect(0, 0, c.width, c.height);
-  // edge lines
-  ctx.fillStyle = '#e7e9ec';
-  ctx.fillRect(6, 0, 5, c.height);
-  ctx.fillRect(c.width - 11, 0, 5, c.height);
+  ctx.fillStyle = '#c6cace';
+  ctx.fillRect(7, 0, 4, c.height);
+  ctx.fillRect(c.width - 11, 0, 4, c.height);
   // dashed centreline
-  for (let y = 40; y < c.height - 40; y += 60) ctx.fillRect(c.width / 2 - 3, y, 6, 32);
+  for (let y = 40; y < c.height - 40; y += 60) ctx.fillRect(c.width / 2 - 2, y, 5, 30);
   // threshold "piano key" bars at both ends
   const threshold = (y0) => {
-    for (let i = 0; i < 5; i++) ctx.fillRect(16 + i * 20, y0, 12, 44);
+    for (let i = 0; i < 5; i++) ctx.fillRect(16 + i * 20, y0, 12, 40);
   };
   threshold(26);
   threshold(c.height - 70);

--- a/magpie/ua17/js/ua17-app.js
+++ b/magpie/ua17/js/ua17-app.js
@@ -98,6 +98,23 @@ async function main() {
   const aircraft = buildAircraft();
   scene.add(aircraft);
 
+  // Soft contact shadow that tracks the plane on the ground (take-off/landing)
+  // and fades out with altitude — grounds it so it doesn't look like it floats.
+  const planeShadow = (() => {
+    const c = document.createElement('canvas'); c.width = c.height = 64;
+    const g = c.getContext('2d').createRadialGradient(32, 32, 2, 32, 32, 32);
+    g.addColorStop(0, 'rgba(0,0,0,0.5)'); g.addColorStop(0.6, 'rgba(0,0,0,0.25)'); g.addColorStop(1, 'rgba(0,0,0,0)');
+    const ctx = c.getContext('2d'); ctx.fillStyle = g; ctx.fillRect(0, 0, 64, 64);
+    const m = new THREE.Mesh(
+      new THREE.PlaneGeometry(46, 46),
+      new THREE.MeshBasicMaterial({ map: new THREE.CanvasTexture(c), transparent: true, depthWrite: false }),
+    );
+    m.rotation.x = -Math.PI / 2;
+    m.renderOrder = 2;
+    scene.add(m);
+    return m;
+  })();
+
   const audio = createAudio();
 
   // --- UI wiring ---
@@ -313,6 +330,16 @@ async function main() {
     // gear up once safely climbed away — both ends get a "real airport" feel.
     aircraft.userData.landingGear.visible = pos.y < 70;
     aircraft.userData.beacon.visible = Math.floor(clock.elapsedTime * 2) % 2 === 0;
+
+    // Contact shadow: on the ground below the plane, fading out as it climbs.
+    const groundY = CITY_GROUND_Y + 0.5;
+    planeShadow.position.set(pos.x, groundY, pos.z);
+    const alt = Math.max(0, pos.y - groundY);
+    const vis = THREE.MathUtils.clamp(1 - alt / 130, 0, 1);
+    planeShadow.visible = vis > 0.02;
+    planeShadow.material.opacity = vis * 0.7;
+    const sc = 1 + alt / 90; // shadow spreads slightly as it lifts
+    planeShadow.scale.set(sc, sc, 1);
 
     updateCamera(pos, forward, dt);
   }

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -83,6 +83,32 @@ function beacon(height, color = 0xffe0a0) {
 // Deterministic-ish hash so a given building always looks the same.
 function hash(i, salt) { return Math.abs(Math.sin((i + 1) * 12.9898 + salt * 78.233)) % 1; }
 
+// Soft contact-shadow texture (radial dark blob) shared by all buildings —
+// grounds them so they read as sitting IN the world, not placed on a plane.
+let sharedShadowTex = null;
+function shadowTexture() {
+  if (sharedShadowTex) return sharedShadowTex;
+  const c = document.createElement('canvas');
+  c.width = c.height = 64;
+  const ctx = c.getContext('2d');
+  const g = ctx.createRadialGradient(32, 32, 2, 32, 32, 32);
+  g.addColorStop(0, 'rgba(0,0,0,0.5)');
+  g.addColorStop(0.6, 'rgba(0,0,0,0.28)');
+  g.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 64, 64);
+  sharedShadowTex = new THREE.CanvasTexture(c);
+  return sharedShadowTex;
+}
+function contactShadow(span) {
+  const mat = new THREE.MeshBasicMaterial({ map: shadowTexture(), transparent: true, depthWrite: false });
+  const m = new THREE.Mesh(new THREE.PlaneGeometry(span * 1.7, span * 1.7), mat);
+  m.rotation.x = -Math.PI / 2;
+  m.position.y = 0.12; // just above the ground pad, avoids z-fighting
+  m.renderOrder = 2;
+  return m;
+}
+
 function scaledPoints(footprint, factor, cx, cz) {
   return footprint.map(([x, z]) => {
     const sx = x * SKYLINE_SCALE, sz = -z * SKYLINE_SCALE;
@@ -132,6 +158,7 @@ function buildOneBuilding(b, index, isLandmark) {
   const icon = landmarkModel(b.name, cx, cz, span, H);
   if (icon) {
     icon.traverse((o) => { if (o.isMesh) o.name = b.name; });
+    const sh = contactShadow(span); sh.position.set(cx, 0.12, cz); icon.add(sh);
     return icon;
   }
 
@@ -163,7 +190,9 @@ function buildOneBuilding(b, index, isLandmark) {
     group.add(crown);
   }
 
-  group.traverse((o) => { if (o.isMesh) o.name = b.name || 'building'; });
+  const sh = contactShadow(span); sh.position.set(cx, 0.12, cz); group.add(sh);
+
+  group.traverse((o) => { if (o.isMesh && !o.name) o.name = b.name || 'building'; });
   return group;
 }
 

--- a/magpie/ua17/js/ua17-sky.js
+++ b/magpie/ua17/js/ua17-sky.js
@@ -13,14 +13,20 @@ void main() {
 
 const skyFrag = `
 uniform vec3 topColor;
+uniform vec3 midColor;
 uniform vec3 horizonColor;
 uniform vec3 hazeColor;
 uniform float haze; // 0..1, driven by real cloud cover along the route
 varying vec3 vWorldPos;
 void main() {
-  float h = clamp(normalize(vWorldPos).y * 1.4 + 0.15, 0.0, 1.0);
-  vec3 col = mix(horizonColor, topColor, pow(h, 0.55));
-  col = mix(col, hazeColor, haze * (1.0 - h) * 0.85);
+  float h = clamp(normalize(vWorldPos).y * 1.25 + 0.06, 0.0, 1.0);
+  // Two-stop vertical gradient (deep zenith -> mid -> bright horizon) reads
+  // richer than a single lerp, and a soft warm band right at the horizon adds
+  // atmosphere for almost no cost.
+  vec3 col = mix(midColor, topColor, pow(h, 0.7));
+  col = mix(horizonColor, col, smoothstep(0.0, 0.42, h));
+  float band = exp(-h * 9.0);            // concentrated near the horizon
+  col = mix(col, hazeColor, clamp(band * (0.35 + 0.5 * haze), 0.0, 0.85));
   gl_FragColor = vec4(col, 1.0);
 }`;
 
@@ -32,9 +38,10 @@ export function buildSky() {
     side: THREE.BackSide,
     depthWrite: false,
     uniforms: {
-      topColor: { value: new THREE.Color(0x2a7be0) },
-      horizonColor: { value: new THREE.Color(0xdff2ff) },
-      hazeColor: { value: new THREE.Color(0xc9d8e0) },
+      topColor: { value: new THREE.Color(0x1657c8) },
+      midColor: { value: new THREE.Color(0x3f8ce0) },
+      horizonColor: { value: new THREE.Color(0xdfeeff) },
+      hazeColor: { value: new THREE.Color(0xf2ead9) }, // warm horizon haze
       haze: { value: 0.2 },
     },
   });
@@ -109,7 +116,9 @@ export function updateSky(sky, fog, cloudTotalPct) {
   const haze = THREE.MathUtils.clamp(cloudTotalPct / 100, 0, 1);
   sky.material.uniforms.haze.value = haze;
   if (fog) {
-    fog.color.setHSL(0.58, 0.35, THREE.MathUtils.lerp(0.75, 0.88, haze));
+    // Hazy light blue matching the horizon so distant terrain/city/sea melt
+    // into the sky instead of ending at a hard edge.
+    fog.color.setHSL(0.58, 0.32, THREE.MathUtils.lerp(0.86, 0.92, haze));
     // Keep a healthy near/far gap at all times — letting `far` drop below (or
     // too close to) `near` degenerates three.js's linear fog into "no fog",
     // which let the destination skyline stay perfectly crisp from mid-ocean.

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // Everything is still precached on install, so the whole experience works
 // fully offline (airplane mode, or from a zip) after one online visit.
 
-const CACHE = 'ua17-v10';
+const CACHE = 'ua17-v11';
 const CORE = [
   './',
   './index.html',


### PR DESCRIPTION
Acting on an independent visual review — its highest impact-for-effort points, all compatible with the offline PWA:

- **Grounding shadows**: soft contact shadow under every building + a tracking shadow under the plane (fades with altitude). Objects now sit *in* the world instead of on a flat plane.
- **Atmosphere**: richer two-stop sky gradient + warm horizon haze; fog tuned to a hazy horizon blue so distant terrain/city/sea melt into the sky (no hard seam).
- **Runway** toned from near-black to mid-grey with softer markings so it no longer dominates the composition.

Next: reduce the intrusive foreground cloud, add tappable-plane affordance, and vendor the real Boeing 767 aircraft model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_