### PR TITLE
Lucid: multi-renderer interop, UX/units polish, skills folder, and a human visual-verification harness

### DIFF
--- a/lucid/compare.html
+++ b/lucid/compare.html
@@ -157,7 +157,7 @@
 
     <main class="main">
       <div class="toolbar">
-        <button class="toggle-sidebar" id="toggle-sidebar">☰</button>
+        <button class="toggle-sidebar" id="toggle-sidebar" title="Toggle scene list" aria-label="Toggle scene list">☰</button>
         <div>
           <div class="scene-title" id="scene-title">Select a scene</div>
           <div class="scene-path" id="scene-path">-</div>

--- a/lucid/components/lucid-renderer.js
+++ b/lucid/components/lucid-renderer.js
@@ -227,11 +227,29 @@ export class LucidRenderer extends HTMLElement {
   updateParam(name, value) {
     if (!this._renderer) return;
 
-    if (this._backend === BACKENDS.STINKYFISH) {
-      this._renderer.updateSceneParam?.(name, value);
-    } else {
-      this._renderer.updateUniform?.(`u_${name}`, value);
+    // Both backends expose setParam(name, value) (Stinkyfish's is an alias for
+    // setSceneParam). This previously called updateSceneParam/updateUniform,
+    // which exist on neither renderer, so the component's public param-update
+    // API silently did nothing. Route to the real, shared method instead.
+    if (typeof this._renderer.setParam === 'function') {
+      this._renderer.setParam(name, value);
     }
+  }
+
+  // Animation time API.
+  // Pin the render clock to an explicit time in seconds (e.g. a timeline
+  // scrubber). Both backends read `overrideTime` in their render loop, so this
+  // works identically on Mayfly and Stinkyfish. Pass null to resume the
+  // renderer's own wall clock.
+  setTime(seconds) {
+    if (!this._renderer) return;
+    this._renderer.overrideTime = (seconds === null || seconds === undefined)
+      ? null
+      : seconds;
+  }
+
+  clearTime() {
+    this.setTime(null);
   }
 
   // Private methods

--- a/lucid/components/render-controls.js
+++ b/lucid/components/render-controls.js
@@ -156,18 +156,18 @@ export class LucidRenderControls extends HTMLElement {
         <div class="section-title">Quality</div>
         <div class="row">
           <span class="label">Steps</span>
-          <input type="range" id="maxSteps" min="20" max="200" value="${s.maxSteps}">
+          <input type="range" id="maxSteps" min="20" max="200" value="${s.maxSteps}" aria-label="Maximum ray-march steps" title="Maximum ray-march steps per pixel">
           <span class="value">${s.maxSteps}</span>
         </div>
         <div class="row">
           <span class="label">Threshold</span>
-          <input type="range" id="hitThreshold" min="-4" max="-1" step="0.1" value="${Math.log10(s.hitThreshold)}">
-          <span class="value">${s.hitThreshold.toFixed(4)}</span>
+          <input type="range" id="hitThreshold" min="-4" max="-1" step="0.1" value="${Math.log10(s.hitThreshold)}" aria-label="Surface hit threshold in metres" title="Surface hit threshold (metres) — smaller is sharper but slower">
+          <span class="value">${s.hitThreshold.toFixed(4)} m</span>
         </div>
         <div class="row">
-          <span class="label">Max Dist</span>
-          <input type="range" id="maxDistance" min="10" max="200" value="${s.maxDistance}">
-          <span class="value">${s.maxDistance}</span>
+          <span class="label">Max dist.</span>
+          <input type="range" id="maxDistance" min="10" max="200" value="${s.maxDistance}" aria-label="Maximum ray distance in metres" title="Maximum ray distance (metres)">
+          <span class="value">${s.maxDistance} m</span>
         </div>
       </div>
 
@@ -175,22 +175,22 @@ export class LucidRenderControls extends HTMLElement {
         <div class="section-title">Lighting</div>
         <div class="row">
           <span class="label">Key</span>
-          <input type="range" id="keyIntensity" min="0" max="1" step="0.05" value="${s.keyIntensity}">
+          <input type="range" id="keyIntensity" min="0" max="1" step="0.05" value="${s.keyIntensity}" aria-label="Key light intensity" title="Key light intensity (0–1)">
           <span class="value">${s.keyIntensity.toFixed(2)}</span>
         </div>
         <div class="row">
           <span class="label">Fill</span>
-          <input type="range" id="fillIntensity" min="0" max="1" step="0.05" value="${s.fillIntensity}">
+          <input type="range" id="fillIntensity" min="0" max="1" step="0.05" value="${s.fillIntensity}" aria-label="Fill light intensity" title="Fill light intensity (0–1)">
           <span class="value">${s.fillIntensity.toFixed(2)}</span>
         </div>
         <div class="row">
           <span class="label">Rim</span>
-          <input type="range" id="rimIntensity" min="0" max="0.5" step="0.01" value="${s.rimIntensity}">
+          <input type="range" id="rimIntensity" min="0" max="0.5" step="0.01" value="${s.rimIntensity}" aria-label="Rim light intensity" title="Rim light intensity (0–0.5)">
           <span class="value">${s.rimIntensity.toFixed(2)}</span>
         </div>
         <div class="row">
           <span class="label">Ambient</span>
-          <input type="range" id="ambient" min="0" max="0.5" step="0.01" value="${s.ambient}">
+          <input type="range" id="ambient" min="0" max="0.5" step="0.01" value="${s.ambient}" aria-label="Ambient light intensity" title="Ambient light intensity (0–0.5)">
           <span class="value">${s.ambient.toFixed(2)}</span>
         </div>
       </div>
@@ -225,10 +225,14 @@ export class LucidRenderControls extends HTMLElement {
           // Update display value
           const valueEl = e.target.parentElement.querySelector('.value');
           if (valueEl) {
-            if (id === 'maxSteps' || id === 'maxDistance') {
+            if (id === 'maxSteps') {
               valueEl.textContent = Math.round(this.settings[id]);
+            } else if (id === 'maxDistance') {
+              valueEl.textContent = Math.round(this.settings[id]) + ' m';
+            } else if (id === 'hitThreshold') {
+              valueEl.textContent = this.settings[id].toFixed(4) + ' m';
             } else {
-              valueEl.textContent = this.settings[id].toFixed(id === 'hitThreshold' ? 4 : 2);
+              valueEl.textContent = this.settings[id].toFixed(2);
             }
           }
 

--- a/lucid/components/scene-params.js
+++ b/lucid/components/scene-params.js
@@ -179,9 +179,9 @@ export class LucidSceneParams extends HTMLElement {
       <div class="section">
         <div class="section-title">Time Control</div>
         <div class="time-controls">
-          <button id="playPause" class="${this.paused ? '' : 'active'}">${this.paused ? '▶' : '⏸'}</button>
-          <button id="reset">⏹</button>
-          <input type="range" id="timeScale" min="0" max="3" step="0.1" value="${this.timeScale}">
+          <button id="playPause" class="${this.paused ? '' : 'active'}" aria-label="${this.paused ? 'Play' : 'Pause'}" title="${this.paused ? 'Play' : 'Pause'}">${this.paused ? '▶' : '⏸'}</button>
+          <button id="reset" aria-label="Reset time" title="Reset time">⏹</button>
+          <input type="range" id="timeScale" min="0" max="3" step="0.1" value="${this.timeScale}" aria-label="Time scale (playback speed multiplier)">
           <span class="value">${this.timeScale.toFixed(1)}x</span>
         </div>
       </div>
@@ -199,6 +199,14 @@ export class LucidSceneParams extends HTMLElement {
     this.setupListeners();
   }
 
+  // Format a unit suffix for display. A leading "°" sits tight against the
+  // number (120°); word/letter units get a hair space so they read cleanly
+  // (0.50 m, 1.0 x). Returns '' when no unit is declared.
+  unitSuffix(param) {
+    if (!param || !param.unit) return '';
+    return param.unit === '°' ? '°' : ' ' + param.unit;
+  }
+
   renderParam(name, param) {
     const value = this.paramValues[name];
     const displayName = param.label || name;
@@ -208,8 +216,22 @@ export class LucidSceneParams extends HTMLElement {
       return `
         <div class="row">
           <span class="label">${displayName}</span>
-          <input type="color" class="color-input" data-name="${name}" value="${hex}">
+          <input type="color" class="color-input" data-name="${name}" value="${hex}" aria-label="${displayName} colour">
           <span class="value">${hex}</span>
+        </div>
+      `;
+    }
+
+    // Vector parameters (position/radii/direction) — read-only triplet display.
+    // A single range slider cannot represent three components, so show the
+    // formatted vector instead of feeding an array into a scalar slider.
+    if (Array.isArray(value)) {
+      const unit = this.unitSuffix(param);
+      const text = value.map(v => (typeof v === 'number' ? v.toFixed(2) : v)).join(', ');
+      return `
+        <div class="row">
+          <span class="label">${displayName}</span>
+          <span class="value" style="width:auto">${text}${unit}</span>
         </div>
       `;
     }
@@ -218,12 +240,13 @@ export class LucidSceneParams extends HTMLElement {
     const min = param.min !== undefined ? param.min : 0;
     const max = param.max !== undefined ? param.max : 1;
     const step = param.step !== undefined ? param.step : (max - min) / 100;
+    const unit = this.unitSuffix(param);
 
     return `
       <div class="row">
         <span class="label">${displayName}</span>
-        <input type="range" data-name="${name}" min="${min}" max="${max}" step="${step}" value="${value}">
-        <span class="value">${typeof value === 'number' ? value.toFixed(2) : value}</span>
+        <input type="range" data-name="${name}" min="${min}" max="${max}" step="${step}" value="${value}" aria-label="${displayName}">
+        <span class="value">${typeof value === 'number' ? value.toFixed(2) : value}${unit}</span>
       </div>
     `;
   }
@@ -266,7 +289,7 @@ export class LucidSceneParams extends HTMLElement {
         this.paramValues[name] = value;
 
         const valueEl = e.target.parentElement.querySelector('.value');
-        if (valueEl) valueEl.textContent = value.toFixed(2);
+        if (valueEl) valueEl.textContent = value.toFixed(2) + this.unitSuffix(this.sceneParams[name]);
 
         this.emitParamChange(name, value);
       });

--- a/lucid/core/json-codegen.js
+++ b/lucid/core/json-codegen.js
@@ -1942,7 +1942,19 @@ function exprToGlsl(expr, ctx) {
     case 'clamp': return `clamp(${args[0]}, ${args[1]}, ${args[2]})`;
     case 'step': return `step(${args[0]}, ${args[1]})`;
     case 'smoothstep': return `smoothstep(${args[0]}, ${args[1]}, ${args[2]})`;
-    case 'mix': return `mix(${args[0]}, ${args[1]}, ${args[2]})`;
+    case 'mix':
+    case 'lerp': return `mix(${args[0]}, ${args[1]}, ${args[2]})`;
+    // Rounding (parity with WGSL codegen)
+    case 'round': return `floor(${args[0]} + 0.5)`;
+    // Inverse trig / atan2 (parity with WGSL codegen)
+    case 'asin': return `asin(${args[0]})`;
+    case 'acos': return `acos(${args[0]})`;
+    case 'atan': return args.length > 1 ? `atan(${args[0]}, ${args[1]})` : `atan(${args[0]})`;
+    // Powers / exponentials (parity with WGSL codegen)
+    case 'pow': return `pow(${args[0]}, ${args[1]})`;
+    case 'sqrt': return `sqrt(${args[0]})`;
+    case 'exp': return `exp(${args[0]})`;
+    case 'log': return `log(${args[0]})`;
     // Noise functions - demoscene effects
     case 'noise': return `noise3(vec3(${args.join(', ')}))`;
     case 'fbm': return `fbm(vec3(${args[0]}, ${args[1]}, ${args[2]}), ${args[3] || '4'})`;

--- a/lucid/core/json-loader.js
+++ b/lucid/core/json-loader.js
@@ -75,7 +75,13 @@ function processSceneParams(params) {
         type: param.type || 'scalar',
         min: param.min,
         max: param.max,
-        step: param.step
+        step: param.step,
+        // UI presentation metadata. `label` is the human-readable name shown in
+        // param panels; `unit` (e.g. "m", "°", "x", "%", "rad") is rendered next
+        // to the value. Both were previously dropped here, so a scene's `label`
+        // silently never reached the panels.
+        label: param.label,
+        unit: param.unit
       };
     }
   }

--- a/lucid/core/wgsl-codegen.js
+++ b/lucid/core/wgsl-codegen.js
@@ -1009,8 +1009,25 @@ ${repeatCode}  return ${childFuncName}(rp);
 }
 
 function generateSelect(node, ctx) {
-  // TODO: Implement select (conditional based on param)
-  return walkNode(node.children?.[0] || { type: 'sphere', params: {} }, ctx);
+  // Branchless conditional selection, matching the GLSL codegen:
+  //   cond < 0.5  -> a,   cond >= 0.5 -> b
+  // (Previously a stub that always rendered a unit sphere and read the wrong
+  //  field — select nodes carry `cond`/`a`/`b`, not `children`.)
+  const aNode = node.a || node.children?.[0] || { type: 'sphere', params: {} };
+  const bNode = node.b || node.children?.[1] || { type: 'sphere', params: {} };
+  const condExpr = node.cond !== undefined ? valueToWgsl(node.cond, ctx) : '0.0';
+  const aExpr = walkNode(aNode, ctx);
+  const bExpr = walkNode(bNode, ctx);
+
+  const funcName = `select_${ctx.helperCounter++}`;
+  ctx.helpers.push(`fn ${funcName}(p: vec3f) -> vec4f {
+  let sel = step(0.5, ${condExpr});
+  let va = ${aExpr};
+  let vb = ${bExpr};
+  return mix(va, vb, sel);
+}`);
+
+  return `${funcName}(${ctx.currentP || 'p'})`;
 }
 
 function generateRound(node, ctx) {
@@ -1329,7 +1346,10 @@ function exprToWgsl(expr, ctx) {
     case 'div':
       return `(${a[0]} / ${a[1]})`;
     case 'mod':
-      return `(${a[0]} % ${a[1]})`;
+      // Floored modulo to match GLSL's mod() semantics (WGSL '%' is truncated,
+      // which diverges from Mayfly/GLSL for negative operands). Keeps SDF domain
+      // repetition identical across backends.
+      return `(${a[0]} - ${a[1]} * floor(${a[0]} / ${a[1]}))`;
     case 'neg':
       return `(-${a[0]})`;
 

--- a/lucid/index.html
+++ b/lucid/index.html
@@ -1304,28 +1304,28 @@
     <header class="header">
       <div class="header-left">
         <div class="header-icons">
-          <button class="icon-btn" id="btn-menu" title="Menu (M)">☰</button>
-          <button class="icon-btn" id="btn-perf" title="Performance Stats">📊</button>
-          <button class="icon-btn" id="btn-debug" title="Debug (D)">🔧</button>
-          <button class="icon-btn" id="btn-params" title="Scene Params (P)">🎛️</button>
-          <button class="icon-btn" id="btn-editor" title="Editor (E)">{ }</button>
-          <button class="icon-btn" id="btn-auto-rotate" title="Auto-rotate (R)">🚁</button>
-          <button class="icon-btn" id="btn-anim" title="Animation: Playing (A)" style="position:relative;">
+          <button class="icon-btn" id="btn-menu" title="Menu (M)" aria-label="Menu">☰</button>
+          <button class="icon-btn" id="btn-perf" title="Performance Stats" aria-label="Performance stats">📊</button>
+          <button class="icon-btn" id="btn-debug" title="Settings (D)" aria-label="Settings">🔧</button>
+          <button class="icon-btn" id="btn-params" title="Scene Parameters (P)" aria-label="Scene parameters">🎛️</button>
+          <button class="icon-btn" id="btn-editor" title="Scene Editor (E)" aria-label="Scene editor">{ }</button>
+          <button class="icon-btn" id="btn-auto-rotate" title="Auto-rotate (R)" aria-label="Auto-rotate camera">🚁</button>
+          <button class="icon-btn" id="btn-anim" title="Animation: Playing (A)" aria-label="Toggle animation" style="position:relative;">
             <span id="anim-icon" style="display:inline-block;">▶</span>
           </button>
-          <button class="icon-btn" id="btn-tree" title="Scene Tree (T)">▹</button>
-          <button class="icon-btn" id="btn-display-mode" title="Display: None (G)">⬚</button>
+          <button class="icon-btn" id="btn-tree" title="Scene Tree (T)" aria-label="Scene tree">▹</button>
+          <button class="icon-btn" id="btn-display-mode" title="Display: None (G)" aria-label="Display mode">⬚</button>
           <div style="position:relative;display:inline-block;">
-            <button class="icon-btn" id="btn-backend" title="Backend: Mayfly (click=cycle, hold=menu)">🦋</button>
+            <button class="icon-btn" id="btn-backend" title="Backend: Mayfly / WebGL (click to cycle, hold for menu)" aria-label="Renderer backend: Mayfly">🦋</button>
             <div id="backend-menu" style="display:none;position:absolute;top:100%;left:0;background:#21262d;border:1px solid #30363d;border-radius:4px;z-index:1000;min-width:100px;box-shadow:0 4px 12px rgba(0,0,0,0.4);">
-              <div class="backend-option" data-backend="mayfly" style="padding:8px 12px;cursor:pointer;color:#c9d1d9;border-bottom:1px solid #30363d;">🦋 Mayfly</div>
-              <div class="backend-option" data-backend="stinkyfish" style="padding:8px 12px;cursor:pointer;color:#c9d1d9;">🐟 Stinkyfish</div>
+              <div class="backend-option" data-backend="mayfly" style="padding:8px 12px;cursor:pointer;color:#c9d1d9;border-bottom:1px solid #30363d;">🦋 Mayfly · WebGL</div>
+              <div class="backend-option" data-backend="stinkyfish" style="padding:8px 12px;cursor:pointer;color:#c9d1d9;">🐟 Stinkyfish · WebGPU</div>
             </div>
           </div>
         </div>
         <div class="demo-info">
-          <h1 id="title">Loading...</h1>
-          <p id="subtitle">JSON SDF Demo</p>
+          <h1 id="title">Loading…</h1>
+          <p id="subtitle">SDF scene viewer</p>
           <div class="scene-path" id="scene-path"></div>
         </div>
       </div>
@@ -1383,13 +1383,13 @@
         <!-- Source Tab Content -->
         <div class="tab-content active" id="content-source">
           <div class="editor-header">
-            <button class="btn primary" id="btn-apply" title="Apply Changes (Ctrl+Enter)">Save</button>
+            <button class="btn primary" id="btn-apply" title="Apply changes to the scene (Ctrl+Enter)">Apply</button>
             <div style="display: flex; gap: 0.25rem;">
-              <button class="btn" id="btn-select-all" title="Select All">All</button>
+              <button class="btn" id="btn-select-all" title="Select all" aria-label="Select all">All</button>
               <button class="btn" id="btn-cut" title="Cut">Cut</button>
               <button class="btn" id="btn-copy-sel" title="Copy">Copy</button>
               <button class="btn" id="btn-paste" title="Paste">Paste</button>
-              <button class="btn" id="btn-format">Fmt</button>
+              <button class="btn" id="btn-format" title="Format JSON" aria-label="Format JSON">Fmt</button>
             </div>
           </div>
           <!-- Scalar Scrubber Panel -->
@@ -1487,7 +1487,7 @@
   <!-- Main Menu -->
   <div class="main-menu" id="main-menu">
     <div class="menu-item" id="menu-debug">
-      <span>🔧 Debug Panel</span>
+      <span>🔧 Settings</span>
     </div>
     <div class="menu-item" id="menu-editor">
       <span>{ } Editor</span>
@@ -1503,14 +1503,14 @@
     </div>
     <div class="menu-divider"></div>
     <div class="menu-item has-submenu" id="menu-demos">
-      <span>📦 Demos</span>
+      <span>📦 Scenes</span>
       <div class="submenu" id="demos-submenu">
         <!-- Populated by JS -->
       </div>
     </div>
     <div class="menu-divider"></div>
     <div class="menu-item" id="menu-new-demo">
-      <span>✨ New Demo</span>
+      <span>✨ New Scene</span>
     </div>
     <div class="menu-item" id="menu-load-url">
       <span>🔗 Load from URL</span>
@@ -1615,31 +1615,31 @@
     <div class="debug-content">
       <div class="debug-row">
         <span class="debug-label">Volume Render Mode</span>
-        <div class="toggle" id="toggle-volume"></div>
+        <div class="toggle" id="toggle-volume" role="switch" tabindex="0" aria-checked="false" aria-label="Volume render mode"></div>
       </div>
       <div class="debug-row">
         <span class="debug-label">Show Ground Plane</span>
-        <div class="toggle active" id="toggle-ground"></div>
+        <div class="toggle active" id="toggle-ground" role="switch" tabindex="0" aria-checked="true" aria-label="Show ground plane"></div>
       </div>
       <div class="debug-row">
         <span class="debug-label">Show Edges</span>
-        <div class="toggle active" id="toggle-edges"></div>
+        <div class="toggle active" id="toggle-edges" role="switch" tabindex="0" aria-checked="true" aria-label="Show edges"></div>
       </div>
       <div class="debug-row">
         <span class="debug-label">Show CSG Cutters</span>
-        <div class="toggle" id="toggle-cutters" title="Debug: Show subtract cutters as visible shapes"></div>
+        <div class="toggle" id="toggle-cutters" role="switch" tabindex="0" aria-checked="false" aria-label="Show CSG cutters" title="Show subtract cutters as visible shapes"></div>
       </div>
       <div class="debug-row">
         <span class="debug-label">Show Axes (RGB)</span>
-        <div class="toggle active" id="toggle-axes" title="Show Blender-style XYZ axes: Red=X, Green=Y, Blue=Z"></div>
+        <div class="toggle active" id="toggle-axes" role="switch" tabindex="0" aria-checked="true" aria-label="Show XYZ axes" title="Show Blender-style XYZ axes: Red=X, Green=Y, Blue=Z"></div>
       </div>
       <div class="debug-row">
         <span class="debug-label">Show Perf Stats</span>
-        <div class="toggle" id="toggle-perf" title="Show FPS, frame time, scene complexity"></div>
+        <div class="toggle" id="toggle-perf" role="switch" tabindex="0" aria-checked="false" aria-label="Show performance stats" title="Show FPS, frame time, scene complexity"></div>
       </div>
       <div class="debug-row">
         <span class="debug-label">Camera Distance</span>
-        <input type="range" min="1" max="15" step="0.5" value="4" id="slider-distance" style="width: 120px;">
+        <input type="range" min="1" max="15" step="0.5" value="4" id="slider-distance" style="width: 120px;" aria-label="Camera distance in metres" title="Camera distance (metres)">
       </div>
       <div class="debug-row" id="volume-controls" style="display: none; flex-direction: column; gap: 0.5rem;">
         <div style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
@@ -2244,6 +2244,25 @@
       if (el) el.addEventListener(event, handler);
       else console.warn(`Element #${id} not found for ${event}`);
     };
+
+    // Accessibility: make the custom `.toggle` switches keyboard-operable and
+    // keep aria-checked in sync with the `active` class. Delegated on document
+    // so it works regardless of when each toggle's own click handler is wired;
+    // the bubble-phase click listener runs after the element toggles `active`.
+    document.addEventListener('keydown', (e) => {
+      const t = e.target;
+      if (t && t.classList && t.classList.contains('toggle') &&
+          (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar')) {
+        e.preventDefault();
+        t.click();
+      }
+    });
+    document.addEventListener('click', (e) => {
+      const t = e.target;
+      if (t && t.classList && t.classList.contains('toggle') && t.hasAttribute('role')) {
+        t.setAttribute('aria-checked', t.classList.contains('active') ? 'true' : 'false');
+      }
+    });
     const loadingEl = $('loading');
     const appEl = $('app');
     const titleEl = $('title');
@@ -4758,30 +4777,35 @@
           badges += '<span class="param-badge expr" title="Expression-driven">ƒ expr</span>';
         }
 
+        // UI presentation: human label + unit suffix (°/m/x/…). Both are
+        // backward-compatible — a scene that declares neither renders as before.
+        const displayName = param.label || name;
+        const unitSfx = param.unit ? (param.unit === '°' ? '°' : ' ' + param.unit) : '';
+
         if (type === 'scalar' && typeof value === 'number') {
           html += `<div class="${rowClass}" style="flex-direction: column; gap: 0.25rem;">
             <div style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
-              <span class="debug-label" style="font-size: 0.75rem;">${name}${badges}</span>
-              <span id="param-val-${name}" style="font-size: 0.7rem; min-width: 3rem; text-align: right; font-family: monospace;">${value.toFixed(2)}</span>
+              <span class="debug-label" style="font-size: 0.75rem;">${displayName}${badges}</span>
+              <span id="param-val-${name}" style="font-size: 0.7rem; min-width: 3rem; text-align: right; font-family: monospace;">${value.toFixed(2)}${unitSfx}</span>
             </div>
             <input type="range" min="${min}" max="${max}" step="${step}" value="${value}"
-                   id="param-slider-${name}" data-param="${name}" style="width: 100%;">
+                   id="param-slider-${name}" data-param="${name}" aria-label="${displayName}" style="width: 100%;">
           </div>`;
         } else if (type === 'color3' && Array.isArray(value)) {
           const hex = rgbToHex(value);
           const hsl = rgbToHsl(value);
           html += `<div class="${rowClass}" style="flex-direction: column; gap: 0.25rem;">
             <div style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
-              <span class="debug-label" style="font-size: 0.75rem;">${name}${badges}</span>
-              <input type="color" value="${hex}" id="param-color-${name}" data-param="${name}" style="width: 40px; height: 24px; border: none; padding: 0; cursor: pointer;">
+              <span class="debug-label" style="font-size: 0.75rem;">${displayName}${badges}</span>
+              <input type="color" value="${hex}" id="param-color-${name}" data-param="${name}" aria-label="${displayName} colour" style="width: 40px; height: 24px; border: none; padding: 0; cursor: pointer;">
             </div>
             <input type="range" min="0" max="360" step="1" value="${Math.round(hsl.h * 360)}"
-                   id="param-hue-${name}" data-param="${name}" style="width: 100%; accent-color: hsl(${hsl.h * 360}, 100%, 50%);">
+                   id="param-hue-${name}" data-param="${name}" aria-label="${displayName} hue" style="width: 100%; accent-color: hsl(${hsl.h * 360}, 100%, 50%);">
           </div>`;
         } else if (Array.isArray(value) && value.length === 3) {
           // position3, radii3, direction3 - show as 3 sliders
           html += `<div class="${rowClass}" style="flex-direction: column; gap: 0.25rem;">
-            <span class="debug-label" style="font-size: 0.75rem;">${name} [x,y,z]${badges}</span>
+            <span class="debug-label" style="font-size: 0.75rem;">${displayName} [x,y,z]${unitSfx ? ' (' + param.unit + ')' : ''}${badges}</span>
             <div style="display: flex; gap: 0.25rem; width: 100%;">
               <input type="number" value="${value[0].toFixed(2)}" step="0.1" id="param-vec-${name}-0" data-param="${name}" data-index="0" style="width: 33%; padding: 0.2rem; background: var(--bg-dark); color: var(--text); border: 1px solid var(--border); border-radius: 3px; font-size: 0.7rem;">
               <input type="number" value="${value[1].toFixed(2)}" step="0.1" id="param-vec-${name}-1" data-param="${name}" data-index="1" style="width: 33%; padding: 0.2rem; background: var(--bg-dark); color: var(--text); border: 1px solid var(--border); border-radius: 3px; font-size: 0.7rem;">
@@ -4871,7 +4895,8 @@
               const val = parseFloat(this.value);
               param.value = val;
               const valEl = $(`param-val-${name}`);
-              if (valEl) valEl.textContent = val.toFixed(2);
+              const unitSfx = param.unit ? (param.unit === '°' ? '°' : ' ' + param.unit) : '';
+              if (valEl) valEl.textContent = val.toFixed(2) + unitSfx;
               renderer.setParam(name, val);
 
               // Check and enforce any coupled constraints
@@ -5544,11 +5569,15 @@
       const LONG_PRESS_MS = 400;
       const backends = ['mayfly', 'stinkyfish'];
       const backendIcons = { mayfly: '🦋', stinkyfish: '🐟' };
+      const backendTech = { mayfly: 'WebGL', stinkyfish: 'WebGPU' };
 
       function updateBackendButton() {
         if (btnBackend) {
           btnBackend.textContent = backendIcons[currentBackend] || '🦋';
-          btnBackend.title = `Backend: ${currentBackend} (click=cycle, hold=menu)`;
+          const label = `${currentBackend.charAt(0).toUpperCase()}${currentBackend.slice(1)}`;
+          const tech = backendTech[currentBackend] || '';
+          btnBackend.title = `Backend: ${label} / ${tech} (click to cycle, hold for menu)`;
+          btnBackend.setAttribute('aria-label', `Renderer backend: ${label}`);
         }
       }
 

--- a/lucid/mayfly/raymarcher.js
+++ b/lucid/mayfly/raymarcher.js
@@ -672,6 +672,11 @@ export class SimpleRaymarcher {
     ];
   }
 
+  // Alias for cross-backend parity: Stinkyfish exposes getCameraPos().
+  getCameraPos() {
+    return this.getCameraPosition();
+  }
+
   render() {
     if (!this.program) return;
 

--- a/lucid/node-editor.html
+++ b/lucid/node-editor.html
@@ -240,7 +240,7 @@
       <div class="palette-item" draggable="true" data-type="group">📦 Group</div>
     </div>
   </div>
-  <button class="edge-toggle toggle-left" id="toggleLeft">▶</button>
+  <button class="edge-toggle toggle-left" id="toggleLeft" title="Toggle node palette" aria-label="Toggle node palette">▶</button>
 
   <!-- Right panel - Preview & Properties -->
   <div class="panel panel-right" id="panelRight">
@@ -252,14 +252,14 @@
     <div class="panel-header">Properties</div>
     <div class="props-area" id="propsArea"><p class="no-selection">Select a node</p></div>
   </div>
-  <button class="edge-toggle toggle-right" id="toggleRight">◀</button>
+  <button class="edge-toggle toggle-right" id="toggleRight" title="Toggle preview &amp; properties panel" aria-label="Toggle preview and properties panel">◀</button>
 
   <!-- Bottom panel - Timeline -->
   <div class="panel panel-bottom" id="panelBottom">
     <div class="tl-controls">
-      <button class="tl-btn" id="btnRewind">⏮</button>
-      <button class="tl-btn" id="btnPlay">▶</button>
-      <button class="tl-btn active" id="btnLoop">🔁</button>
+      <button class="tl-btn" id="btnRewind" title="Rewind to start" aria-label="Rewind to start">⏮</button>
+      <button class="tl-btn" id="btnPlay" title="Play" aria-label="Play or pause">▶</button>
+      <button class="tl-btn active" id="btnLoop" title="Loop" aria-label="Toggle loop" aria-pressed="true">🔁</button>
       <span class="time-display" id="timeDisplay">0.00s</span>
     </div>
     <div class="scrubber" id="scrubber">
@@ -267,13 +267,13 @@
       <div class="scrubber-handle" id="scrubberHandle"></div>
     </div>
     <div class="wiggler-row">
-      <span class="wiggler-chip" data-fn="sin">∿ sin</span>
-      <span class="wiggler-chip" data-fn="bounce">⌢ bounce</span>
-      <span class="wiggler-chip" data-fn="pulse">⎍ pulse</span>
-      <span class="wiggler-chip" data-fn="spring">🌀 spring</span>
+      <span class="wiggler-chip" data-fn="sin" role="button" tabindex="0" aria-label="Sine wiggler">∿ sin</span>
+      <span class="wiggler-chip" data-fn="bounce" role="button" tabindex="0" aria-label="Bounce wiggler">⌢ bounce</span>
+      <span class="wiggler-chip" data-fn="pulse" role="button" tabindex="0" aria-label="Pulse wiggler">⎍ pulse</span>
+      <span class="wiggler-chip" data-fn="spring" role="button" tabindex="0" aria-label="Spring wiggler">🌀 spring</span>
     </div>
   </div>
-  <button class="edge-toggle toggle-bottom" id="toggleBottom">▲</button>
+  <button class="edge-toggle toggle-bottom" id="toggleBottom" title="Toggle timeline" aria-label="Toggle timeline">▲</button>
 
   <script type="module">
     import './components/lucid-renderer.js';
@@ -1374,6 +1374,12 @@
       scrubberFill.style.width = pct + '%';
       scrubberHandle.style.left = pct + '%';
       timeDisplay.textContent = timeline.time.toFixed(2) + 's';
+      // Drive the preview: the scrubber is authoritative over the render clock.
+      // (Previously the timeline only moved the visual handle and never reached
+      // the renderer, so play/pause/loop/scrub were cosmetic.)
+      if (previewEl && typeof previewEl.setTime === 'function') {
+        previewEl.setTime(timeline.time);
+      }
     }
 
     let lastFrame = 0;
@@ -1393,12 +1399,14 @@
     document.getElementById('btnPlay').addEventListener('click', function() {
       timeline.playing = !timeline.playing;
       this.textContent = timeline.playing ? '⏸' : '▶';
+      this.title = timeline.playing ? 'Pause' : 'Play';
       this.classList.toggle('active', timeline.playing);
     });
     document.getElementById('btnRewind').addEventListener('click', () => { timeline.time = 0; updateScrubber(); });
     document.getElementById('btnLoop').addEventListener('click', function() {
       timeline.loop = !timeline.loop;
       this.classList.toggle('active', timeline.loop);
+      this.setAttribute('aria-pressed', timeline.loop ? 'true' : 'false');
     });
 
     let scrubbing = false;

--- a/lucid/scene-catalog.html
+++ b/lucid/scene-catalog.html
@@ -321,7 +321,7 @@
     function setImages(renders, imgs) {
       renders.forEach((r, i) => {
         const lbl = r.querySelector('.lbl').textContent;
-        r.innerHTML = `<img src="${imgs[i]}"><span class="lbl">${lbl}</span>`;
+        r.innerHTML = `<img src="${imgs[i]}" alt="${lbl} render" loading="lazy"><span class="lbl">${lbl}</span>`;
       });
     }
 

--- a/lucid/skills/README.md
+++ b/lucid/skills/README.md
@@ -1,0 +1,34 @@
+# Lucid Skills
+
+Agent skills for working on the Lucid SDF/CSG graphics system, following the
+[agentskills.io](https://agentskills.io) `SKILL.md` convention: each skill is a
+directory with a `SKILL.md` (YAML frontmatter — `name` + `description` — plus a
+Markdown body) and optional `references/` files loaded on demand.
+
+These skills encode hard-won, code-verified knowledge about this system so an
+agent (or a person) can make correct changes without re-deriving the architecture
+each time. They are scoped to `lucid/` only.
+
+## Skills in this folder
+
+| Skill | Use it when you are… |
+|-------|----------------------|
+| **lucid-scene-authoring** | creating/editing scene JSON — primitives, CSG, transforms, modifiers, `defs`/`ref`, params, driven-value expressions |
+| **lucid-renderer-interop** | working across the Mayfly (WebGL/GLSL) and Stinkyfish (WebGPU/WGSL) backends — the codegen pipeline, the `<lucid-renderer>` component, and where the two backends still diverge |
+| **lucid-rigging-and-physics** | working with the rig/constraint layer (`rig-evaluator.js`) or the XPBD physics stacks, and the param uniforms that connect them to the renderer |
+| **lucid-animation-and-interaction** | working on time/animation, looping, the timeline scrubber, or camera/gesture interaction |
+
+## How skills load
+
+Point your agent runtime at this folder (or symlink individual skills into your
+skills path). The `description` field is the trigger — it says both what the
+skill does and when to reach for it. The body loads when the skill triggers;
+`references/*` load only when the body points to them, keeping context lean.
+
+## Ground truth
+
+When a skill and a doc disagree, **the code is ground truth** — every claim here
+was checked against the source in `lucid/core`, `lucid/mayfly`, `lucid/stinkyfish`,
+and `lucid/components`. Where a backend feature is known-incomplete or visually
+unverified, the skill says so rather than implying parity. See also
+`../CLAUDE.md` and `../../docs/fable-audit/` for the repo-wide accuracy ledger.

--- a/lucid/skills/lucid-animation-and-interaction/SKILL.md
+++ b/lucid/skills/lucid-animation-and-interaction/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: lucid-animation-and-interaction
+description: >-
+  Work on time, animation, looping, the timeline scrubber, and camera/gesture
+  interaction in the Lucid SDF viewer. Use this when driving scene parameters
+  over time, wiring or debugging the node-editor timeline (play/pause/loop/
+  scrub), controlling the render clock, adding orbit/pan/zoom or touch/tap
+  interaction, or connecting a tap to a physics impulse or picking. Covers how
+  the two backends derive time, how the timeline drives the preview, and the
+  camera-interaction paths (the reusable <lucid-orbit-controls> component vs the
+  hand-rolled handlers in index.html).
+---
+
+# Lucid Animation & Interaction
+
+## Time & the render clock
+
+Animation is driven by **time**, not keyframes — there is no keyframe model
+anywhere in the system. Params animate through the shader `u_time` uniform and
+the rig `time` variable; looping is implicit via periodic expressions like
+`sin(time)`.
+
+Both backends derive time the same way and expose the same override hook:
+
+```
+time = overrideTime !== null ? overrideTime : (performance.now() - startTime) / 1000
+```
+
+- `renderer.overrideTime = seconds` pins the clock (Mayfly `raymarcher.js:83`,
+  Stinkyfish `raymarcher.js:106`); `= null` resumes the wall clock.
+- Via the component: `<lucid-renderer>.setTime(seconds)` / `.clearTime()` — works
+  on both backends (added July 2026).
+
+To animate a param, reference `time` in an `expr` (see lucid-scene-authoring):
+
+```json
+{ "expr": "add", "args": [ 1.0,
+  { "expr": "mul", "args": [ 0.2, { "expr": "sin", "args": [ { "var": "time" } ] } ] } ] }
+```
+
+## Two animation UIs
+
+**index.html** — a binary `playing | frozen` state (no scrubber). Freezing pins
+`overrideTime` to the captured time each frame; playing resumes the clock.
+Auto-rotate is a separate camera concern, not animation.
+
+**node-editor.html** — a full timeline: `{ time, duration:10, playing, loop }`
+with play/pause, rewind, loop toggle, and a draggable scrubber. As of July 2026
+the scrubber **is authoritative over the preview**: `updateScrubber()` calls
+`previewEl.setTime(timeline.time)`, so play/pause/loop/scrub genuinely drive the
+`<lucid-renderer>` clock. (Before that, the timeline only moved the visual handle
+and never reached the renderer — it was cosmetic.)
+
+**If you extend the timeline:** keep `setTime()` the single point where timeline
+state reaches the renderer. Looping wraps `timeline.time` at `duration`; the
+scrubber maps pointer x → time. To add keyframing, introduce a keyframe model
+that resolves to param values at `timeline.time` and push them via the
+component's `updateParam(name, value)` (backend-agnostic), keeping `setTime()`
+for the clock.
+
+## Interaction: camera
+
+`<lucid-orbit-controls>` (`components/lucid-orbit-controls.js`) is the reusable
+camera controller — spherical `{theta, phi, distance, target}`, mouse drag/wheel,
+1-finger orbit, 2-finger pinch-zoom + pan, `touch-action:none`. It emits
+`camera-change` / `drag-start` / `drag-end` and exposes
+`getCamera/setCamera/getCameraPosition/isDragging`. **Prefer wrapping a canvas in
+this component** for new interaction surfaces.
+
+⚠️ Rough edge: **index.html does not use `<lucid-orbit-controls>`** — it
+hand-rolls its own mouse + touch handling with separate click-vs-drag and tap
+detection. Two camera-interaction implementations exist. Changing camera feel in
+the main viewer means editing the hand-rolled handlers, not the component; ideally
+migrate index.html onto the component rather than deepening the divergence.
+
+## Interaction: tap → physics
+
+`index.html`'s `applyImpulseFromScreen` projects a tap/click, finds the nearest
+`PhysicsScene` body, and calls `applyImpulse`. Tap qualification: a click that
+wasn't a drag, or a touch with movement < 15px and duration < 300ms. This path
+targets **Stack B (`PhysicsScene`) only** — `PhysicsBridge.applyImpulse` (Stack A)
+is not reachable from the index.html tap handler. See lucid-rigging-and-physics
+for the two-physics-stack picture.
+
+## Verifying animation without WebGPU
+
+Headless Chromium runs Mayfly (WebGL), so you can verify the clock end-to-end:
+load a page, press play, and assert the renderer's `overrideTime` advances, e.g.
+
+```js
+await page.click('#btnPlay');
+const t1 = await page.evaluate(() => document.getElementById('preview')._renderer.overrideTime);
+// …wait…
+const t2 = await page.evaluate(() => document.getElementById('preview')._renderer.overrideTime);
+// expect t2 > t1  — proves the timeline drives the render clock
+```
+
+(WebGPU is unavailable headless, so this exercises the Mayfly path; Stinkyfish
+timing must be checked in a real WebGPU browser.)

--- a/lucid/skills/lucid-renderer-interop/SKILL.md
+++ b/lucid/skills/lucid-renderer-interop/SKILL.md
@@ -54,6 +54,11 @@ you expect is present in **both** strings. "Compiles" ≠ "renders correctly" fo
 WGSL — confirm anything visual in a real WebGPU browser via `compare.html`,
 `scene-catalog.html`, or `index.html?backend=stinkyfish`.
 
+**Can't see WGSL headless?** That's the whole point of `lucid/verify/` — a public
+page that has a human on a real GPU device compare both backends and file the
+result as a `visual-verification` GitHub issue you can read back. Reach for it
+whenever a WGSL change needs human eyes; see `lucid/verify/README.md`.
+
 ## Renderer public API (what both expose)
 
 Shared: `setParam(name, value)`, camera props (`cameraDistance/Theta/Phi/Target`)

--- a/lucid/skills/lucid-renderer-interop/SKILL.md
+++ b/lucid/skills/lucid-renderer-interop/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: lucid-renderer-interop
+description: >-
+  Work across Lucid's two rendering backends — Mayfly (WebGL/GLSL,
+  lucid/mayfly/) and Stinkyfish (WebGPU/WGSL, lucid/stinkyfish/) — and the code
+  that unifies them: the shared JSON→shader codegen (core/json-codegen.js,
+  core/wgsl-codegen.js), the <lucid-renderer backend="auto"> web component, and
+  the uniform/param plumbing. Use this when a scene looks right in one backend
+  but wrong/blank in the other, when adding a node type or expression operator
+  (it must be implemented in BOTH codegens), when touching the renderer public
+  API or backend switching, or when deciding which backend a feature can rely
+  on. Includes the GLSL↔WGSL capability parity matrix.
+---
+
+# Lucid Multi-Renderer Interop
+
+Lucid renders one backend-neutral JSON scene through two backends:
+
+```
+JSON scene ─ core/json-loader.js ─▶ shared IR
+                                     ├─ core/json-codegen.js  ─▶ GLSL ─▶ Mayfly (WebGL)   mayfly/raymarcher.js
+                                     └─ core/wgsl-codegen.js  ─▶ WGSL ─▶ Stinkyfish (WebGPU) stinkyfish/raymarcher.js
+```
+
+`<lucid-renderer backend="auto">` (`components/lucid-renderer.js`) picks
+Stinkyfish when `navigator.gpu` exists, else Mayfly. **Mayfly is the reference
+backend** — more complete and the only one verifiable headless (WebGPU is not
+available in headless Chromium, so Stinkyfish output is visually unverified; see
+`stinkyfish/BUGS.md`). Treat Mayfly as ground truth when they disagree.
+
+## The golden rule
+
+**Anything that reads the IR must be implemented in BOTH codegens, or the two
+backends diverge silently.** `json-codegen.js` and `wgsl-codegen.js` have
+matching node-type switches but historically drifted on expression operators and
+domain modifiers. When you add or change a node type or an `expr` op, update
+both files and verify with the Node harness below.
+
+## Verify codegen without a browser
+
+Both codegens run in Node — this is the fast, reliable check (no WebGPU needed):
+
+```js
+import { loadJsonScene } from '../core/json-loader.js';
+import { generateGlslFromJson } from '../core/json-codegen.js';
+import { generateWgslFromJson } from '../core/wgsl-codegen.js';
+const scene = loadJsonScene(myJson);
+const glsl = generateGlslFromJson(scene);   // inspect length, uniforms, ops
+const wgsl = generateWgslFromJson(scene);
+```
+
+Check: non-empty output, no `Unknown expression op` warning, the operator/helper
+you expect is present in **both** strings. "Compiles" ≠ "renders correctly" for
+WGSL — confirm anything visual in a real WebGPU browser via `compare.html`,
+`scene-catalog.html`, or `index.html?backend=stinkyfish`.
+
+## Renderer public API (what both expose)
+
+Shared: `setParam(name, value)`, camera props (`cameraDistance/Theta/Phi/Target`)
++ a `camera` proxy, `setQuality`, `setLighting`, `pause/resume`,
+`getCameraPos()`/`getCameraPosition()` (both names work on both since the July
+2026 parity pass).
+
+Divergent — know these when writing backend-agnostic code:
+
+| Concern | Mayfly | Stinkyfish |
+|---|---|---|
+| Compile a scene | `updateScene(glsl, params, rig, json)` — sync | `await compileScene(wgsl, layout)` — async, needs a uniform layout |
+| Init | ready in constructor | `await init()` required |
+| Bulk params | via `updateScene` | separate `setSceneParams(params)` after compile |
+| Unknown param name | `setParam` creates it | `setParam` silently drops it (updates existing only) |
+| `render()` | no args; internal clock | `render(physicsParams?)` — arg is a physics-param object, not time |
+| Physics | first-class (Stack A, see rigging skill) | none; only accepts precomputed `physicsParams` |
+| Volume rendering | jelly/xray/heatmap modes | surface mode only |
+| Ground plane default | on | off |
+
+Prefer the `<lucid-renderer>` component over talking to a renderer class
+directly — it abstracts init/compile/camera. Its `setParam`-based `updateParam`,
+`setCamera({…})`, and `setTime(seconds)` work on both backends.
+
+## Where the backends still diverge (as of July 2026)
+
+The July 2026 interop pass fixed: GLSL expression-op parity
+(pow/sqrt/exp/log/asin/acos/atan/round/lerp), WGSL floored `mod`, WGSL `select`,
+the component's dead `updateParam`, and camera-accessor naming. **Still
+divergent** (design around these, or fix in both codegens + verify):
+
+- **WGSL vector `expr` ops** (`vec2/3/4`, `length`, `normalize`, `dot`, `cross`)
+  have no GLSL equivalent — GLSL-targeted scenes must avoid them.
+- **`repeat` `exposeId`** per-instance variation: GLSL only; WGSL ignores it.
+- **`displace`**: WGSL hardcodes `fbm(…,4)`, ignoring `noiseType`/`octaves`/`animate`.
+- **`customExpr`**: GLSL reads `node.glsl` (base64); WGSL reads `node.expr` (raw).
+  Inherently backend-specific shader text — cannot be shared.
+- **`mirror` under a rotated ancestor**: GLSL has the LCD-003 fix; WGSL does not.
+- **Domain modifiers drop `node.transform`** in WGSL (`radial`/`mirror`/`repeat`).
+- **Node-graph/DSL path** (`core/glsl-codegen.js`, used by node-editor) is
+  **GLSL-only** — there is no `generateWgslFromSceneGraph`.
+
+The full, current matrix with file:line anchors is in
+**`references/codegen-parity.md`** — consult it before assuming a feature is
+cross-backend.
+
+## Uniform layout: the fragile part
+
+- **GLSL** binds params by name (`u_<name>`) at draw time — order-independent and
+  robust to a param-set mismatch (missing params are skipped).
+- **WGSL** packs params into a `SceneUniforms` struct with std140-style 16-byte
+  `vec3f` alignment; the JS-side layout (`_buildUniformLayout`), the generated
+  struct, and the buffer writer must agree exactly. A param-order or type
+  mismatch corrupts every field after it. When adding a param type to WGSL,
+  update all three in lockstep.

--- a/lucid/skills/lucid-renderer-interop/references/codegen-parity.md
+++ b/lucid/skills/lucid-renderer-interop/references/codegen-parity.md
@@ -1,0 +1,84 @@
+# GLSL ↔ WGSL Codegen Parity Matrix
+
+Authoritative, code-verified comparison of `core/json-codegen.js` (GLSL, Mayfly)
+and `core/wgsl-codegen.js` (WGSL, Stinkyfish). Reflects the state **after the
+July 2026 interop pass**. Mayfly/GLSL is the reference backend.
+
+Legend: ✅ parity · ⚠️ present but divergent behaviour · ❌ missing/stub on that side.
+
+## Node types
+
+Both codegens dispatch the same 25 node types (`walkNode`). Behavioural
+differences:
+
+| Node | GLSL | WGSL | Note |
+|------|------|------|------|
+| primitives (sphere…plane) | ✅ | ✅ | aligned |
+| CSG (union…smoothIntersect) | ✅ | ✅ | aligned |
+| `transform`, `group`, `material` | ✅ | ✅ | aligned |
+| `ref` / `defs` (+ overrides) | ✅ | ✅ | `applyOverrides`/`substituteVars`, json-loader.js |
+| `round`, `shell` | ✅ | ✅ | aligned |
+| `select` | ✅ | ✅ | **fixed July 2026** — WGSL was a sphere-returning stub; now branchless `mix(a,b,step(0.5,cond))` in both |
+| `radial` | ✅ | ⚠️ | WGSL drops `node.transform` on the modifier |
+| `mirror` | ✅ | ⚠️ | WGSL drops `node.transform`; lacks LCD-003 ancestor-rotation fix (json-codegen.js ~1238) |
+| `repeat` | ✅ | ⚠️ | WGSL drops `node.transform` and ignores `exposeId` per-instance variation |
+| `displace` | ✅ | ⚠️ | WGSL hardcodes `fbm(p*scale,4)`; ignores `noiseType`/`octaves`/`animate` |
+| `customExpr` | ⚠️ | ⚠️ | GLSL reads `node.glsl` (base64 → `atob`); WGSL reads `node.expr` (raw). Backend-specific shader text — not shareable |
+
+## Expression operators (`expr`)
+
+After the July 2026 pass GLSL and WGSL share the full **scalar** vocabulary:
+
+`add sub mul div mod neg abs floor ceil fract round sin cos tan asin acos atan
+pow sqrt exp log min max clamp step smoothstep mix lerp noise fbm turbulence hash`
+
+Details / caveats:
+
+| Op(s) | Status | Note |
+|-------|--------|------|
+| `pow sqrt exp log asin acos atan round lerp` | ✅ | **added to GLSL July 2026** — previously emitted `0.0` + a warning in GLSL |
+| `mod` | ✅ | **WGSL changed July 2026** to floored `a - b*floor(a/b)` to match GLSL's `mod()`; WGSL `%` had diverged for negative operands |
+| `atan` | ✅ | 1-arg and 2-arg (atan2) both handled in both |
+| `noise fbm turbulence hash` | ✅ | both; octaves must be integer |
+| `vec2 vec3 vec4 length normalize dot cross` | ❌ GLSL | WGSL-only. GLSL codegen's value model is scalar-oriented — **avoid these unless targeting WebGPU only** |
+
+The GLSL `default` case still emits `0.0` + `console.warn("Unknown expression
+op")` — so an unknown op degrades silently. Always run the Node harness after
+adding an op.
+
+## Transforms
+
+| Field | GLSL | WGSL | Note |
+|-------|------|------|------|
+| `translate`, `scale`, `rotate` (Euler °) | ✅ | ✅ | |
+| `mat4` | ✅ | ⚠️ | verify on WGSL |
+| `rotateQ`, `rotateAxis` | ⚠️ | ⚠️ | incomplete in GLSL codegen (json-codegen.js ~2209); verify before relying on either |
+
+## Renderer / component
+
+| Concern | Status | Note |
+|---------|--------|------|
+| `<lucid-renderer>.updateParam()` | ✅ | **fixed July 2026** — routed to `setParam` (was calling non-existent methods) |
+| `getCameraPos()` / `getCameraPosition()` | ✅ | **aliased July 2026** on both renderers |
+| `<lucid-renderer>.setTime()` | ✅ | **added July 2026** — drives each backend's `overrideTime` |
+| Rig passed to compile | ⚠️ | component's Mayfly path passes `rig`; Stinkyfish path only feeds rig param names into the uniform layout |
+| `auto` fallback | ⚠️ | capability-presence only — an async WebGPU `init()` failure fires `render-error` rather than falling back to Mayfly |
+| Node-graph/DSL codegen | ❌ WGSL | `core/glsl-codegen.js` `generateGlslFromSceneGraph` has no WGSL counterpart; the node-editor authoring path is Mayfly-only |
+
+## Rendering features
+
+| Feature | GLSL/Mayfly | WGSL/Stinkyfish |
+|---------|-------------|-----------------|
+| Surface raymarch | ✅ | ✅ (visually unverified headless) |
+| Volume render (jelly/xray/heatmap) | ✅ | ❌ |
+| Physics integration in renderer | ✅ (Stack A) | ❌ |
+| Ground plane default | on | off |
+
+## When you touch codegen
+
+1. Implement the change in **both** `json-codegen.js` and `wgsl-codegen.js`.
+2. Run the Node harness (see SKILL.md) — confirm the op/helper appears in both,
+   no `Unknown` warning, output non-empty.
+3. For WGSL param changes, update `_buildUniformLayout` (lucid-renderer.js), the
+   generated `SceneUniforms` struct, and the buffer writer together.
+4. Update this matrix and, if it changes a documented divergence, `stinkyfish/BUGS.md`.

--- a/lucid/skills/lucid-rigging-and-physics/SKILL.md
+++ b/lucid/skills/lucid-rigging-and-physics/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: lucid-rigging-and-physics
+description: >-
+  Work with Lucid's constraint/rig layer (core/rig-evaluator.js) and its physics
+  stacks (core/physics/*.js) — the systems that drive scene parameters from
+  expressions, phase-coupled animation, bounds, and XPBD simulation, and feed the
+  results into the renderer as uniforms. Use this when authoring or debugging a
+  scene's `rig` or `physics` block, when a physics scene behaves oddly (jitter,
+  double simulation), when wiring parameters to be driven/constrained, or when
+  you need to know what the rig binding-state badges (phys/constrained/driver/
+  expr) actually mean. Covers the integration points between rig, physics,
+  params, and the render loop — including two known architectural rough edges.
+---
+
+# Lucid Rigging & Physics
+
+Two layers sit between a scene's params and the shader: the **rig** (CPU,
+deterministic, evaluated every frame) and **physics** (XPBD simulation). Both
+ultimately write parameter values that become `u_<name>` / `phys_<name>`
+uniforms.
+
+```
+params ─▶ rig-evaluator (derived/phase/bounds) ─▶ uniforms ─▶ shader
+       └▶ physics (XPBD) ─▶ phys_<name> uniforms ─▶ shader
+```
+
+## The rig layer (`core/rig-evaluator.js`)
+
+`evaluateRig(rig, baseParams, time)` interprets the **same expression AST as
+codegen** (`const` / `var` (incl. `time`) / `expr`). A scene's `rig` object has
+six sections:
+
+| Section | Status | What it does |
+|---------|--------|--------------|
+| `derived` | ✅ implemented | computed params, topologically sorted (cycle-detected). **Drives geometry.** |
+| `bounds` | ✅ implemented | min/max validity → `violations[]` (reports only; does **not** clamp) |
+| `phase` | ✅ implemented | phase-coupled animation: a `driver` expr feeds `followers` with phase/amplitude/offset/waveform. Emits `${cycle}_${follower}` params |
+| `chains` | ❌ stub | only registers `${chain}_joint${i}` defaults; `maxBend/taper/sequential` are unimplemented |
+| `conserved` | ❌ stub | no-op (volume/mass preservation not implemented) |
+| `constraints` | ⚠️ UI-only | see below |
+
+⚠️ **Expression gap:** the CPU rig evaluator implements arithmetic/trig/`pow`/
+`sqrt` etc. but **not** `noise/fbm/turbulence/hash` (which the GLSL shader path
+has). A rig `derived`/`phase` expression using noise evaluates differently on the
+CPU than the same expression in-shader. Avoid noise in rig expressions.
+
+## Two "constraint" concepts — don't confuse them
+
+This is a real rough edge. `rig.constraints` and `rig.derived`/`phase` are
+**disjoint systems that don't reference each other**:
+
+- **`rig.derived` / `rig.phase`** → evaluated by `rig-evaluator.js`, produce
+  uniform values, **affect the rendered geometry**. The evaluator has **no
+  handling of `rig.constraints`**.
+- **`rig.constraints`** → read only by the `index.html` param panel
+  (`enforceConstraints`) as `coupled` driver/follower relations that **clamp
+  slider ranges in the UI**. Never touches geometry.
+
+## Binding-state badges (param panel)
+
+Computed per param in the index.html panel:
+
+| Badge | Condition |
+|-------|-----------|
+| ⚛️ phys | `param.physics` is truthy |
+| ⚙️ constrained | param is a `follower` in `rig.constraints` (the UI-only system) |
+| ⚙️ driver | param is a `driver` in `rig.constraints` |
+| ƒ expr | `param.expr` is a string |
+
+⚠️ The ⚙️ badges reflect only `rig.constraints`, so a param driven by
+`rig.derived`/`phase` gets **no badge** even though it is genuinely driven. Keep
+this in mind when reasoning about "why is there no badge."
+
+## Physics — two stacks, one conflict
+
+There are **two independent physics implementations**. Know which one a scene/
+entry point uses:
+
+| | Stack A — `PhysicsBridge` | Stack B — `PhysicsScene` |
+|---|---|---|
+| Files | `physics/physics-bridge.js` + `xpbd-gpu.js` (WGSL compute, GPU w/ CPU fallback) | `physics/physics-scene.js` (CPU only) |
+| Wired via | the **renderer**: `raymarcher.js` `initPhysics` when `sceneJson.physics.enabled`; steps inside `render()` | **`index.html` directly**: instantiated & stepped in the render loop, pushing positions via `renderer.setParam` |
+| Used cleanly by | `stinkyfish/demo.html` | `index.html` |
+
+⚠️ **The conflict:** loading a physics scene in `index.html` activates **both** —
+`renderer.updateScene(...)` triggers Stack A inside Mayfly, while `index.html`
+also builds and steps Stack B. Both write the same `phys_*` uniforms with no
+arbitration, so they double-simulate and fight. If you see physics jitter/doubled
+motion in the main viewer, this is the likely cause. When changing physics
+wiring, make one stack authoritative per entry point rather than adding a third
+path.
+
+Other notes: Stack B steps **after** `render()` using the frame's
+`renderer.lastRigValues`, so physics lags the rig by one frame; Stack A steps
+before draw. `splat-physics.js` is a separate rigid/soft stack for Gaussian
+splats (open TODOs: torque on offset impulse, object-object collisions).
+
+## Integration points (the API surface)
+
+- **rig → shader:** `evaluateRig` output → `u_<name>` uniforms (raymarcher binds
+  base + derived + phase).
+- **rig → physics:** `renderer.lastRigValues` → `PhysicsScene.updateFromRig`
+  (rig-driven constraint targets).
+- **physics → shader:** `phys_<name>` position3 uniforms via `renderer.setParam`.
+- **interaction → physics:** `applyImpulse(bodyName|id, impulse)` on either stack;
+  the index.html tap handler (`applyImpulseFromScreen`) currently reaches **Stack
+  B only**.
+
+## Authoring a physics/rig scene
+
+- Physics config: `physics.enabled` + `bodies`, `distanceConstraints`,
+  `positionConstraints`, plus `gravity`/`ground`/`bounds`/`damping`/`iterations`/
+  `dt`. Params exposed as `phys_<name>` (position3).
+- Rig config: put geometry-driving relations in `derived`/`phase`; use
+  `constraints` only for UI slider coupling.
+- Test in `stinkyfish/demo.html` (Stack A, isolated) to avoid the index.html
+  double-physics interaction while iterating.

--- a/lucid/skills/lucid-scene-authoring/SKILL.md
+++ b/lucid/skills/lucid-scene-authoring/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: lucid-scene-authoring
+description: >-
+  Author, edit, and debug Lucid SDF/CSG scene JSON files (lucid/scenes/**/*.json).
+  Use this whenever you are creating a new scene, adding or modifying primitives,
+  CSG boolean operations, transforms, modifiers (round/shell/displace), reusable
+  definitions (defs/ref), scene parameters, or driven-value expressions for the
+  Lucid renderer. Also use it when a scene renders as an empty frame, a param has
+  no visible effect, or you need to know which node types, transform modes, or
+  expression operators are supported. Covers the shared scene format consumed by
+  BOTH the Mayfly (WebGL/GLSL) and Stinkyfish (WebGPU/WGSL) backends.
+---
+
+# Lucid Scene Authoring
+
+Lucid scenes are backend-neutral JSON. One scene file is compiled to GLSL (Mayfly)
+or WGSL (Stinkyfish) by `core/json-codegen.js` / `core/wgsl-codegen.js` after being
+parsed by `core/json-loader.js`. Author to the JSON contract and both backends work.
+
+**Units:** 1 unit = 1 meter. All positions, radii, and distances are metres; all
+rotation angles are **degrees**. See `references/node-reference.md` and
+`lucid/docs/sdf-units-convention.md`. Keep human-scale objects near 1–2 units.
+
+## Minimal scene
+
+```json
+{
+  "name": "Hello Sphere",
+  "root": {
+    "type": "sphere",
+    "params": { "r": 1.0 },
+    "transform": { "translate": [0, 1, 0] }
+  }
+}
+```
+
+Every scene needs a `root` node. `defs`, `params`, `rig`, `physics`, `camera`, and
+`quality` (`"low"|"medium"|"high"`) are optional top-level fields.
+
+## Node model at a glance
+
+- **Primitives** — `sphere`, `box`, `torus`, `cylinder`, `capsule`, `ellipsoid`,
+  `cone`, `roundCone`, `plane`. Carry a `params` object.
+- **CSG** — `union`, `subtract`, `intersect` and their smooth variants
+  `smoothUnion`, `smoothSubtract`, `smoothIntersect` (take `children[]` and an
+  optional blend radius `k`, in metres).
+- **Structure** — `transform` (single `child`), `group` (`children[]` + optional
+  transform), `material` (wraps a `child`, sets surface `params`), `ref`
+  (instantiate a `defs` entry, with `params` overrides).
+- **Symmetry / repetition** — `mirror` (`axis`), `radial` (`count`, `axis`),
+  `repeat` (`period`, optional `exposeId`).
+- **Modifiers** — `round` (`r`), `shell` (`thickness`), `displace`
+  (`amount`, `scale`, `octaves`, `noiseType`), `select` (`cond`, `a`, `b`).
+
+Full parameter tables for every node, transform mode, and value type are in
+**`references/node-reference.md`** — read it before authoring an unfamiliar node.
+
+## Reusable modules: `defs` + `ref`
+
+Define a sub-tree once, instantiate it many times, override its variables:
+
+```json
+{
+  "defs": {
+    "leg": { "type": "capsule", "params": { "r": { "var": "thickness" }, "h": 0.8 } }
+  },
+  "root": {
+    "type": "union",
+    "children": [
+      { "type": "ref", "id": "leg", "params": { "thickness": 0.12 },
+        "transform": { "translate": [-0.4, 0, 0] } },
+      { "type": "ref", "id": "leg", "params": { "thickness": 0.12 },
+        "transform": { "translate": [ 0.4, 0, 0] } }
+    ]
+  }
+}
+```
+
+A `ref`'s `params` substitute `{ "var": "name" }` placeholders inside the def. This
+is how one template yields many variants (see `scenes/csg/chunky-parametric.json`).
+
+## Driven values: constants, variables, expressions
+
+Any numeric field accepts three forms:
+
+| Form | JSON | Meaning |
+|------|------|---------|
+| Constant | `1.5` | Fixed number |
+| Variable | `{ "var": "radius" }` | Read a scene `param` (or def override) |
+| Expression | `{ "expr": "mul", "args": [ … ] }` | Compute from other values / `time` |
+
+Expressions let one slider drive many features and enable animation via the
+built-in `time` variable (seconds). Example — a radius that pulses:
+
+```json
+{ "r": { "expr": "add", "args": [ 1.0,
+        { "expr": "mul", "args": [ 0.2, { "expr": "sin", "args": [ { "var": "time" } ] } ] } ] } }
+```
+
+**Supported operators are backend-dependent — check parity before shipping.**
+The full operator table and the GLSL/WGSL parity matrix live in
+`../lucid-renderer-interop/references/codegen-parity.md`. Core arithmetic
+(`add sub mul div mod neg abs floor ceil fract`), trig (`sin cos tan`),
+`min max clamp step smoothstep mix`, and noise (`noise fbm turbulence hash`) work
+on both backends. Prefer these unless you have verified a wider op renders in the
+backend you target.
+
+## Scene parameters (the UI sliders)
+
+`params` declares the controls shown in the viewer's parameter panel:
+
+```json
+"params": {
+  "bodyRadius": { "value": 0.5, "min": 0.2, "max": 1.0, "step": 0.01,
+                  "type": "scalar", "unit": "m", "label": "Body radius" },
+  "skinColor":  { "value": [0.8, 0.5, 0.3], "type": "color3", "label": "Skin" }
+}
+```
+
+Types: `scalar`, `color3`, `position3`, `radii3`, `direction3`. Shorthands: a bare
+number becomes a `scalar`; a bare array becomes a `position3`. Add `unit`
+(`"m"`, `"°"`, `"x"`, `"%"`, `"rad"`) and `label` so the panel reads
+professionally — the panel renders the unit next to the value and the label in
+place of the raw key.
+
+## Authoring checklist
+
+1. Start from the closest existing scene in `scenes/` rather than a blank file.
+2. Keep sizes in metres, angles in degrees, human-scale near 1–2 units.
+3. Give every `params` entry `min`/`max`/`step`, a `label`, and a `unit`.
+4. Use `{ "var": "…" }`/expressions instead of hardcoded numbers when a value
+   should be tunable or animated.
+5. Restrict expression operators to the cross-backend-safe set unless you have
+   verified the target backend.
+6. **Register the scene in `scenes/toc.json`** (see `references/node-reference.md`
+   for the entry shape) — unlisted scenes never appear in the catalog.
+7. Validate: `node -e` loading `loadJsonScene` + `generateGlslFromJson` should
+   produce non-empty GLSL. An empty render usually means a missing `camera`, a
+   param using `"default"` instead of `"value"`, or a `ref` to an absent `def`.
+
+## Common failure modes
+
+- **Blank frame, valid shader** — no `camera` block, or the root resolves to
+  nothing. Add a camera; confirm the `ref` targets an existing `def`.
+- **Param does nothing** — the value is hardcoded in the tree instead of
+  `{ "var": "paramName" }`. Replace the literal with a variable reference.
+- **`fbm`/`turbulence` look wrong** — octaves must be an integer; pass
+  `Math.floor(octaves)`.
+- **Works in WebGPU, breaks in WebGL (or vice-versa)** — an expression operator
+  or node exists on one backend only. See the interop skill's parity matrix.

--- a/lucid/skills/lucid-scene-authoring/references/node-reference.md
+++ b/lucid/skills/lucid-scene-authoring/references/node-reference.md
@@ -1,0 +1,171 @@
+# Lucid Scene JSON — Node Reference
+
+Complete node/parameter reference for the JSON scene format. Source of truth:
+`core/json-loader.js` (parsing) and `core/json-codegen.js` (GLSL generation).
+Units: **1 unit = 1 metre; all rotation angles are degrees** (see
+`lucid/docs/sdf-units-convention.md`).
+
+## Contents
+
+1. Top-level scene fields
+2. Primitives
+3. CSG operations
+4. Structure & instancing nodes
+5. Modifiers
+6. Transforms
+7. Value types (const / var / expr)
+8. Scene params
+9. TOC registration
+
+---
+
+## 1. Top-level scene fields
+
+```json
+{
+  "name": "…",            // display name
+  "version": "1.0",        // optional
+  "defs": { },             // reusable named sub-trees (see §4 ref)
+  "params": { },           // UI-exposed parameters (see §8)
+  "rig": { },              // constraint/animation layer (see lucid-rigging-and-physics)
+  "physics": { },          // physics config (see lucid-rigging-and-physics)
+  "camera": { },           // camera settings — omit and scenes often render blank
+  "quality": "medium",     // "low" | "medium" | "high"
+  "root": { }              // REQUIRED root node
+}
+```
+
+## 2. Primitives
+
+Each primitive is `{ "type": …, "params": { … }, "transform": { … } }`. Defaults
+below are what codegen uses when a param is omitted. All carry an optional
+`color` (`[r,g,b]`, 0–1). Sizes are metres.
+
+| type | params (default) | notes |
+|------|------------------|-------|
+| `sphere` | `r` (1.0) | radius |
+| `box` | `size` ([1,1,1]) | **half-extents** — box spans −size…+size per axis |
+| `torus` | `major` (1.0), `minor` (0.3) | ring & tube radii |
+| `cylinder` | `h` (1.0), `r` (0.5) | half-height, radius |
+| `capsule` | `h` (1.0), `r` (0.25) | cylinder with hemispherical caps |
+| `ellipsoid` | `radii` ([1,0.5,0.5]) | per-axis radii |
+| `cone` | `h` (1.0), `r` (0.5) | simple cone (tip up) |
+| `cone`/`roundCone` | `h`, `r1` (0.5, bottom), `r2` (0.0, top) | truncated/rounded cone when `r1`/`r2` present |
+| `plane` | `normal` ([0,1,0]), `h` (0) | infinite plane, `h` = offset along normal |
+
+## 3. CSG operations
+
+Take `children[]`. Smooth variants take a blend radius `k` (metres).
+
+| type | fields | effect |
+|------|--------|--------|
+| `union` | `children[]` | min of children |
+| `subtract` | `children[]` | first minus the rest |
+| `intersect` | `children[]` | overlap only |
+| `smoothUnion` | `children[]`, `k` | blended union |
+| `smoothSubtract` | `children[]`, `k` | blended subtraction |
+| `smoothIntersect` | `children[]`, `k` | blended intersection |
+
+CSG nodes may carry an optional `boundingBox` (`{center, halfSize}`) used for BVH
+spatial optimisation — preserve it if present.
+
+## 4. Structure & instancing nodes
+
+| type | fields | purpose |
+|------|--------|---------|
+| `transform` | `transform`, `child` | wrap a single child in a transform (§6) |
+| `group` | `children[]`, `transform?` | group with an optional shared transform |
+| `material` | `params`, `child` | set surface material (`color`, `metallic`, `roughness`, `emit`) on a sub-tree |
+| `ref` | `id`, `params?` | instantiate a `defs` entry; `params` override `{var:…}` placeholders inside it |
+| `mirror` | `axis` ('x'), `child` | bilateral symmetry via `abs()` domain fold |
+| `radial` | `count` (6), `axis` ('y'), `child` | N-fold radial symmetry |
+| `repeat` | `period` ([2,0,2]), `exposeId?`, `child` | infinite tiling; `exposeId` exposes a per-instance id for variation |
+| `select` | `cond`, `a`, `b` | branchless pick: `cond < 0.5` → a, else b |
+
+**Prefer `mirror`/`radial`/`repeat` over duplicating geometry with `ref`** — they
+are O(1) domain folds in the shader, not N copies.
+
+`defs` + `ref` is the reusable-module mechanism:
+
+```json
+"defs": { "wheel": { "type": "torus", "params": { "major": { "var": "size" }, "minor": 0.1 } } },
+"root": { "type": "ref", "id": "wheel", "params": { "size": 0.5 } }
+```
+
+## 5. Modifiers
+
+| type | fields (default) | effect |
+|------|------------------|--------|
+| `round` | `r` (0.05), `child` | inflate/soften edges by `r` |
+| `shell` | `thickness` (0.05), `child` | hollow out to a shell |
+| `displace` | `amount` (0.1), `scale` (3.0), `octaves` (4), `noiseType` ('fbm'), `animate` (false), `child` | noise surface displacement |
+
+## 6. Transforms
+
+A `transform` object supports (priority high→low): `mat4` > `rotateQ` >
+`rotateAxis` > `rotate`. Plus `translate` and `scale`.
+
+| field | shape | notes |
+|-------|-------|-------|
+| `translate` | `[x,y,z]` | metres |
+| `rotate` | `[rx,ry,rz]` | Euler **degrees**, XYZ order |
+| `rotateQ` | `[x,y,z,w]` | quaternion (glTF convention) |
+| `rotateAxis` | `{ axis:[x,y,z], angle }` | axis-angle, **degrees** |
+| `scale` | number or `[x,y,z]` | uniform or per-axis |
+| `mat4` | 16 numbers | column-major; overrides all rotation fields |
+
+⚠️ Backend note: `rotateQ`/`rotateAxis` handling is incomplete in GLSL codegen,
+and domain-modifier nodes (`radial`/`mirror`/`repeat`) drop their own `transform`
+in WGSL. See `../../lucid-renderer-interop/references/codegen-parity.md`.
+
+## 7. Value types
+
+Any numeric field can be a constant, a variable, or an expression:
+
+- **const** — a number: `1.5`
+- **array** — `[a, b, c]` (each element may itself be a value)
+- **var** — `{ "var": "name" }` — reads a scene `param`, a `ref` override, or the
+  built-in `time` (seconds)
+- **expr** — `{ "expr": "op", "args": [ … ] }`
+
+Cross-backend-safe operators (work in GLSL **and** WGSL): `add sub mul div mod
+neg abs floor ceil fract round sin cos tan asin acos atan pow sqrt exp log min
+max clamp step smoothstep mix lerp noise fbm turbulence hash`. WGSL additionally
+offers vector ops (`vec2/3/4 length normalize dot cross`) that GLSL codegen does
+not — avoid those unless you target WebGPU only. For the authoritative matrix see
+the interop skill's `codegen-parity.md`.
+
+`fbm`/`turbulence` need an **integer** octave count.
+
+## 8. Scene params
+
+```json
+"params": {
+  "radius": { "value": 0.5, "min": 0.2, "max": 1.0, "step": 0.01,
+              "type": "scalar", "unit": "m", "label": "Radius" }
+}
+```
+
+- `type`: `scalar` | `color3` | `position3` | `radii3` | `direction3`
+- Shorthand: a bare number → `scalar`; a bare `[a,b,c]` → `position3`
+- `min`/`max`/`step` shape the slider; `unit` (`"m"`, `"°"`, `"x"`, `"%"`,
+  `"rad"`) and `label` drive professional panel display (both preserved by the
+  loader as of the July 2026 UX pass).
+
+Reference a param anywhere via `{ "var": "radius" }`. Params with no `{var}`
+reference anywhere in the tree render a slider that does nothing.
+
+## 9. TOC registration
+
+Add every new scene to `scenes/toc.json` or it won't appear in the catalog. Entry
+shape (inside a category's `scenes[]`):
+
+```json
+{ "path": "csg/my-scene.json", "title": "My Scene",
+  "subtitle": "One-line description", "isAnimated": false }
+```
+
+Categories: `recent`, `prim`, `csg`, `transform`, `creatures`, `physics`,
+`archive`. A scene may appear in more than one category. After scene changes run
+`node scripts/update-recent-changes.mjs --days=14 --max=8` to refresh the Recent
+category (manual — there is no pre-commit hook).

--- a/lucid/stinkyfish/demo.html
+++ b/lucid/stinkyfish/demo.html
@@ -143,10 +143,10 @@
     <header>
       <h1>Stinkyfish</h1>
       <button id="browseBtn">📦 Browse</button>
-      <button id="animBtn">🎬</button>
-      <button id="settingsBtn">⚙️</button>
-      <span id="sceneTitle">Sphere</span>
-      <div id="status">Loading...</div>
+      <button id="animBtn" title="Toggle animation" aria-label="Toggle animation">🎬</button>
+      <button id="settingsBtn" title="Settings" aria-label="Settings">⚙️</button>
+      <span id="sceneTitle">Shape Catalogue</span>
+      <div id="status">Loading…</div>
     </header>
     <div id="canvasContainer">
       <canvas id="canvas"></canvas>

--- a/lucid/stinkyfish/raymarcher.js
+++ b/lucid/stinkyfish/raymarcher.js
@@ -357,6 +357,12 @@ export class StinkyfishRenderer {
     ];
   }
 
+  // Alias for cross-backend parity: Mayfly and <lucid-orbit-controls> expose
+  // getCameraPosition().
+  getCameraPosition() {
+    return this.getCameraPos();
+  }
+
   setCamera(distance, target = [0, 0.5, 0], theta = 0.3, phi = 0.4) {
     this.cameraDistance = distance;
     this.cameraTarget = target;

--- a/lucid/verify/README.md
+++ b/lucid/verify/README.md
@@ -1,0 +1,74 @@
+# Lucid Human Visual Verification
+
+A public, static page that closes the **headless verification gap**: automated
+agents and CI run in headless Chromium, which cannot render WebGPU at all and
+renders WebGL at ~2 FPS via SwiftShader — so nothing automated can actually *see*
+what Lucid looks like on real hardware (this is the "Stinkyfish output visually
+unverified" caveat in `stinkyfish/BUGS.md` and the interop skill).
+
+This page makes a human the renderer's eyes.
+
+**Live:** `https://danbri.github.io/glitchcan-minigam/lucid/verify/`
+(deploys automatically with the rest of the site via GitHub Pages).
+
+## The loop
+
+```
+human on a real GPU device
+   │  visits verify/ → sees each scene in Mayfly (WebGL) AND Stinkyfish (WebGPU)
+   │  answers "do they match? what differs?" per scene; captures screenshots
+   ▼
+pre-filled GitHub issue (label: visual-verification)
+   │  human drags the downloaded PNGs into the issue, submits
+   ▼
+agent reads the issue (GitHub API) → gets objective env data + human verdicts
+   │  parses the machine-readable JSON block, acts on real observations
+```
+
+## What the page does
+
+1. **Probes the environment** — WebGPU availability + adapter, the WebGL
+   `UNMASKED_RENDERER` string (objective GPU identity), browser, viewport, DPR.
+   This alone is data headless can't produce.
+2. **Interviews per scene** — a scene at a time, rendered in both backends side
+   by side, with questions targeting the known GLSL↔WGSL divergences (mirror,
+   radial, repeat, displace — see `../skills/lucid-renderer-interop/references/codegen-parity.md`).
+   The scene/question list is data-driven in `verify-config.js`.
+3. **Captures screenshots** — `renderer.render()` then `canvas.toDataURL()` per
+   backend (forcing a synchronous draw so the buffer is valid). If a capture
+   comes back blank it's flagged orange and the page tells you to use your
+   device's own screenshot instead.
+4. **Assembles a submission** — a Markdown report plus a `machine-readable` JSON
+   block, a pre-filled GitHub-issue link, a copy button, and a screenshot
+   download button.
+
+No secrets, ever — it's a public page, so submission is via a pre-filled issue
+URL you complete yourself, not an API token.
+
+## For the human (danbri)
+
+1. Open the page on the device/browser you want to test (ideally WebGPU-capable).
+2. Click **Start**, walk the scenes, answer, hit **Capture** on each.
+3. On the review screen: **Open pre-filled GitHub issue** → **Download
+   screenshots** → drag the PNGs into the issue where each scene is marked →
+   **Submit**.
+
+## For the agent (reading it back)
+
+Find submissions with `search_issues` for `label:visual-verification` in
+`danbri/glitchcan-minigam`. Each issue body contains:
+
+- A human-readable summary (environment + per-scene verdicts).
+- A `<details>` block with a fenced ```json` payload — parse this for
+  `env` (GPU/WebGPU facts) and `answers` (per-scene `match` / `discrepancies` /
+  `notes`). This is the authoritative, structured signal.
+- Screenshots the human dragged in (GitHub-hosted image URLs).
+
+Treat the typed verdicts as the primary evidence — they are the observation
+headless could not make. Screenshots corroborate and document.
+
+## Extending
+
+Add scenes or reword questions in `verify-config.js`. Bias new scenes toward
+whatever backend divergence you currently distrust; keep the set short enough
+that a human will actually finish it in one sitting.

--- a/lucid/verify/index.html
+++ b/lucid/verify/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Lucid · Human Visual Verification</title>
+  <style>
+    :root {
+      --bg: #0d1117; --panel: #161b22; --border: #30363d; --text: #c9d1d9;
+      --muted: #8b949e; --accent: #4a9eff; --ok: #3fb950; --warn: #d29922; --err: #f85149;
+      --mayfly: #4af; --stinkyfish: #f4a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font-family: system-ui, -apple-system, sans-serif;
+      background: var(--bg); color: var(--text); line-height: 1.5;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    }
+    header { padding: 1rem 1.25rem; border-bottom: 1px solid var(--border); }
+    h1 { font-size: 1.15rem; margin: 0; }
+    h1 .sub { color: var(--muted); font-weight: 400; font-size: 0.85rem; }
+    main { max-width: 1000px; margin: 0 auto; padding: 1rem 1.25rem 4rem; }
+    .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.25rem; margin-bottom: 1rem; }
+    .muted { color: var(--muted); }
+    .small { font-size: 0.85rem; }
+    code, .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em; }
+
+    /* Environment probe */
+    .env-grid { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 1rem; font-size: 0.85rem; }
+    .env-grid dt { color: var(--muted); }
+    .env-grid dd { margin: 0; }
+    .pill { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 0.75rem; font-weight: 600; }
+    .pill.ok { background: rgba(63,185,80,.18); color: var(--ok); }
+    .pill.err { background: rgba(248,81,73,.18); color: var(--err); }
+    .pill.warn { background: rgba(210,153,34,.18); color: var(--warn); }
+
+    /* Renders */
+    .renders { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    @media (max-width: 640px) { .renders { grid-template-columns: 1fr; } }
+    .render-col h3 { margin: 0 0 0.35rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: .05em; }
+    .render-col.mayfly h3 { color: var(--mayfly); }
+    .render-col.stinkyfish h3 { color: var(--stinkyfish); }
+    .render-frame { aspect-ratio: 1 / 1; background: #000; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; position: relative; }
+    lucid-renderer { width: 100%; height: 100%; display: block; }
+
+    /* Questions */
+    fieldset { border: 1px solid var(--border); border-radius: 8px; margin: 0 0 0.75rem; padding: 0.75rem 1rem; }
+    legend { padding: 0 0.4rem; color: var(--text); font-size: 0.9rem; font-weight: 600; }
+    .opt { display: flex; gap: 0.5rem; align-items: flex-start; padding: 0.25rem 0; cursor: pointer; }
+    .opt input { margin-top: 0.2rem; }
+    textarea { width: 100%; min-height: 3rem; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 0.5rem; font: inherit; resize: vertical; }
+
+    .focus { border-left: 3px solid var(--accent); padding-left: 0.75rem; margin: 0.25rem 0 1rem; color: var(--muted); font-size: 0.9rem; }
+
+    button { font: inherit; cursor: pointer; border-radius: 8px; border: 1px solid var(--border); background: #21262d; color: var(--text); padding: 0.5rem 1rem; }
+    button:hover { background: #2d333b; }
+    button.primary { background: var(--accent); border-color: var(--accent); color: #04101f; font-weight: 600; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .row { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .spacer { flex: 1; }
+    .progress { color: var(--muted); font-size: 0.85rem; }
+
+    .thumbs { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem; }
+    .thumb { border: 1px solid var(--border); border-radius: 6px; overflow: hidden; width: 96px; }
+    .thumb img { display: block; width: 96px; height: 96px; object-fit: cover; background: #000; }
+    .thumb .cap { font-size: 0.65rem; padding: 2px 4px; color: var(--muted); text-align: center; }
+    .thumb.blank img { outline: 2px solid var(--warn); outline-offset: -2px; }
+
+    pre.report { white-space: pre-wrap; word-break: break-word; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem; max-height: 320px; overflow: auto; font-size: 0.8rem; }
+    .hidden { display: none; }
+    a.link { color: var(--accent); }
+    ol.steps { padding-left: 1.2rem; }
+    ol.steps li { margin: 0.35rem 0; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>🔬 Lucid Visual Verification <span class="sub">— what does it really look like on your device?</span></h1>
+  </header>
+  <main>
+    <div class="card" id="intro">
+      <p class="small muted" style="margin-top:0">
+        Headless test machines can't render WebGPU and barely render WebGL, so an
+        automated agent never actually <em>sees</em> Lucid on real hardware. This page
+        turns your real browser into its eyes: it shows each scene in both backends,
+        asks you what you see, and packages your answers (plus screenshots) into a
+        GitHub issue the agent can read back.
+      </p>
+      <div class="env-grid" id="env"></div>
+      <div class="row" style="margin-top:1rem">
+        <button class="primary" id="btn-start">Start verification</button>
+        <span class="progress" id="scene-count"></span>
+      </div>
+    </div>
+
+    <div class="card hidden" id="session">
+      <div class="row">
+        <strong id="scene-title"></strong>
+        <span class="spacer"></span>
+        <span class="progress" id="progress"></span>
+      </div>
+      <p class="focus" id="scene-focus"></p>
+      <div class="renders">
+        <div class="render-col mayfly">
+          <h3>🦋 Mayfly · WebGL</h3>
+          <div class="render-frame"><lucid-renderer id="r-mayfly" backend="mayfly" quality="medium"></lucid-renderer></div>
+        </div>
+        <div class="render-col stinkyfish">
+          <h3>🐟 Stinkyfish · WebGPU</h3>
+          <div class="render-frame"><lucid-renderer id="r-stinkyfish" backend="stinkyfish" quality="medium"></lucid-renderer></div>
+        </div>
+      </div>
+      <div class="row" style="margin:0.75rem 0">
+        <button id="btn-capture">📸 Capture screenshots</button>
+        <span class="small muted">Tip: if a thumbnail is blank (outlined orange), use your device's own screenshot instead and drag it into the issue later.</span>
+      </div>
+      <div class="thumbs" id="thumbs"></div>
+
+      <div id="questions" style="margin-top:1rem"></div>
+
+      <div class="row">
+        <button id="btn-prev">← Previous</button>
+        <span class="spacer"></span>
+        <button class="primary" id="btn-next">Next →</button>
+      </div>
+    </div>
+
+    <div class="card hidden" id="review">
+      <h2 style="margin-top:0;font-size:1.05rem">Review &amp; submit</h2>
+      <p class="small muted">
+        Your report is below. It includes a machine-readable block the agent parses
+        automatically — your typed answers are the real signal, screenshots are a
+        corroborating record.
+      </p>
+      <div class="row" style="margin-bottom:0.75rem">
+        <button class="primary" id="btn-issue">📮 Open pre-filled GitHub issue</button>
+        <button id="btn-copy">📋 Copy full report</button>
+        <button id="btn-download">⬇︎ Download screenshots</button>
+      </div>
+      <p class="small">How to finish:</p>
+      <ol class="steps small">
+        <li>Click <strong>Open pre-filled GitHub issue</strong> — title, labels and your answers are filled in.</li>
+        <li>Click <strong>Download screenshots</strong>, then drag those PNG files into the issue body where each scene is marked (GitHub uploads and links them automatically).</li>
+        <li>Submit the issue. That's it — the agent reads it from there.</li>
+      </ol>
+      <details style="margin-top:0.5rem"><summary class="small muted">Preview report</summary>
+        <pre class="report" id="report-preview"></pre>
+      </details>
+    </div>
+  </main>
+
+  <script type="module">
+    import '../components/lucid-renderer.js';
+    import { VERIFY_CONFIG as CFG } from './verify-config.js';
+
+    // ---- state ----
+    const state = { i: 0, env: {}, answers: {}, shots: {} };
+    const $ = id => document.getElementById(id);
+    const rMayfly = $('r-mayfly'), rStinky = $('r-stinkyfish');
+
+    // ---- environment probe ----
+    async function probeEnv() {
+      const env = {
+        timestamp: new Date().toISOString(),
+        ua: navigator.userAgent,
+        platform: navigator.platform || '',
+        viewport: `${window.innerWidth}×${window.innerHeight}`,
+        dpr: window.devicePixelRatio || 1,
+        webgpu: false, webgpuAdapter: '',
+        webglRenderer: '', webglVendor: '',
+      };
+      // WebGL renderer string (objective GPU identity)
+      try {
+        const c = document.createElement('canvas');
+        const gl = c.getContext('webgl2') || c.getContext('webgl');
+        if (gl) {
+          const dbg = gl.getExtension('WEBGL_debug_renderer_info');
+          if (dbg) {
+            env.webglRenderer = gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) || '';
+            env.webglVendor = gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) || '';
+          }
+        }
+      } catch (e) {}
+      // WebGPU availability + adapter
+      try {
+        if ('gpu' in navigator) {
+          const adapter = await navigator.gpu.requestAdapter();
+          if (adapter) {
+            env.webgpu = true;
+            const info = adapter.info || (adapter.requestAdapterInfo ? await adapter.requestAdapterInfo() : null);
+            if (info) env.webgpuAdapter = [info.vendor, info.architecture, info.description].filter(Boolean).join(' ');
+          }
+        }
+      } catch (e) {}
+      state.env = env;
+      renderEnv();
+    }
+
+    function pill(ok, textOk, textNo, cls) {
+      return `<span class="pill ${ok ? 'ok' : (cls || 'err')}">${ok ? textOk : textNo}</span>`;
+    }
+    function renderEnv() {
+      const e = state.env;
+      $('env').innerHTML = `
+        <dt>WebGPU (Stinkyfish)</dt><dd>${pill(e.webgpu, 'available', 'not available', 'warn')} <span class="small muted mono">${e.webgpuAdapter || ''}</span></dd>
+        <dt>WebGL (Mayfly)</dt><dd><span class="mono small">${e.webglRenderer || 'unknown'}</span></dd>
+        <dt>Browser</dt><dd class="small mono">${e.ua}</dd>
+        <dt>Viewport</dt><dd class="small">${e.viewport} @ ${e.dpr}×</dd>`;
+      $('scene-count').textContent = `${CFG.scenes.length} scenes to review`;
+      if (!e.webgpu) {
+        $('env').insertAdjacentHTML('beforeend',
+          `<dt></dt><dd class="small" style="color:var(--warn)">This device has no WebGPU — you can still record the WebGL side, but the most valuable pass is on a WebGPU-capable device/browser.</dd>`);
+      }
+    }
+
+    // ---- session ----
+    function loadScene(idx) {
+      const s = CFG.scenes[idx];
+      $('scene-title').textContent = s.title;
+      $('scene-focus').textContent = 'Focus: ' + s.focus;
+      $('progress').textContent = `Scene ${idx + 1} of ${CFG.scenes.length}`;
+      // (Re)load in both backends. Setting the attribute triggers loadScene().
+      rMayfly.setAttribute('scene', s.path);
+      rStinky.setAttribute('scene', s.path);
+      renderQuestions(s);
+      renderThumbs(s);
+      $('btn-prev').disabled = idx === 0;
+      $('btn-next').textContent = idx === CFG.scenes.length - 1 ? 'Finish →' : 'Next →';
+    }
+
+    function renderQuestions(s) {
+      const a = state.answers[s.id] || (state.answers[s.id] = {});
+      const html = CFG.perSceneQuestions.map(q => {
+        if (q.type === 'match') {
+          return `<fieldset><legend>${q.label}</legend>${q.options.map(o => `
+            <label class="opt"><input type="radio" name="${s.id}-${q.id}" value="${o.value}" ${a[q.id] === o.value ? 'checked' : ''}>
+            <span>${o.label}</span></label>`).join('')}</fieldset>`;
+        }
+        if (q.type === 'checks') {
+          const set = new Set(a[q.id] || []);
+          return `<fieldset><legend>${q.label}</legend>${q.options.map(o => `
+            <label class="opt"><input type="checkbox" name="${s.id}-${q.id}" value="${o.value}" ${set.has(o.value) ? 'checked' : ''}>
+            <span>${o.label}</span></label>`).join('')}</fieldset>`;
+        }
+        return `<fieldset><legend>${q.label}</legend>
+          <textarea name="${s.id}-${q.id}" placeholder="${q.placeholder || ''}">${a[q.id] || ''}</textarea></fieldset>`;
+      }).join('');
+      $('questions').innerHTML = html;
+      // wire inputs -> state
+      $('questions').querySelectorAll('input,textarea').forEach(el => {
+        el.addEventListener('input', () => saveAnswers(s));
+      });
+    }
+
+    function saveAnswers(s) {
+      const a = state.answers[s.id] || (state.answers[s.id] = {});
+      CFG.perSceneQuestions.forEach(q => {
+        const els = $('questions').querySelectorAll(`[name="${s.id}-${q.id}"]`);
+        if (q.type === 'match') {
+          const chosen = [...els].find(e => e.checked);
+          a[q.id] = chosen ? chosen.value : '';
+        } else if (q.type === 'checks') {
+          a[q.id] = [...els].filter(e => e.checked).map(e => e.value);
+        } else {
+          a[q.id] = els[0] ? els[0].value.trim() : '';
+        }
+      });
+    }
+
+    // ---- screenshots ----
+    function grabCanvas(el) {
+      try {
+        const canvas = el.shadowRoot && el.shadowRoot.querySelector('canvas');
+        if (!canvas) return null;
+        // Force one synchronous draw so the drawing buffer is valid this tick
+        // (avoids blank captures when preserveDrawingBuffer is off).
+        if (el.renderer && typeof el.renderer.render === 'function') {
+          try { el.renderer.render(); } catch (e) {}
+        }
+        const url = canvas.toDataURL('image/png');
+        const blank = !url || url.length < 2000; // rough blank heuristic
+        return { url, blank };
+      } catch (e) { return null; }
+    }
+
+    function captureCurrent() {
+      const s = CFG.scenes[state.i];
+      const shots = state.shots[s.id] || (state.shots[s.id] = {});
+      shots.mayfly = grabCanvas(rMayfly);
+      shots.stinkyfish = grabCanvas(rStinky);
+      renderThumbs(s);
+    }
+
+    function renderThumbs(s) {
+      const shots = state.shots[s.id] || {};
+      const cell = (backend, label) => {
+        const shot = shots[backend];
+        if (!shot || !shot.url) return '';
+        return `<div class="thumb ${shot.blank ? 'blank' : ''}"><img src="${shot.url}" alt="${s.id} ${backend}"><div class="cap">${label}${shot.blank ? ' ⚠' : ''}</div></div>`;
+      };
+      $('thumbs').innerHTML = cell('mayfly', '🦋 WebGL') + cell('stinkyfish', '🐟 WebGPU');
+    }
+
+    // ---- report ----
+    function buildReport() {
+      const e = state.env;
+      const lines = [];
+      lines.push(`## ${CFG.issueTitlePrefix} — ${e.timestamp.slice(0, 10)}`);
+      lines.push('');
+      lines.push('**Environment**');
+      lines.push(`- WebGPU: ${e.webgpu ? '✅ available' : '❌ not available'}${e.webgpuAdapter ? ' (' + e.webgpuAdapter + ')' : ''}`);
+      lines.push(`- WebGL renderer: \`${e.webglRenderer || 'unknown'}\``);
+      lines.push(`- Browser: \`${e.ua}\``);
+      lines.push(`- Viewport: ${e.viewport} @ ${e.dpr}×`);
+      lines.push('');
+      const labelFor = (qid, val) => {
+        const q = CFG.perSceneQuestions.find(x => x.id === qid);
+        if (!q || !q.options) return val;
+        const o = q.options.find(x => x.value === val);
+        return o ? o.label : val;
+      };
+      CFG.scenes.forEach(s => {
+        const a = state.answers[s.id] || {};
+        lines.push(`### ${s.title} — \`${s.path}\``);
+        lines.push(`_Focus: ${s.focus}_`);
+        lines.push(`- **Match:** ${a.match ? labelFor('match', a.match) : '_(not answered)_'}`);
+        if (a.discrepancies && a.discrepancies.length) lines.push(`- **Differs:** ${a.discrepancies.map(v => labelFor('discrepancies', v)).join(', ')}`);
+        if (a.notes) lines.push(`- **Notes:** ${a.notes}`);
+        const shots = state.shots[s.id] || {};
+        const want = [];
+        if (shots.mayfly) want.push(`verify-${s.id}-mayfly.png`);
+        if (shots.stinkyfish) want.push(`verify-${s.id}-stinkyfish.png`);
+        lines.push(`- _Screenshots — drag here:_ ${want.length ? want.map(f => '`' + f + '`').join(', ') : '(use your device screenshot)'}`);
+        lines.push('');
+      });
+      // machine-readable block for the agent
+      const machine = {
+        reportVersion: CFG.reportVersion,
+        env: e,
+        answers: state.answers,
+        scenes: CFG.scenes.map(s => ({ id: s.id, path: s.path })),
+      };
+      lines.push('<details><summary>machine-readable (agent parses this)</summary>');
+      lines.push('');
+      lines.push('```json');
+      lines.push(JSON.stringify(machine, null, 2));
+      lines.push('```');
+      lines.push('</details>');
+      return lines.join('\n');
+    }
+
+    function issueUrl(body) {
+      const e = state.env;
+      const gpu = e.webgpuAdapter || e.webglRenderer || 'device';
+      const title = `${CFG.issueTitlePrefix}: ${gpu} (${e.timestamp.slice(0, 10)})`;
+      const base = `https://github.com/${CFG.repo}/issues/new`;
+      // Keep the URL under practical limits; fall back to a compact body.
+      let b = body;
+      const build = (bd) => `${base}?title=${encodeURIComponent(title)}&labels=${encodeURIComponent(CFG.issueLabel)}&body=${encodeURIComponent(bd)}`;
+      let url = build(b);
+      if (url.length > 7500) {
+        b = body.split('<details>')[0] + '\n> Full machine-readable report was too long for the URL — click **Copy full report** on the page and paste it here.';
+        url = build(b);
+      }
+      return url;
+    }
+
+    function downloadShots() {
+      let n = 0;
+      CFG.scenes.forEach(s => {
+        const shots = state.shots[s.id] || {};
+        ['mayfly', 'stinkyfish'].forEach(backend => {
+          const shot = shots[backend];
+          if (shot && shot.url && !shot.blank) {
+            const a = document.createElement('a');
+            a.href = shot.url; a.download = `verify-${s.id}-${backend}.png`;
+            document.body.appendChild(a); a.click(); a.remove(); n++;
+          }
+        });
+      });
+      if (!n) alert('No screenshots captured yet (or all were blank). Use your device screenshot tool and drag those into the issue instead.');
+    }
+
+    function showReview() {
+      const report = buildReport();
+      $('report-preview').textContent = report;
+      $('btn-issue').onclick = () => window.open(issueUrl(report), '_blank', 'noopener');
+      $('btn-copy').onclick = async () => {
+        try { await navigator.clipboard.writeText(report); $('btn-copy').textContent = '✓ Copied'; setTimeout(() => $('btn-copy').textContent = '📋 Copy full report', 1500); }
+        catch (e) { alert('Copy failed — select the text in the preview instead.'); }
+      };
+      $('btn-download').onclick = downloadShots;
+      $('session').classList.add('hidden');
+      $('review').classList.remove('hidden');
+      $('review').scrollIntoView({ behavior: 'smooth' });
+    }
+
+    // ---- navigation ----
+    $('btn-start').onclick = () => {
+      $('intro').classList.add('hidden');
+      $('session').classList.remove('hidden');
+      state.i = 0; loadScene(0);
+    };
+    $('btn-prev').onclick = () => { saveAnswers(CFG.scenes[state.i]); if (state.i > 0) { state.i--; loadScene(state.i); } };
+    $('btn-next').onclick = () => {
+      saveAnswers(CFG.scenes[state.i]);
+      if (state.i < CFG.scenes.length - 1) { state.i++; loadScene(state.i); window.scrollTo({ top: 0, behavior: 'smooth' }); }
+      else showReview();
+    };
+    $('btn-capture').onclick = captureCurrent;
+
+    // surface backend load errors to the human
+    [rMayfly, rStinky].forEach(el => el.addEventListener('render-error', ev => {
+      console.warn('render-error', el.id, ev.detail);
+    }));
+
+    probeEnv();
+  </script>
+</body>
+</html>

--- a/lucid/verify/verify-config.js
+++ b/lucid/verify/verify-config.js
@@ -1,0 +1,109 @@
+/**
+ * Configuration for the Lucid human visual-verification harness.
+ *
+ * WHY THIS EXISTS
+ * Headless Chromium (the CI / agent environment) cannot render WebGPU at all and
+ * renders WebGL at ~2 FPS via SwiftShader, so an agent can never actually SEE
+ * what Stinkyfish (WebGPU) produces on real hardware. This harness closes that
+ * gap: a human opens the page on a real GPU device, the page interviews them
+ * about what they see across both backends, and packages the answers +
+ * screenshots into a GitHub issue the agent can read back.
+ *
+ * The `scenes` list is deliberately biased toward the known GLSL↔WGSL divergences
+ * documented in skills/lucid-renderer-interop/references/codegen-parity.md, so a
+ * single pass exercises the exact things headless cannot verify. Edit freely —
+ * add scenes, reword questions; the harness is fully data-driven.
+ */
+
+export const VERIFY_CONFIG = {
+  // GitHub target for the pre-filled issue. Owner/repo only — no tokens (this is
+  // a public page and must never hold secrets).
+  repo: 'danbri/glitchcan-minigam',
+  issueLabel: 'visual-verification',
+  issueTitlePrefix: 'Visual verification',
+
+  // Report format version, so the agent-side parser can evolve.
+  reportVersion: 1,
+
+  // Scenes to walk through, each rendered in BOTH backends side by side.
+  // `focus` names the interop concern the scene stresses (shown to the human);
+  // `paths` are relative to lucid/scenes/.
+  scenes: [
+    {
+      id: 'sphere',
+      path: 'primitives/sphere.json',
+      title: 'Single sphere',
+      focus: 'Baseline — lighting, shading, and colour parity on the simplest shape.',
+    },
+    {
+      id: 'table',
+      path: 'patterns/table.json',
+      title: 'CSG table',
+      focus: 'Boolean CSG (union/subtract) and transforms.',
+    },
+    {
+      id: 'mirror',
+      path: 'patterns/mirror.json',
+      title: 'Mirror symmetry',
+      focus: 'WGSL mirror lacks the ancestor-rotation fix and may drop the node transform — watch for a mirrored half that is offset, rotated wrong, or missing.',
+    },
+    {
+      id: 'radial',
+      path: 'patterns/radial-flower.json',
+      title: 'Radial symmetry',
+      focus: 'Radial domain fold. WGSL drops the modifier transform — watch for petals that are misplaced or a different count/rotation than WebGL.',
+    },
+    {
+      id: 'infinite-field',
+      path: 'patterns/infinite-field.json',
+      title: 'Infinite repeat',
+      focus: 'Repeat/tiling domain fold (mod-based in GLSL, fract-based in WGSL, both marked unverified). Watch for seams, doubled/missing tiles, or misalignment between backends.',
+    },
+    {
+      id: 'snowman',
+      path: 'creatures/snowman.json',
+      title: 'Snowman (creature)',
+      focus: 'A composed creature — overall shape, proportions, and material parity.',
+    },
+  ],
+
+  // Questions asked for every scene. `type` drives the input widget.
+  // - 'match'   : the headline verdict (single choice)
+  // - 'checks'  : multi-select of specific discrepancies
+  // - 'text'    : free observation
+  perSceneQuestions: [
+    {
+      id: 'match',
+      type: 'match',
+      label: 'Do the WebGL (Mayfly) and WebGPU (Stinkyfish) renders match?',
+      options: [
+        { value: 'match', label: 'Match — visually equivalent' },
+        { value: 'minor', label: 'Minor differences (shading/tone)' },
+        { value: 'major', label: 'Major differences (geometry/colour)' },
+        { value: 'webgpu-blank', label: 'WebGPU is blank / errored' },
+        { value: 'webgl-blank', label: 'WebGL is blank / errored' },
+        { value: 'na', label: 'WebGPU unavailable on this device' },
+      ],
+    },
+    {
+      id: 'discrepancies',
+      type: 'checks',
+      label: 'If they differ, what differs? (tick all that apply)',
+      options: [
+        { value: 'geometry', label: 'Shape / geometry' },
+        { value: 'position', label: 'Position / symmetry / count' },
+        { value: 'colour', label: 'Colour / material' },
+        { value: 'lighting', label: 'Lighting / shading / tone' },
+        { value: 'ground', label: 'Ground plane' },
+        { value: 'artifacts', label: 'Noise / artefacts / banding' },
+        { value: 'missing', label: 'Missing parts' },
+      ],
+    },
+    {
+      id: 'notes',
+      type: 'text',
+      label: 'Anything else you notice (optional)',
+      placeholder: 'e.g. "WebGPU petals rotated ~15° vs WebGL"',
+    },
+  ],
+};


### PR DESCRIPTION
Professionalises the Lucid SDF system's UX/unit text, tightens Mayfly↔Stinkyfish interop, adds an agentskills.io skills folder, and builds a human-in-the-loop page to verify what headless can't see. All changes are scoped to `lucid/`.

## 1 · Multi-renderer interop (WebGL/GLSL ↔ WebGPU/WGSL)
Real divergences where a scene rendered differently on each backend — all verified with a Node JSON→GLSL/WGSL codegen harness:
- **GLSL was missing 9 expression ops** (`pow sqrt exp log asin acos atan round lerp`) that WGSL had — they silently became `0.0` + a console warning. Now at parity.
- **WGSL `mod` was truncated (`%`)** vs GLSL's floored `mod()` — diverged for negatives and broke SDF domain-repeat parity. WGSL now emits floored modulo.
- **WGSL `select` was a stub** that always drew a unit sphere and read the wrong node field. Now uses the same branchless `mix(a, b, step(0.5, cond))` as GLSL.
- **`<lucid-renderer>.updateParam()` was dead code** (called methods on neither backend) → routed to `setParam`.
- Added `getCameraPos`/`getCameraPosition` **aliases** on both renderers and a **`setTime()`** clock API on the component.

## 2 · Animation timeline / looping
The node-editor scrubber was **cosmetic** — `timeline.time` never reached the preview. It now drives it via `setTime()`. Verified headless: after pressing play the renderer clock advanced 1.52 → 2.52.

## 3 · UX, unit text, accessibility
- Param panels now show **units** (metres for distances per the units convention, `°`, `x`) and **human labels** — the loader was silently dropping both.
- **aria-labels / keyboard** on icon-only buttons and the settings toggles (now real `role="switch"` controls); scene-catalog thumbnails get alt text.
- One term per concept (**Scene** not Demo, **Settings** not Debug Panel), **Apply** label matches its action, backend menu shows the tech (Mayfly/WebGL, Stinkyfish/WebGPU).
- All five viewer surfaces load with **0 uncaught errors**; core suite **70/70**.

## 4 · Skills folder (`lucid/skills/`, agentskills.io format)
Four code-verified `SKILL.md` skills + references + README: **scene-authoring** (full node reference), **renderer-interop** (with the GLSL↔WGSL parity matrix), **rigging-and-physics**, **animation-and-interaction**. Each honestly distinguishes what works, what was just fixed, and what remains divergent, with file:line ground truth.

## 5 · Human visual-verification harness (`lucid/verify/`)
Closes the headless gap: agents/CI can't render WebGPU and barely render WebGL, so nothing automated can *see* Lucid on real hardware. This public static page makes a human the renderer's eyes — it probes the real GPU environment, shows each scene in both backends, interviews the user about discrepancies, captures canvas screenshots, and assembles a pre-filled `visual-verification` GitHub issue (with a machine-readable JSON block) the agent reads back. No secrets — submission is a pre-filled issue the human completes, not an API token. Deploys to `/lucid/verify/` once merged.

## Deliberately documented, not changed
Honesty over false parity: several deeper WGSL gaps that can't be verified headless (no WebGPU) — `displace` options, `repeat.exposeId`, mirror-under-rotation, domain-modifier transforms — and the **double-physics conflict** in index.html (both physics stacks run and fight over uniforms). These are captured with file:line detail in the skills so they're fixed safely later, in a WebGPU-capable session (the new `verify/` page is the tool for that).

## Verification
- Node JSON→GLSL/WGSL codegen harness: all 9 ops compile on both backends; `select` emits both children; `mod` uses the floored form.
- Core suite (`npm run test:core`): 70/70.
- Headless Chromium smoke across index / node-editor / compare / scene-catalog / stinkyfish-demo / verify: 0 uncaught errors; timeline drives the render clock; canvas capture yields a real PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VZBUkNuopErvJ4Sk8Ut3W

---
_Generated by [Claude Code](https://claude.ai/code/session_017VZBUkNuopErvJ4Sk8Ut3W)_