### PR TITLE
Waterworld: neon particle universe, boid fish, god rays, IR thermal sight

### DIFF
--- a/magpie/waterworld/README.md
+++ b/magpie/waterworld/README.md
@@ -28,10 +28,29 @@ running out of air) and the dive ends with a partial score.
 
 Sonar also stuns eels up close and safely detonates mines at a distance.
 
+## The living water (js/fx.js)
+
+The blocky bones wear a neon skin: structures are near-silhouettes traced
+in additive glowing edges (`neonize`), each family its own signature
+colour. One basin-wide gyre (`currentAt`) carries everything: three boid
+fish schools haunting the wrecks (shimmering hue-cycling point clouds),
+plankton, drifting debris, vent bubble columns, and the dust motes
+hanging in the **god rays** — slanted additive light shafts that fade
+with depth. The sub casts a visible beam cone and feels the current.
+
+**IR / thermal sight** (I key, or the IR button in the HUD): the water
+goes near-black and unusually clear; everything drops to a cold navy
+silhouette unless it carries heat. Fatbergs blaze (decomposition runs
+warm — how sewer crews actually find them), the sub's engine glows, old
+mines smoulder, eels barely register (cold-blooded), and the ghost whale
+reads as a *cold* blue presence. Heat plumes rise off warm sources.
+Late-spawned entities inherit the active mode.
+
 ## Controls
 
 - **Steer:** arrows / WASD / d-pad (left-right = yaw, up-down = pitch)
 - **A / Space / Z:** thrust · **B / Escape / X:** sonar ping + tools
+- **I / IR button:** thermal sight
 - Touch pad appears standalone; inside the FINK shell the host provides
   input (`sdk.onControls`) and this pad hides.
 

