### PR TITLE
UA17: fix climb-out composition + low-rise clutter; Skyport WebGPU error surfacing

### DIFF
--- a/magpie/skyport-webgpu-pwa/app.js
+++ b/magpie/skyport-webgpu-pwa/app.js
@@ -506,6 +506,19 @@ async function main() {
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
   context.configure({ device, format: presentationFormat, alphaMode: 'opaque' });
 
+  // --- Diagnostics ---------------------------------------------------------
+  // Safari's WebGPU validation is stricter than Chrome's; when it rejects a
+  // pipeline the draw is silently dropped and the canvas stays on its black
+  // clear colour while the HTML overlay still shows. Surface any such error
+  // on-screen (into the fps chip / no-support card) instead of failing black.
+  device.addEventListener('uncapturederror', (e) => {
+    console.error('WebGPU uncaptured error:', e.error?.message || e.error);
+    if (fpsEl) { fpsEl.textContent = 'GPU error'; fpsEl.title = String(e.error?.message || e.error); }
+  });
+  device.lost.then((info) => { showNoSupport('WebGPU device lost: ' + info.message); });
+  // Catch validation errors thrown while building pipelines/resources below.
+  device.pushErrorScope('validation');
+
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./sw.js').catch(() => {});
   }
@@ -764,6 +777,13 @@ async function main() {
     device.queue.submit([encoder.finish()]);
     requestAnimationFrame(frame);
   }
+
+  // Report any validation error accumulated while creating the pipelines and
+  // GPU resources above — this is what turns the "silent black canvas" on iOS
+  // into a readable message.
+  device.popErrorScope().then((err) => {
+    if (err) showNoSupport('WebGPU validation error:\n' + err.message);
+  });
 
   resize();
   requestAnimationFrame(frame);

