### PR TITLE
Lucid: fix Mayfly aspect-ratio distortion + add aspect-ratio response to verify harness

### DIFF
--- a/lucid/mayfly/raymarcher.js
+++ b/lucid/mayfly/raymarcher.js
@@ -165,10 +165,40 @@ export class SimpleRaymarcher {
     this.isPaused = false;
   }
 
-  resize() {
-    const dpr = window.devicePixelRatio || 1;
-    this.canvas.width = window.innerWidth * dpr;
-    this.canvas.height = window.innerHeight * dpr;
+  /**
+   * Resize the drawing buffer.
+   *
+   * @param {number} [width]  backing-store width in device pixels
+   * @param {number} [height] backing-store height in device pixels
+   *
+   * When a caller passes explicit dimensions (e.g. the <lucid-renderer>
+   * ResizeObserver, which already accounts for devicePixelRatio) they are
+   * honoured directly. Otherwise the buffer is sized to the canvas's OWN
+   * displayed box — never the window.
+   *
+   * Sizing to window.innerWidth/Height was a bug: whenever the canvas wasn't
+   * full-window (e.g. a square frame in the verify/compare pages) the buffer
+   * took the viewport's aspect and got stretched into the element's box — a
+   * sphere rendered as an ellipse. On mobile it also meant every address-bar
+   * show/hide on scroll fired 'resize' and visibly distorted the render.
+   */
+  resize(width, height) {
+    let w, h;
+    if (typeof width === 'number' && typeof height === 'number' && width > 0 && height > 0) {
+      w = Math.floor(width);
+      h = Math.floor(height);
+    } else {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = this.canvas.getBoundingClientRect();
+      const cw = rect.width || this.canvas.clientWidth || window.innerWidth;
+      const ch = rect.height || this.canvas.clientHeight || window.innerHeight;
+      w = Math.max(1, Math.floor(cw * dpr));
+      h = Math.max(1, Math.floor(ch * dpr));
+    }
+    if (this.canvas.width !== w || this.canvas.height !== h) {
+      this.canvas.width = w;
+      this.canvas.height = h;
+    }
     if (this.gl) {
       this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     }

--- a/lucid/verify/index.html
+++ b/lucid/verify/index.html
@@ -231,7 +231,9 @@
     function renderQuestions(s) {
       const a = state.answers[s.id] || (state.answers[s.id] = {});
       const html = CFG.perSceneQuestions.map(q => {
-        if (q.type === 'match') {
+        // Single-choice: any question with options that isn't a multi-select.
+        // Covers 'match' and 'aspect' (and any future single-choice type).
+        if (q.options && q.type !== 'checks') {
           return `<fieldset><legend>${q.label}</legend>${q.options.map(o => `
             <label class="opt"><input type="radio" name="${s.id}-${q.id}" value="${o.value}" ${a[q.id] === o.value ? 'checked' : ''}>
             <span>${o.label}</span></label>`).join('')}</fieldset>`;
@@ -256,7 +258,7 @@
       const a = state.answers[s.id] || (state.answers[s.id] = {});
       CFG.perSceneQuestions.forEach(q => {
         const els = $('questions').querySelectorAll(`[name="${s.id}-${q.id}"]`);
-        if (q.type === 'match') {
+        if (q.options && q.type !== 'checks') {
           const chosen = [...els].find(e => e.checked);
           a[q.id] = chosen ? chosen.value : '';
         } else if (q.type === 'checks') {
@@ -313,19 +315,29 @@
       lines.push(`- Browser: \`${e.ua}\``);
       lines.push(`- Viewport: ${e.viewport} @ ${e.dpr}×`);
       lines.push('');
-      const labelFor = (qid, val) => {
-        const q = CFG.perSceneQuestions.find(x => x.id === qid);
+      const optLabel = (q, val) => {
         if (!q || !q.options) return val;
         const o = q.options.find(x => x.value === val);
         return o ? o.label : val;
       };
+      const isEmpty = (v) => v === undefined || v === '' || (Array.isArray(v) && v.length === 0);
       CFG.scenes.forEach(s => {
         const a = state.answers[s.id] || {};
         lines.push(`### ${s.title} — \`${s.path}\``);
         lines.push(`_Focus: ${s.focus}_`);
-        lines.push(`- **Match:** ${a.match ? labelFor('match', a.match) : '_(not answered)_'}`);
-        if (a.discrepancies && a.discrepancies.length) lines.push(`- **Differs:** ${a.discrepancies.map(v => labelFor('discrepancies', v)).join(', ')}`);
-        if (a.notes) lines.push(`- **Notes:** ${a.notes}`);
+        // Emit every configured question generically so new response types
+        // (e.g. aspect ratio) flow through without touching this builder.
+        CFG.perSceneQuestions.forEach(q => {
+          const val = a[q.id];
+          const lbl = q.reportLabel || q.label;
+          if (q.type === 'checks') {
+            if (!isEmpty(val)) lines.push(`- **${lbl}:** ${val.map(v => optLabel(q, v)).join(', ')}`);
+          } else if (q.options) {
+            lines.push(`- **${lbl}:** ${isEmpty(val) ? '_(not answered)_' : optLabel(q, val)}`);
+          } else if (!isEmpty(val)) {
+            lines.push(`- **${lbl}:** ${val}`);
+          }
+        });
         const shots = state.shots[s.id] || {};
         const want = [];
         if (shots.mayfly) want.push(`verify-${s.id}-mayfly.png`);

--- a/lucid/verify/verify-config.js
+++ b/lucid/verify/verify-config.js
@@ -76,6 +76,7 @@ export const VERIFY_CONFIG = {
       id: 'match',
       type: 'match',
       label: 'Do the WebGL (Mayfly) and WebGPU (Stinkyfish) renders match?',
+      reportLabel: 'Match',
       options: [
         { value: 'match', label: 'Match — visually equivalent' },
         { value: 'minor', label: 'Minor differences (shading/tone)' },
@@ -86,11 +87,30 @@ export const VERIFY_CONFIG = {
       ],
     },
     {
+      // Aspect ratio / shape distortion — a round shape must read as round. A
+      // squashed/stretched sphere (ellipse) means the canvas backing-store
+      // aspect doesn't match its displayed box. Ask per-backend because the
+      // two size their canvases differently.
+      id: 'aspect',
+      type: 'aspect',
+      label: 'Aspect ratio — is a round shape actually round (not a stretched ellipse)?',
+      reportLabel: 'Aspect ratio',
+      options: [
+        { value: 'both-correct', label: 'Correct in both' },
+        { value: 'webgl-stretched', label: 'WebGL (Mayfly) is stretched / squashed' },
+        { value: 'webgpu-stretched', label: 'WebGPU (Stinkyfish) is stretched / squashed' },
+        { value: 'both-stretched', label: 'Both are stretched / squashed' },
+        { value: 'changes-on-scroll', label: 'Distortion appears or changes when I scroll / rotate the device' },
+      ],
+    },
+    {
       id: 'discrepancies',
       type: 'checks',
       label: 'If they differ, what differs? (tick all that apply)',
+      reportLabel: 'Differs',
       options: [
         { value: 'geometry', label: 'Shape / geometry' },
+        { value: 'aspect', label: 'Aspect ratio / stretch' },
         { value: 'position', label: 'Position / symmetry / count' },
         { value: 'colour', label: 'Colour / material' },
         { value: 'lighting', label: 'Lighting / shading / tone' },
@@ -103,6 +123,7 @@ export const VERIFY_CONFIG = {
       id: 'notes',
       type: 'text',
       label: 'Anything else you notice (optional)',
+      reportLabel: 'Notes',
       placeholder: 'e.g. "WebGPU petals rotated ~15° vs WebGL"',
     },
   ],


### PR DESCRIPTION
Follow-up to #747. The verify harness earned its keep on first real use: on an iPhone the Mayfly (WebGL) sphere rendered as a wide **ellipse** while Stinkyfish (WebGPU) was a correct circle, and scrolling changed the distortion.

## Fix: Mayfly aspect-ratio / scroll distortion
`SimpleRaymarcher.resize()` **ignored its arguments** and sized the drawing buffer to `window.innerWidth × window.innerHeight` — the whole viewport's aspect — even when the `<lucid-renderer>` ResizeObserver passed the correct (square) canvas dimensions. A portrait buffer stretched into a square frame turns a sphere into an ellipse; on mobile, the address bar showing/hiding on scroll fires `resize` and re-stretched it (that's the "scrolling affects the render" observation).

`resize()` now honours explicit dimensions when given, and otherwise sizes to the canvas's **own displayed box**, never the window.

Verified headless:
- Square frame (verify page): Mayfly canvas is now **318×318, ratio 1.0** → circular sphere (was portrait/window-sized).
- Full-screen (index.html): canvas **1280×720** still matches viewport aspect — no regression.
- 0 uncaught errors.

## Add: aspect-ratio response type
Per request — a dedicated **Aspect ratio** question in the verify interview (round-should-be-round; per-backend stretch; "changes when I scroll/rotate"), plus an *aspect* option on the discrepancy checklist. The harness's question rendering and report builder are generalised so new response types flow through with no bespoke code.

## Verification
Headless Chromium: aspect fix confirmed on both the square-frame and full-screen paths; verify page shows 4 question groups incl. the aspect question; report builds; 0 uncaught errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VZBUkNuopErvJ4Sk8Ut3W

---
_Generated by [Claude Code](https://claude.ai/code/session_017VZBUkNuopErvJ4Sk8Ut3W)_