--- a/magpie/waterworld/js/fx.js
+++ b/magpie/waterworld/js/fx.js
@@ -1,0 +1,338 @@
+// Waterworld FX — the living water. Everything in here is atmosphere:
+// a basin-wide gyre current, boid fish schools, god rays with dust motes,
+// neon plankton, drifting debris, vent bubble columns, and the thermal
+// (IR) systems. No gameplay state lives here; game.js asks, fx answers.
+
+import * as THREE from '../../../trees/vendor/three.module.min.js';
+import { BOUNDS, floorYAt } from './world.js';
+
+// ---------------------------------------------------------------- textures
+function radialTexture(inner = 'rgba(255,255,255,1)', outer = 'rgba(255,255,255,0)') {
+  const c = document.createElement('canvas');
+  c.width = c.height = 64;
+  const g = c.getContext('2d');
+  const grad = g.createRadialGradient(32, 32, 2, 32, 32, 30);
+  grad.addColorStop(0, inner);
+  grad.addColorStop(1, outer);
+  g.fillStyle = grad;
+  g.fillRect(0, 0, 64, 64);
+  const t = new THREE.CanvasTexture(c);
+  return t;
+}
+
+function rayTexture() {
+  const c = document.createElement('canvas');
+  c.width = 64; c.height = 256;
+  const g = c.getContext('2d');
+  const v = g.createLinearGradient(0, 0, 0, 256);
+  v.addColorStop(0, 'rgba(255,250,220,0.75)');
+  v.addColorStop(0.55, 'rgba(200,235,255,0.28)');
+  v.addColorStop(1, 'rgba(150,220,255,0)');
+  g.fillStyle = v;
+  g.fillRect(0, 0, 64, 256);
+  // fade the shaft's edges so planes read as light, not geometry
+  const h = g.createLinearGradient(0, 0, 64, 0);
+  h.addColorStop(0, 'rgba(0,0,0,0)');
+  h.addColorStop(0.25, 'rgba(0,0,0,1)');
+  h.addColorStop(0.75, 'rgba(0,0,0,1)');
+  h.addColorStop(1, 'rgba(0,0,0,0)');
+  g.globalCompositeOperation = 'destination-in';
+  g.fillStyle = h;
+  g.fillRect(0, 0, 64, 256);
+  return new THREE.CanvasTexture(c);
+}
+
+export function glowSprite(color, size = 3, opacity = 0.55) {
+  const m = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: radialTexture(), color, transparent: true, opacity,
+    blending: THREE.AdditiveBlending, depthWrite: false,
+  }));
+  m.scale.setScalar(size);
+  return m;
+}
+
+// ---------------------------------------------------------------- current
+// One slow anticlockwise gyre around the basin centre, wobbled so nothing
+// ever quite repeats. Everything drifting asks this one function.
+const _tmp = new THREE.Vector3();
+export function currentAt(p, t, out) {
+  const r = Math.hypot(p.x, p.z) + 4;
+  const s = 1.5 * Math.min(1, r / 90);
+  out.set(
+    (-p.z / r) * s + 0.35 * Math.sin(0.09 * p.z + t * 0.13),
+    0.12 * Math.sin(t * 0.21 + p.x * 0.045),
+    (p.x / r) * s + 0.35 * Math.cos(0.08 * p.x + t * 0.11));
+  return out;
+}
+
+// ---------------------------------------------------------------- boids
+class School {
+  constructor(scene, n, home, radius, baseHue, size) {
+    this.n = n;
+    this.home = home;
+    this.radius = radius;
+    this.baseHue = baseHue;
+    this.phase = Math.random() * 9;
+    this.pos = new Float32Array(n * 3);
+    this.vel = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) {
+      this.pos[i * 3] = home.x + (Math.random() - 0.5) * radius;
+      this.pos[i * 3 + 1] = home.y + (Math.random() - 0.5) * radius * 0.5;
+      this.pos[i * 3 + 2] = home.z + (Math.random() - 0.5) * radius;
+      this.vel[i * 3] = (Math.random() - 0.5) * 4;
+      this.vel[i * 3 + 1] = (Math.random() - 0.5) * 1;
+      this.vel[i * 3 + 2] = (Math.random() - 0.5) * 4;
+    }
+    this.geo = new THREE.BufferGeometry();
+    this.geo.setAttribute('position', new THREE.BufferAttribute(this.pos, 3));
+    this.mat = new THREE.PointsMaterial({
+      size, transparent: true, opacity: 0.95, depthWrite: false,
+      blending: THREE.AdditiveBlending, sizeAttenuation: true,
+    });
+    this.mat.color.setHSL(baseHue, 0.85, 0.62);
+    this.points = new THREE.Points(this.geo, this.mat);
+    this.points.frustumCulled = false;
+    scene.add(this.points);
+  }
+
+  step(dt, t, sub, threats) {
+    const { n, pos, vel } = this;
+    const K = 7;                       // sampled neighbours per boid
+    const maxV = 8.5;
+    for (let i = 0; i < n; i++) {
+      const ix = i * 3;
+      let ax = 0, ay = 0, az = 0;
+      let cx = 0, cy = 0, cz = 0, vx = 0, vy = 0, vz = 0;
+      // sample a handful of flockmates — O(n·K), swirls just as well
+      for (let k = 0; k < K; k++) {
+        const j = ((Math.random() * n) | 0) * 3;
+        const dx = pos[j] - pos[ix], dy = pos[j + 1] - pos[ix + 1], dz = pos[j + 2] - pos[ix + 2];
+        const d2 = dx * dx + dy * dy + dz * dz;
+        if (d2 < 6) { ax -= dx; ay -= dy; az -= dz; }            // separate
+        cx += dx; cy += dy; cz += dz;                             // cohere
+        vx += vel[j]; vy += vel[j + 1]; vz += vel[j + 2];         // align
+      }
+      ax += cx * 0.012 + (vx / K - vel[ix]) * 0.18;
+      ay += cy * 0.012 + (vy / K - vel[ix + 1]) * 0.18;
+      az += cz * 0.012 + (vz / K - vel[ix + 2]) * 0.18;
+      // home spring keeps the school haunting its wreck
+      ax += (this.home.x - pos[ix]) * 0.015;
+      ay += (this.home.y - pos[ix + 1]) * 0.03;
+      az += (this.home.z - pos[ix + 2]) * 0.015;
+      // flee the sub and the eels
+      for (const th of threats) {
+        const dx = pos[ix] - th.x, dy = pos[ix + 1] - th.y, dz = pos[ix + 2] - th.z;
+        const d2 = dx * dx + dy * dy + dz * dz;
+        if (d2 < 144 && d2 > 0.01) {
+          const f = 30 / d2;
+          ax += dx * f; ay += dy * f; az += dz * f;
+        }
+      }
+      // the gyre carries everyone
+      _tmp.set(pos[ix], pos[ix + 1], pos[ix + 2]);
+      currentAt(_tmp, t, _tmp);
+      ax += _tmp.x * 0.35; ay += _tmp.y * 0.35; az += _tmp.z * 0.35;
+
+      vel[ix] += ax * dt * 4; vel[ix + 1] += ay * dt * 4; vel[ix + 2] += az * dt * 4;
+      const sp = Math.hypot(vel[ix], vel[ix + 1], vel[ix + 2]);
+      if (sp > maxV) { const f = maxV / sp; vel[ix] *= f; vel[ix + 1] *= f; vel[ix + 2] *= f; }
+      pos[ix] += vel[ix] * dt; pos[ix + 1] += vel[ix + 1] * dt; pos[ix + 2] += vel[ix + 2] * dt;
+      // stay off the mud and under the surface
+      const fy = floorYAt(pos[ix], pos[ix + 2]) + 1.5;
+      if (pos[ix + 1] < fy) { pos[ix + 1] = fy; vel[ix + 1] = Math.abs(vel[ix + 1]); }
+      if (pos[ix + 1] > -3) { pos[ix + 1] = -3; vel[ix + 1] = -Math.abs(vel[ix + 1]); }
+    }
+    this.geo.attributes.position.needsUpdate = true;
+    // neon shimmer: the whole school breathes through nearby hues
+    this.mat.color.setHSL(
+      (this.baseHue + 0.05 * Math.sin(t * 0.6 + this.phase) + 1) % 1,
+      0.85, 0.55 + 0.18 * Math.sin(t * 2.3 + this.phase));
+  }
+}
+
+// ---------------------------------------------------------------- the lot
+export class UnderwaterFX {
+  constructor(scene, opts = {}) {
+    this.scene = scene;
+    this.lite = !!opts.lite;
+    this.ir = false;
+    const q = this.lite ? 0.45 : 1;
+
+    // --- god rays: slanted additive shafts under the surface
+    this.rays = [];
+    const rayTex = rayTexture();
+    for (let i = 0; i < Math.round(11 * q); i++) {
+      const w = 5 + Math.random() * 11;
+      const m = new THREE.Mesh(
+        new THREE.PlaneGeometry(w, 62),
+        new THREE.MeshBasicMaterial({
+          map: rayTex, transparent: true, opacity: 0,
+          blending: THREE.AdditiveBlending, depthWrite: false,
+          side: THREE.DoubleSide, fog: false,
+        }));
+      m.position.set(-115 + Math.random() * 150, -30, BOUNDS.minZ + 10 + Math.random() * 140);
+      m.rotation.y = Math.random() * Math.PI;
+      m.rotation.z = 0.18 + Math.random() * 0.14;   // sun comes in aslant
+      m.userData = { phase: Math.random() * 9, base: 0.16 + Math.random() * 0.22 };
+      m.frustumCulled = false;
+      scene.add(m);
+      this.rays.push(m);
+    }
+
+    // --- motes: dust hanging in the light, brightest inside the shafts
+    this.motes = this._cloud(Math.round(420 * q), 0xfff4cc, 0.3, (i, a) => {
+      const ray = this.rays[i % Math.max(1, this.rays.length)];
+      a[i * 3] = (ray ? ray.position.x : 0) + (Math.random() - 0.5) * 14;
+      a[i * 3 + 1] = -2 - Math.random() * 30;
+      a[i * 3 + 2] = (ray ? ray.position.z : 0) + (Math.random() - 0.5) * 14;
+    }, 0.5);
+
+    // --- plankton: neon specks everywhere, vertex-coloured
+    const pn = Math.round(650 * q);
+    const pgeo = new THREE.BufferGeometry();
+    const pa = new Float32Array(pn * 3), pc = new Float32Array(pn * 3);
+    const palette = [0x33ffee, 0xff66cc, 0x66aaff, 0x9efff2, 0x88ffaa];
+    const col = new THREE.Color();
+    for (let i = 0; i < pn; i++) {
+      pa[i * 3] = BOUNDS.minX + Math.random() * (BOUNDS.maxX - BOUNDS.minX);
+      pa[i * 3 + 1] = -3 - Math.random() * 58;
+      pa[i * 3 + 2] = BOUNDS.minZ + Math.random() * (BOUNDS.maxZ - BOUNDS.minZ);
+      col.set(palette[(Math.random() * palette.length) | 0]);
+      pc[i * 3] = col.r; pc[i * 3 + 1] = col.g; pc[i * 3 + 2] = col.b;
+    }
+    pgeo.setAttribute('position', new THREE.BufferAttribute(pa, 3));
+    pgeo.setAttribute('color', new THREE.BufferAttribute(pc, 3));
+    this.plankton = new THREE.Points(pgeo, new THREE.PointsMaterial({
+      size: 0.42, vertexColors: true, transparent: true, opacity: 0.7,
+      blending: THREE.AdditiveBlending, depthWrite: false, sizeAttenuation: true,
+    }));
+    this.plankton.frustumCulled = false;
+    scene.add(this.plankton);
+
+    // --- drifting stuff: dull debris riding the gyre
+    this.debris = this._cloud(Math.round(240 * q), 0xa8926a, 0.5, (i, a) => {
+      a[i * 3] = BOUNDS.minX + Math.random() * (BOUNDS.maxX - BOUNDS.minX);
+      a[i * 3 + 1] = -4 - Math.random() * 55;
+      a[i * 3 + 2] = BOUNDS.minZ + Math.random() * (BOUNDS.maxZ - BOUNDS.minZ);
+    }, 0.35);
+
+    // --- fish: three schools, each haunting a wreck
+    this.schools = [
+      new School(scene, Math.round(130 * q), new THREE.Vector3(-40, -26, 30), 26, 0.5, 0.6),  // cyan, barge
+      new School(scene, Math.round(110 * q), new THREE.Vector3(60, -50, 40), 22, 0.12, 0.55), // gold, crane
+      new School(scene, Math.round(100 * q), new THREE.Vector3(85, -52, -30), 22, 0.87, 0.6), // pink, warehouse
+    ];
+
+    // --- vents: bubble columns off the dock floor
+    this.vents = [];
+    for (const [vx, vz] of [[-20, -12], [64, 18], [-62, -58]]) {
+      const vy = floorYAt(vx, vz);
+      const v = this._cloud(Math.round(70 * q), 0xcdf6ff, 0.35, (i, a) => {
+        a[i * 3] = vx + (Math.random() - 0.5) * 2.5;
+        a[i * 3 + 1] = vy + Math.random() * 34;
+        a[i * 3 + 2] = vz + (Math.random() - 0.5) * 2.5;
+      }, 0.5);
+      v.userData = { vx, vy, vz };
+      this.vents.push(v);
+    }
+
+    // --- heat plumes: born cold, only visible in IR
+    this.plumes = this._cloud(Math.round(160 * q), 0xffcc66, 0.7, (i, a) => {
+      a[i * 3] = 0; a[i * 3 + 1] = -200; a[i * 3 + 2] = 0;   // parked offscreen
+    }, 0.0);
+    this._plumeAge = new Float32Array(this.plumes.geometry.attributes.position.count).map(() => Math.random() * 3);
+  }
+
+  _cloud(count, color, size, fill, opacity) {
+    const geo = new THREE.BufferGeometry();
+    const a = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) fill(i, a);
+    geo.setAttribute('position', new THREE.BufferAttribute(a, 3));
+    const p = new THREE.Points(geo, new THREE.PointsMaterial({
+      color, size, transparent: true, opacity,
+      blending: THREE.AdditiveBlending, depthWrite: false, sizeAttenuation: true,
+    }));
+    p.frustumCulled = false;
+    this.scene.add(p);
+    return p;
+  }
+
+  // hotSpots: [{x,y,z}] — fatbergs and the sub's engine, fed by game.js
+  step(dt, t, subPos, threats, camDepth, hotSpots = []) {
+    // god rays live near the surface and die with depth
+    const depthFade = Math.max(0, Math.min(1, 1 - (camDepth - 10) / 34));
+    for (const r of this.rays) {
+      const u = r.userData;
+      r.material.opacity = this.ir ? 0
+        : u.base * depthFade * (0.55 + 0.45 * Math.sin(t * 0.3 + u.phase));
+      r.rotation.y += dt * 0.02;
+    }
+
+    // motes rise gently and twinkle as one
+    this._drift(this.motes, dt, t, 0.35, 0.55);
+    this.motes.material.opacity = this.ir ? 0.05
+      : depthFade * (0.35 + 0.2 * Math.sin(t * 1.7));
+
+    this._drift(this.plankton, dt, t, 0.5, 0);
+    this.plankton.material.opacity = this.ir ? 0.08 : 0.55 + 0.25 * Math.sin(t * 0.9);
+
+    this._drift(this.debris, dt, t, 1.0, 0);
+
+    for (const s of this.schools) s.step(dt, t, subPos, threats);
+
+    // vent bubbles rise and recycle
+    for (const v of this.vents) {
+      const pos = v.geometry.attributes.position;
+      const { vx, vy, vz } = v.userData;
+      for (let i = 0; i < pos.count; i++) {
+        let y = pos.getY(i) + dt * (3.5 + (i % 5) * 0.5);
+        if (y > vy + 36) {
+          y = vy + Math.random() * 2;
+          pos.setX(i, vx + (Math.random() - 0.5) * 2.5);
+          pos.setZ(i, vz + (Math.random() - 0.5) * 2.5);
+        }
+        pos.setY(i, y);
+      }
+      pos.needsUpdate = true;
+    }
+
+    // heat plumes: only fed while IR is on
+    if (this.ir && hotSpots.length) {
+      const pos = this.plumes.geometry.attributes.position;
+      for (let i = 0; i < pos.count; i++) {
+        this._plumeAge[i] += dt;
+        if (this._plumeAge[i] > 3) {
+          this._plumeAge[i] = 0;
+          const h = hotSpots[i % hotSpots.length];
+          pos.setXYZ(i, h.x + (Math.random() - 0.5) * 2, h.y + 1, h.z + (Math.random() - 0.5) * 2);
+        } else {
+          pos.setY(i, pos.getY(i) + dt * 2.2);
+          pos.setX(i, pos.getX(i) + Math.sin(t * 3 + i) * dt * 0.4);
+        }
+      }
+      pos.needsUpdate = true;
+      this.plumes.material.opacity = 0.5;
+    } else {
+      this.plumes.material.opacity = 0;
+    }
+  }
+
+  _drift(points, dt, t, carry, rise) {
+    const pos = points.geometry.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+      _tmp.set(pos.getX(i), pos.getY(i), pos.getZ(i));
+      const p = _tmp.clone();
+      currentAt(p, t, _tmp);
+      let x = p.x + _tmp.x * carry * dt;
+      let y = p.y + (_tmp.y * carry + rise) * dt;
+      let z = p.z + _tmp.z * carry * dt;
+      if (x < BOUNDS.minX) x = BOUNDS.maxX; if (x > BOUNDS.maxX) x = BOUNDS.minX;
+      if (z < BOUNDS.minZ) z = BOUNDS.maxZ; if (z > BOUNDS.maxZ) z = BOUNDS.minZ;
+      if (y > -2) y = -58; if (y < -60) y = -3;
+      pos.setXYZ(i, x, y, z);
+    }
+    pos.needsUpdate = true;
+  }
+
+  setIR(on) { this.ir = on; }
+}

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -8,12 +8,14 @@ import * as THREE from '../../../trees/vendor/three.module.min.js';
 import {
   P8, mat, buildDock, makeSub, makeEelHead, makeEelSegment, makeFatberg,
   makeMine, makeSalvageMesh, makeQuestMesh, makeParticleCloud,
-  makeGhostWhale, BOUNDS, SHELF_Y, DEEP_Y, floorYAt,
+  makeGhostWhale, BOUNDS, SHELF_Y, DEEP_Y, floorYAt, neonize,
 } from './world.js';