--- a/magpie/skyport-webgpu-pwa/sw.js
+++ b/magpie/skyport-webgpu-pwa/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'skyport-webgpu-pwa-v1';
+const CACHE_NAME = 'skyport-webgpu-pwa-v2';
 const APP_SHELL = [
   './',
   './index.html',

--- a/magpie/ua17/js/ua17-app.js
+++ b/magpie/ua17/js/ua17-app.js
@@ -148,6 +148,9 @@ async function main() {
   // projects an other-flights instance to CSS pixel coords for tap testing.
   window.__ua17 = {
     state,
+    scene,
+    THREE,
+    elev: terrain.elevation, // debug: ground height at (x,z)
     jumpTo: (t) => { state.t = THREE.MathUtils.clamp(t, 0, 1); },
     setOrbit,
     activeParticles: () => particles.group.children.filter((c) => c.visible).length,
@@ -265,14 +268,21 @@ async function main() {
     // Auto-frame the skyline: aim the camera at the actual city bearing during
     // climb-out (London) and approach (New York), so the skyline swings into
     // view whether it's ahead (far) or beside (close). Hands off in cruise.
-    const cf = t < 0.18 ? cities[0] : (t > 0.8 ? cities[1] : null);
+    const cf = t < 0.2 ? cities[0] : (t > 0.8 ? cities[1] : null);
     if (cf) {
       const p = flightCurve.getPointAt(t);
       const fwd = flightCurve.getTangentAt(t);
       let rel = Math.atan2(cf.x - p.x, cf.z - p.z) - Math.atan2(fwd.x, fwd.z);
       rel = Math.atan2(Math.sin(rel), Math.cos(rel));
-      // Negated: in this camera convention a city on +x frames with negative yaw.
-      setAutoFrame(THREE.MathUtils.clamp(-rel, -0.95, 0.95));
+      // Only frame the city while it's still AHEAD-ish (within ~66° of straight
+      // ahead). Once the plane has passed it, the bearing swings past 90° and we
+      // release to the calm straight-behind chase — otherwise the camera yanks
+      // backward to stare at the receding skyline, which made the climb-out read
+      // as a chaotic near-crash with the (grounded) city looking detached.
+      if (Math.abs(rel) < 1.15) {
+        // Negated: in this camera convention a city on +x frames with negative yaw.
+        setAutoFrame(THREE.MathUtils.clamp(-rel, -0.95, 0.95));
+      } else setAutoFrame(null);
     } else setAutoFrame(null);
 
     updateAircraftPose(t, dt);

--- a/magpie/ua17/js/ua17-buildings.js
+++ b/magpie/ua17/js/ua17-buildings.js
@@ -23,7 +23,7 @@ const SKYLINE_SCALE = 0.36;
 const FAMILIES = [
   { name: 'glass', w: 5, colors: [0x5b8fc9, 0x4f86c6, 0x6fa6d6, 0x3f9fb0, 0x5fb0c4, 0x7fbfe0], roughness: 0.16, metalness: 0.55, emissive: 0.22 },
   { name: 'glass-teal', w: 3, colors: [0x3fa0a0, 0x4fb0aa, 0x5fbfc0, 0x6ec9c0], roughness: 0.18, metalness: 0.5, emissive: 0.22 },
-  { name: 'steel', w: 2, colors: [0x9fb2c0, 0x8ea6b6, 0xafc0cc], roughness: 0.35, metalness: 0.5, emissive: 0.18 },
+  { name: 'steel', w: 1, colors: [0xb9c3ca, 0xc4ccce, 0xadb9c0], roughness: 0.4, metalness: 0.45, emissive: 0.2 },
   { name: 'stone', w: 1, colors: [0xcabaa0, 0xbfae93, 0xd3c4a8], roughness: 0.75, metalness: 0.05, emissive: 0.2 },
 ];
 const FAMILY_TOTAL_W = FAMILIES.reduce((s, f) => s + f.w, 0);
@@ -146,13 +146,16 @@ function buildOneBuilding(b, index, isLandmark) {
   const group = new THREE.Group();
   // CRITICAL: scale height by the SAME factor as the footprint, or towers come
   // out ~3x too thin and read as needles/cones instead of buildings.
-  const H = b.height * SKYLINE_SCALE;
   const { cx, cz, w, d, area } = footprintMetrics(b.footprint);
   const span = Math.max(w, d);
 
   // Reject degenerate/tiny footprints — they extrude to nothing and would
   // otherwise leave a floating roof-cap slab hovering over the ground.
   if (!isLandmark && (area < 12 || span < 4)) return group;
+
+  // Floor the height so genuinely low-rise footprints read as small BOXES
+  // rather than flat grey pancake slabs strewn across the ground like debris.
+  const H = Math.max(b.height * SKYLINE_SCALE, isLandmark ? 0 : 13);
 
   // Iconic named landmarks get a bespoke recognisable model.
   const icon = landmarkModel(b.name, cx, cz, span, H);
@@ -226,7 +229,7 @@ function buildOneBuilding(b, index, isLandmark) {
 // centroid. Real footprints include sparse far-flung outliers that would
 // splay the "city" into a 900-wide band; trimming to the core lets us place
 // a compact, recognisable skyline as a close flyby beside the path.
-const CORE_RADIUS = 170;
+const CORE_RADIUS = 150;
 
 export function buildSkyline(data, worldZ, worldX = 0) {
   // Centroid of the whole set.

--- a/magpie/ua17/sw.js
+++ b/magpie/ua17/sw.js
@@ -10,7 +10,7 @@
 // Everything is still precached on install, so the whole experience works
 // fully offline (airplane mode, or from a zip) after one online visit.
 
-const CACHE = 'ua17-v13';
+const CACHE = 'ua17-v14';
 const CORE = [
   './',
   './index.html',


### PR DESCRIPTION
Addresses the issues visible in the fresh iPhone captures.

## UA17
- **Climb-out no longer reads as a crash / floating city.** The auto-frame was yanking the camera *backward* to stare at the receding London skyline during the steep climb, which made the plane look like it was plunging and the (grounded) buildings look detached. Now a city is only framed while it's still **ahead** of the plane; once passed, the camera releases to the calm straight-behind chase. Probed every building's base-to-terrain gap = ~0, so **nothing was ever actually floating** — it was pure camera composition.
- **No more grey pancake-slab clutter.** Low-rise OSM footprints now get a minimum height so they render as small boxes instead of flat slabs strewn about like debris. Lightened/softened the cold-grey "steel" family and tightened the city core radius to drop lone outliers.
- SW → `ua17-v14`.

## Skyport (comparison reference)
- **Black-on-black-except-overlay diagnosis + instrumentation.** The signature means Safari's stricter WebGPU validation is rejecting a pipeline (draw silently dropped → swapchain stays on its black clear colour) while the HTML overlay still renders. This environment has **no WebGPU**, so it can't be reproduced/verified here — instead I added an uncaptured-error handler, a device-lost handler, and a validation error scope around pipeline creation so the **real GPU error message now shows on-screen** (in the no-support card) rather than failing silently. SW → `v2`. The next on-device load should report the exact cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_