### PR TITLE
Skyport: fix Safari black-screen (sky pipeline missing depth state)

### DIFF
--- a/magpie/skyport-webgpu-pwa/app.js
+++ b/magpie/skyport-webgpu-pwa/app.js
@@ -550,7 +550,14 @@ async function main() {
     layout: pipelineLayout,
     vertex: { module: device.createShaderModule({ code: skyWGSL }), entryPoint: 'vs' },
     fragment: { module: device.createShaderModule({ code: skyWGSL }), entryPoint: 'fs', targets: [{ format: 'rgba8unorm' }] },
-    primitive: { topology:'triangle-list' }
+    primitive: { topology:'triangle-list' },
+    // MUST declare a depth state: this pipeline is used in a pass that has a
+    // depth-stencil attachment, and WebGPU requires the pipeline's depth format
+    // to match. Chrome/Dawn tolerates omitting it; Safari/WebKit rejects the
+    // draw, which invalidates the whole command buffer and leaves the canvas
+    // black (the "black on black except overlay" bug). The sky is the
+    // background, so never write depth and always pass.
+    depthStencil: { format:'depth32float', depthWriteEnabled:false, depthCompare:'always' }
   });
   const mainPipeline = device.createRenderPipeline({
     layout: pipelineLayout,

--- a/magpie/skyport-webgpu-pwa/sw.js
+++ b/magpie/skyport-webgpu-pwa/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'skyport-webgpu-pwa-v2';
+const CACHE_NAME = 'skyport-webgpu-pwa-v3';
 const APP_SHELL = [
   './',
   './index.html',


### PR DESCRIPTION
## Root cause of the "black on black except overlay" report
`skyPipeline` declared **no `depthStencil` state**, but it's used in the main render pass which **has a depth-stencil attachment**. WebGPU requires a pipeline's depth format to match the pass's depth attachment.

- **Chrome/Dawn tolerates** the omission → renders fine on desktop.
- **Safari/WebKit strictly enforces** it → rejects the sky `draw()`, which invalidates the entire command buffer, so `queue.submit()` is dropped and nothing reaches the swapchain. The canvas stays on its black clear color while the HTML overlay still renders. Exact match for the symptom.

## Fix
The sky pipeline now declares `depthStencil: { format:'depth32float', depthWriteEnabled:false, depthCompare:'always' }` — it's the background layer, so it never occludes geometry and always passes. SW cache bumped to `v3`.

Found by static inspection (this environment has no WebGPU to run it). The diagnostic error-surfacing added in the previous commit remains as a safety net in case any further Safari-specific validation issue surfaces on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131KzDXM7EDUgmpEG46NjWT)_