+import { UnderwaterFX, glowSprite, currentAt } from './fx.js';
 import { FACTS, QUEST_ITEMS, TOOLS, HINTS } from './facts.js';
 
 const AIR_MAX = 100;
 const HULL_MAX = 4;
+const _cur = new THREE.Vector3();
 
 export class WaterworldGame {
   // ui: { hud(state), toast(text, cls), fact(title, text, icon),
@@ -76,6 +78,17 @@ export class WaterworldGame {
 
     this.sub = makeSub();
     this.sub.position.copy(this.pos);
+    neonize(this.sub, 0xffec27, { keepFaces: true });
+    this.sub.userData.irColor = 0xbb5533;          // a warm engine in the dark
+    // the visible beam: an additive cone the headlamp appears to cast
+    this.lightCone = new THREE.Mesh(
+      new THREE.ConeGeometry(3.6, 16, 10, 1, true),
+      new THREE.MeshBasicMaterial({ color: 0xcfe8ff, transparent: true, opacity: 0.06,
+        blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide, fog: false }));
+    this.lightCone.rotation.z = Math.PI / 2;       // apex forward at the nose
+    this.lightCone.position.set(10.5, 0, 0);
+    this.lightCone.userData.noNeon = true;
+    this.sub.add(this.lightCone);
     this.scene.add(this.sub);
     this.headlamp = new THREE.SpotLight(0xfff1e8, 0, 60, 0.5, 0.4);
     this.headlamp.position.set(2, 0, 0);
@@ -101,6 +114,12 @@ export class WaterworldGame {
     this.snow = makeParticleCloud(this.lite ? 150 : 500, 0x99bbdd, 0.35, 180);
     this.snow.position.y = -30;
     this.scene.add(this.snow);
+
+    // the living water: currents, fish, god rays, plankton, vents, plumes
+    this.fx = new UnderwaterFX(this.scene, { lite: this.lite });
+    this.ir = false;
+    this._irMats = new Map();
+    this._irUsedOnce = false;
     this.bubbles = [];
     this._bubbleT = 0;
 
@@ -109,9 +128,18 @@ export class WaterworldGame {
       new THREE.TorusGeometry(1, 0.12, 4, 24),
       mat(P8.blue, { emissive: 0x1155aa, transparent: true, opacity: 0.9 }));
     this.pingRing.visible = false;
+    this.pingRing.userData.irSkip = true;
     this.scene.add(this.pingRing);
     this._pingAge = 99;
     this.glints = [];
+
+    // the bell is the warm heart of the dive — let it read that way
+    const bellGlow = glowSprite(0xffec27, 11, 0.5);
+    bellGlow.userData.irHot = true;
+    bellGlow.position.y = -1;
+    this.dock.bell.add(bellGlow);
+    this.dock.bell.userData.irColor = 0xffaa44;
+    this.lightCone.userData.irSkip = true;
 
     this.resize();
     this.render();
@@ -134,6 +162,12 @@ export class WaterworldGame {
       const g = makeSalvageMesh(type);
       g.position.set(x, y, z);
       g.rotation.y = Math.random() * Math.PI * 2;
+      const halo = glowSprite(
+        type === 'captains_chest' ? 0xffec27 : type === 'fatberg_relic' ? 0xffccaa : 0xaef0ff,
+        type === 'captains_chest' ? 4.5 : 2.0,
+        type === 'captains_chest' ? 0.6 : 0.3);
+      halo.position.y = 0.8;
+      g.add(halo);
       this.scene.add(g);
       this.salvage.push({ type, mesh: g, collected: false,
         heavy: !!opts.heavy, hidden: !!opts.hidden,
@@ -161,6 +195,9 @@ export class WaterworldGame {
     const put = (id, x, z, y) => {
       const g = makeQuestMesh();
       g.position.set(x, y ?? floorYAt(x, z) + 0.3, z);
+      const halo = glowSprite(0xff77a8, 3.2, 0.45);
+      halo.position.y = 0.7;
+      g.add(halo);
       this.scene.add(g);
       this.quest.push({ id, mesh: g, taken: false });
     };
@@ -178,13 +215,22 @@ export class WaterworldGame {
     this.eels = this.eels || [];
     for (let i = 0; i < n; i++) {
       const head = makeEelHead();
+      neonize(head, 0x00e436);
+      head.userData.irColor = 0x38506e;         // cold-blooded: a faint trace
+      const eyeGlow = glowSprite(0xff004d, 1.6, 0.6);
+      eyeGlow.position.set(-0.2, 0.45, 0);
+      eyeGlow.userData.irHot = true;
+      head.add(eyeGlow);
       const segs = [];
       for (let s = 0; s < 6; s++) {
         const m = makeEelSegment(s);
+        neonize(m, 0x00e436);
+        m.userData.irColor = 0x38506e;
         this.scene.add(m);
         segs.push(m);
       }
       this.scene.add(head);
+      if (this.ir) { this._irApply(head); segs.forEach(s => this._irApply(s)); }
       const cx = 30 + Math.random() * 70, cz = (Math.random() - 0.5) * 120;
       this.eels.push({
         head, segs,
@@ -203,6 +249,13 @@ export class WaterworldGame {
     const spots = [[45, -50], [70, 10], [95, -10], [60, 55], [110, 30]];
     for (const [x, z] of spots) {
       const m = makeMine();
+      neonize(m, 0xff004d);
+      m.userData.irColor = 0x8a4a33;             // old explosive, faintly warm
+      const blink = glowSprite(0xff004d, 1.6, 0.35);
+      blink.position.y = 1.4;
+      blink.userData.irHot = true;
+      m.add(blink);
+      m.userData.blink = blink;
       const y = floorYAt(x, z) + 5 + Math.random() * 6;
       m.position.set(x, y, z);
       this.scene.add(m);
@@ -219,6 +272,8 @@ export class WaterworldGame {
     // one parked in each culvert mouth, blocking it
     for (const mouth of this.dock.culverts) {
       const f = makeFatberg(4.2);
+      neonize(f, 0xffccaa, { keepFaces: true });
+      f.userData.irColor = 0xffdd66;             // decomposition runs HOT
       f.position.set(mouth.x, mouth.y + 1, mouth.z + 2);
       this.scene.add(f);
       this.fatbergs.push({ mesh: f, hp: 3, r: 4.5, blocking: true,
@@ -229,8 +284,11 @@ export class WaterworldGame {
   _spawnRampantFatberg() {
     const mouth = this.dock.culverts[Math.floor(Math.random() * this.dock.culverts.length)];
     const f = makeFatberg(2.6);
+    neonize(f, 0xffccaa, { keepFaces: true });
+    f.userData.irColor = 0xffdd66;
     f.position.set(mouth.x, mouth.y + 2, mouth.z + 6);
     this.scene.add(f);
+    if (this.ir) this._irApply(f);
     const away = new THREE.Vector3(Math.random() - 0.5, 0.1, 0.8).normalize().multiplyScalar(2.2);
     this.fatbergs.push({ mesh: f, hp: 2, r: 2.8, blocking: false, vel: away,
       wobble: Math.random() * 9 });
@@ -242,6 +300,74 @@ export class WaterworldGame {
   setKey(k, down) {
     if (k in this.keys) this.keys[k] = down;
     if (k === 'b' && down) this._doPing();
+  }
+
+  // ------------------------------------------------------------- IR mode
+  // Thermal sight: every mesh drops to a cold navy silhouette unless
+  // something tagged it with a temperature (userData.irColor, inherited
+  // down the subtree). Fatbergs blaze — decomposition runs warm — the
+  // sub's engine glows, old explosives smoulder, eels barely register
+  // (cold-blooded), and the ghost whale shows as a COLD blue void.
+  _irMat(color) {
+    if (!this._irMats.has(color)) {
+      this._irMats.set(color, new THREE.MeshBasicMaterial({ color }));
+    }
+    return this._irMats.get(color);
+  }
+
+  _irColorFor(o) {
+    let n = o;
+    while (n) {
+      if (n.userData && n.userData.irColor) return n.userData.irColor;
+      n = n.parent;
+    }
+    return null;
+  }
+
+  _irApply(root) {
+    root.traverse((o) => {
+      if (o.userData && o.userData.irSkip) return;
+      if (o.isLineSegments) {
+        if (o.visible) { o.userData._irHid = true; o.visible = false; }
+      } else if (o.isSprite) {
+        if (!o.userData.irHot && o.visible) { o.userData._irHid = true; o.visible = false; }
+      } else if (o.isMesh) {
+        if (!o.userData._origMat) o.userData._origMat = o.material;
+        o.material = this._irMat(this._irColorFor(o) ?? 0x0a1224);
+      }
+    });
+  }
+
+  _irRestore(root) {
+    root.traverse((o) => {
+      if (o.userData && o.userData._irHid) { o.visible = true; delete o.userData._irHid; }
+      if (o.isMesh && o.userData._origMat) {
+        o.material = o.userData._origMat;
+        delete o.userData._origMat;
+      }
+    });
+  }
+
+  toggleIR() {
+    this.ir = !this.ir;
+    this.fx.setIR(this.ir);
+    if (this.ir) {
+      this._irApply(this.scene);
+      this.whale.material.color.set(0x3366ff);
+      this.ui.toast('▣ THERMAL SIGHT', 'warn');
+      if (!this._irUsedOnce) {
+        this._irUsedOnce = true;
+        this.ui.fact('THERMAL EYE',
+          'Decomposing fat runs warm — sewer crews find fatbergs by their heat. Ghosts, of course, run cold.',
+          '🌡️');
+      }
+      this.ui.announce('Thermal view on. Warm things glow; the water goes dark.');
+    } else {
+      this._irRestore(this.scene);
+      this.whale.material.color.set(0xc8f0ff);
+      this.ui.toast('▢ THERMAL OFF', 'hint');
+      this.ui.announce('Thermal view off.');
+    }
   }
 
   // ------------------------------------------------------------- actions
@@ -443,6 +569,8 @@ export class WaterworldGame {
     this.vel.addScaledVector(fwd, thrust * dt);
     this.vel.multiplyScalar(Math.pow(0.14, dt));            // water drag
     this.vel.y += Math.sin(this.elapsed * 0.8) * 0.06 * dt; // gentle swell
+    currentAt(this.pos, this.elapsed, _cur);                 // the gyre tugs
+    this.vel.addScaledVector(_cur, 0.35 * dt);
     this.pos.addScaledVector(this.vel, dt);
 
     // -------- containment: walls, floor, surface
@@ -475,13 +603,29 @@ export class WaterworldGame {
 
     // -------- fog and light by depth (the deep is DARK without the lamp)
     const depth = -this.pos.y;
-    const deepT = Math.min(1, Math.max(0, (depth - 25) / 40));
-    const fogC = new THREE.Color(P8.navy).lerp(new THREE.Color(P8.black), deepT * 0.9);
-    this.scene.fog.color.copy(fogC);
-    this.scene.background.copy(fogC);
-    const lampBoost = this.tools.has('arclamp') ? 0.45 : 1;
-    this.scene.fog.density = (0.018 + deepT * 0.03 * lampBoost);
+    if (this.ir) {
+      // heat sees through the murk: near-black, unusually clear
+      this.scene.fog.color.set(0x000308);
+      this.scene.background.set(0x000308);
+      this.scene.fog.density = 0.011;
+    } else {
+      const deepT = Math.min(1, Math.max(0, (depth - 25) / 40));
+      const fogC = new THREE.Color(P8.navy).lerp(new THREE.Color(P8.black), deepT * 0.9);
+      this.scene.fog.color.copy(fogC);
+      this.scene.background.copy(fogC);
+      const lampBoost = this.tools.has('arclamp') ? 0.45 : 1;
+      this.scene.fog.density = (0.018 + deepT * 0.03 * lampBoost);
+    }
     if (!this.tools.has('arclamp')) this.headlamp.intensity = 40;
+    this.lightCone.material.opacity = this.ir ? 0
+      : (this.tools.has('arclamp') ? 0.13 : 0.06);
+
+    // -------- the living water
+    const threats = [this.pos, ...this.eels.map(e => e.pos)];
+    const hot = this.ir
+      ? [...this.fatbergs.map(f => f.mesh.position), this.pos]
+      : [];
+    this.fx.step(dt, this.elapsed, this.pos, threats, -this.camera.position.y, hot);
 
     // -------- air + hull economy
     this.air -= dt * (k.a ? 1.7 : 1.1) * (1 + this.banks * 0.06);
@@ -562,6 +706,7 @@ export class WaterworldGame {
       tools: [...this.tools],
       codex: this.codex.size, codexTotal: Object.keys(FACTS).length,
       whale: this.whaleActive, chest: this.hasChest, over: this.over, won: this.won,
+      ir: this.ir,
     };
   }
 
@@ -676,6 +821,11 @@ export class WaterworldGame {
       if (!m.live) continue;
       m.mesh.rotation.y += dt * 0.4;
       const d = m.mesh.position.distanceTo(this.pos);
+      const blink = m.mesh.userData.blink;
+      if (blink) {
+        blink.material.opacity = 0.2 +
+          0.5 * Math.abs(Math.sin(this.elapsed * (d < 8 ? 7 : 1.6)));
+      }
       if (d < 3.2) this._detonate(m, true);
       else if (d < 8) {
         m.beep -= dt;
@@ -699,9 +849,10 @@ export class WaterworldGame {
     if (dist > 1) this.whale.position.addScaledVector(dir.normalize(), Math.min(6, dist) * dt * 0.9);
     this.whale.lookAt(target);
     this.whale.rotateY(-Math.PI / 2);
-    // fade in, breathe
+    // fade in, breathe (in thermal sight she is a steady cold presence)
     const m = this.whale.material;
-    m.opacity = Math.min(0.75, m.opacity + dt * 0.2) * (0.8 + Math.sin(this.whalePhase * 1.3) * 0.2);
+    const ceiling = this.ir ? 0.95 : 0.75;
+    m.opacity = Math.min(ceiling, m.opacity + dt * 0.2) * (0.8 + Math.sin(this.whalePhase * 1.3) * 0.2);
     // tail swish: displace the base positions a little
     const pos = this.whale.geometry.attributes.position, base = this.whale.userData.base;
     for (let i = 0; i < pos.count; i++) {
@@ -718,6 +869,7 @@ export class WaterworldGame {
 
   _stepParticles(dt) {
     // marine snow drifts down and wraps
+    this.snow.material.opacity = this.ir ? 0.12 : 0.8;
     const sp = this.snow.geometry.attributes.position;
     for (let i = 0; i < sp.count; i++) {
       let y = sp.getY(i) - dt * 1.1;

--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -61,6 +61,9 @@ function hud(s) {
     ...s.items.map(i => ({ magnet: '🧲', rope: '🪢', lamp: '🏮', battery: '🔋', soda: '📦', nozzle: '🔩' }[i] || '❓')),
   ];
   $('inv').textContent = held.join(' ') || '·';
+  const irBtn = $('ir-btn');
+  irBtn.classList.toggle('on', !!s.ir);
+  irBtn.setAttribute('aria-pressed', String(!!s.ir));
 }
 
 function complete(result) {
@@ -115,6 +118,7 @@ function setAction(action, down, fromRepeat) {
 }
 document.addEventListener('keydown', (e) => {
   if (!started && (e.key === ' ' || e.key === 'Enter')) { startGame(); return; }
+  if ((e.key === 'i' || e.key === 'I') && !e.repeat) { game?.toggleIR(); return; }
   const action = KEYMAP[e.key] ?? KEYMAP[e.key?.toLowerCase?.()];
   if (!action) return;
   if (e.key !== 'Escape') e.preventDefault?.();
@@ -179,6 +183,7 @@ function startGame() {
 }
 
 $('splash').addEventListener('pointerdown', startGame);
+$('ir-btn').addEventListener('pointerdown', (e) => { e.stopPropagation(); game?.toggleIR(); });
 $('endcard').addEventListener('pointerdown', () => {
   if (!EMBED && game?.over) location.reload();
 });

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -35,6 +35,42 @@ export function cyl(parent, rt, rb, h, color, x = 0, y = 0, z = 0, seg = 6) {
   return m;
 }
 
+// Neon treatment: darken the faces to near-silhouette and trace every
+// hard edge with an additive glowing line. Structures become mysterious
+// shapes drawn in light; the particles do the rest of the talking.
+const _lineMats = new Map();
+function lineMat(color) {
+  if (!_lineMats.has(color)) {
+    _lineMats.set(color, new THREE.LineBasicMaterial({
+      color, transparent: true, opacity: 0.85,
+      blending: THREE.AdditiveBlending, depthWrite: false,
+    }));
+  }
+  return _lineMats.get(color);
+}
+const _darkMats = new Map();
+function darkMat(srcColor) {
+  const c = new THREE.Color(srcColor).multiplyScalar(0.22).getHex();
+  if (!_darkMats.has(c)) {
+    _darkMats.set(c, new THREE.MeshLambertMaterial({ color: c, flatShading: true }));
+  }
+  return _darkMats.get(c);
+}
+
+export function neonize(root, edgeColor, { keepFaces = false } = {}) {
+  root.traverse((o) => {
+    if (!o.isMesh || o.userData.noNeon || o.isLineSegments) return;
+    if (!keepFaces && o.material && o.material.color) {
+      o.material = darkMat(o.material.color.getHex());
+    }
+    const edges = new THREE.LineSegments(
+      new THREE.EdgesGeometry(o.geometry, 20), lineMat(edgeColor));
+    edges.userData.noNeon = true;
+    o.add(edges);
+  });
+  return root;
+}
+
 // Chunk a geometry: snap vertices to a coarse grid so even curved
 // primitives read as hand-placed picoCAD verts.
 export function crunch(geo, step = 0.5) {
@@ -199,8 +235,8 @@ function makeFloor(scene) {
     const x = pos.getX(i), z = pos.getZ(i);
     pos.setY(i, floorYAt(x, z) - 0.4);
     const t = Math.min(1, Math.max(0, (x - 10) / 60));
-    const c = silt.clone().lerp(deep, t);
-    if (Math.sin(x * 1.7 + z * 2.3) > 0.93) c.copy(weed);
+    const c = silt.clone().lerp(deep, t).multiplyScalar(0.5);   // let the neon lead
+    if (Math.sin(x * 1.7 + z * 2.3) > 0.93) c.copy(weed).multiplyScalar(0.7);
     colors.push(c.r, c.g, c.b);
   }
   geo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
@@ -329,15 +365,18 @@ function makeCrates(scene) {
 }
 
 // Kelp/weed: thin green boxes waving — cheap, sells "underwater" hard.
-export function makeWeeds(scene) {
+export function makeWeeds(scene, count = 110) {
   const g = new THREE.Group();
   const stalks = [];
-  for (let i = 0; i < 60; i++) {
+  for (let i = 0; i < count; i++) {
     const x = BOUNDS.minX + Math.random() * (BOUNDS.maxX - BOUNDS.minX);
     const z = BOUNDS.minZ + Math.random() * (BOUNDS.maxZ - BOUNDS.minZ);
-    const h = 3 + Math.random() * 6;
-    const s = box(g, 0.4, h, 0.4, Math.random() > 0.5 ? P8.green : P8.lime,
-      x, floorYAt(x, z) + h / 2, z);
+    const h = 3 + Math.random() * 8;
+    const s = new THREE.Mesh(new THREE.BoxGeometry(0.4, h, 0.4),
+      mat(Math.random() > 0.5 ? P8.green : P8.lime,
+        { emissive: Math.random() > 0.5 ? 0x0a3d22 : 0x123d0a }));
+    s.position.set(x, floorYAt(x, z) + h / 2, z);
+    g.add(s);
     s.userData.phase = Math.random() * Math.PI * 2;
     stalks.push(s);
   }
@@ -348,14 +387,22 @@ export function makeWeeds(scene) {
 // The whole static set. Returns collider list for the physics step.
 export function buildDock(scene) {
   makeFloor(scene);
-  makeQuayWalls(scene);
+  const quay = makeQuayWalls(scene);
   const culverts = makeCulverts(scene);
   const crane = makeCrane(scene);
   const barge = makeBarge(scene);
   const warehouse = makeWarehouse(scene);
   const bell = makeDivingBell(scene);
-  makeCrates(scene);
+  const crates = makeCrates(scene);
   const weeds = makeWeeds(scene);
+  // the neon pass: each structure family gets its own signature glow
+  neonize(quay, 0x1d6f8f);
+  for (const m of culverts) neonize(m.group, 0x00e436);
+  neonize(crane, 0xffa300);
+  neonize(barge, 0xff77a8);
+  neonize(warehouse, 0x83769c);
+  neonize(crates, 0x8f6a30);
+  neonize(bell, 0xffec27, { keepFaces: true });
   // sphere colliders for the big set pieces (cheap, forgiving)
   const colliders = [
     { x: 60, y: DEEP_Y + 8, z: 40, r: 9 },       // crane base

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -127,6 +127,39 @@ try {
   if (eelDelta > 1) pass(`eel gave chase (closed ${eelDelta.toFixed(1)} units)`);
   else fail(`eel did not chase (delta ${eelDelta.toFixed(2)})`);
 
+  // the living water: fish schools must exist and actually swirl
+  const fish = await page.evaluate(async () => {
+    const fx = window.__waterworld.game.fx;
+    const p0 = fx.schools[0].pos[0];
+    await new Promise(r => setTimeout(r, 800));
+    return { schools: fx.schools.length, moved: Math.abs(fx.schools[0].pos[0] - p0) };
+  });
+  if (fish.schools >= 2 && fish.moved > 0.01) pass(`fish schools swirling (${fish.schools} schools)`);
+  else fail(`boids inert: ${JSON.stringify(fish)}`);
+
+  // IR mode: toggle on via the real key, hot things read hot, toggle off
+  await page.keyboard.press('i');
+  const ir = await page.evaluate(() => {
+    const g = window.__waterworld.game;
+    return {
+      on: g.ir, fxIr: g.fx.ir,
+      fatbergHot: g.fatbergs[0].mesh.material.color.getHex(),
+      fogDark: g.scene.fog.color.getHex(),
+    };
+  });
+  if (ir.on && ir.fxIr) pass('IR toggled on via I key');
+  else fail('IR did not toggle: ' + JSON.stringify(ir));
+  if (ir.fatbergHot === 0xffdd66) pass('fatberg reads hot in IR');
+  else fail(`fatberg not hot in IR: ${ir.fatbergHot.toString(16)}`);
+  if (SHOTS) await page.screenshot({ path: join(SHOTDIR, 'waterworld-ir.png') });
+  await page.keyboard.press('i');
+  const irOff = await page.evaluate(() => {
+    const g = window.__waterworld.game;
+    return { on: g.ir, restored: g.fatbergs[0].mesh.material.color.getHex() !== 0xffdd66 };
+  });
+  if (!irOff.on && irOff.restored) pass('IR toggled off, materials restored');
+  else fail('IR restore broken: ' + JSON.stringify(irOff));
+
   if (SHOTS) {
     await page.screenshot({ path: join(SHOTDIR, 'waterworld-play.png') });
     pass(`screenshot → ${SHOTDIR}/waterworld-play.png`);

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -42,7 +42,7 @@
   #hud {
     position: absolute; top: 0; left: 0; right: 0;
     display: flex; flex-wrap: wrap; align-items: center; gap: 0.5em 1em;
-    padding: max(0.4em, env(safe-area-inset-top)) 0.7em 0.4em;
+    padding: max(0.4em, env(safe-area-inset-top)) 4.5em 0.4em 0.7em;
     font-size: clamp(11px, 2.4vmin, 16px);
     letter-spacing: 0.06em;
     color: #ffec27;
@@ -59,6 +59,21 @@
   @keyframes blink { 50% { opacity: 0.35; } }
   #hull { color: #ff77a8; }
   #inv { color: #ffccaa; }
+  #ir-btn {
+    position: absolute;
+    top: max(0.4em, env(safe-area-inset-top));
+    right: 0.7em;
+    z-index: 21;
+    font: inherit; font-size: clamp(10px, 2.2vmin, 14px); letter-spacing: 0.1em;
+    background: rgba(0,0,0,0.5); color: #83769c;
+    border: 1px solid #83769c; padding: 0.15em 0.6em;
+    min-width: 44px; min-height: 28px; cursor: pointer;
+  }
+  #ir-btn.on {
+    color: #ffa300; border-color: #ffa300;
+    box-shadow: 0 0 8px rgba(255,163,0,0.6);
+  }
+  #ir-btn:focus-visible { outline: 2px solid #29adff; outline-offset: 2px; }
 
   /* ------- toasts + facts ------- */
   #toasts {
@@ -171,6 +186,7 @@
     <span id="codex">📖0/12</span>
     <span id="inv">·</span>
   </div>
+  <button id="ir-btn" type="button" aria-label="toggle thermal sight" aria-pressed="false">IR</button>
 
   <div id="toasts"></div>
 
@@ -185,7 +201,7 @@
     <p>— DOCKLANDS DEEP —</p>
     <p>The old dock flooded a century ago and kept everything it swallowed.
        Pilot the sub. Ping the dark. Raise what London lost.</p>
-    <p>STEER: pad · THRUST: A · SONAR/TOOL: B<br>
+    <p>STEER: pad · THRUST: A · SONAR/TOOL: B · THERMAL: I / IR<br>
        Bank salvage at the diving bell before your air runs out.</p>
     <p class="press">▶ PRESS A OR TAP TO DIVE ◀</p>
   </div>


### PR DESCRIPTION
Visual evolution of Waterworld from blocky picoCAD to a neon, shimmering, particle-based universe — gameplay loop unchanged.

- **Neon pass:** structures become near-silhouettes traced in additive glowing edges, one signature colour per family; salvage/quest/mines/eel-eyes get additive halos; the sub casts a visible beam cone.
- **The living water (`js/fx.js`):** a basin-wide gyre current carries three boid fish schools (shimmering hue-cycling point clouds that flee the sub and eels), neon plankton, drifting debris and vent bubble columns. God rays slant down from the surface, full of drifting dust motes, fading with depth. The gyre also tugs the sub.
- **IR thermal sight** (I key / HUD IR button): near-black clear water, cold navy silhouettes, heat where heat belongs — fatbergs blaze (decomposition runs warm; codex fact on first use), engine glows, mines smoulder, cold-blooded eels barely register, and the ghost whale reads as a cold blue void. Heat plumes rise off warm sources; toggling restores every material; late spawns inherit the mode.

Tests: playtest grows fish-swirl + IR toggle/restore assertions; shell e2e, html-validate, standalone suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_