### PR TITLE
Waterworld: mobile-first UX — guide arrow, ship's log, cheery presentation

### DIFF
--- a/magpie/waterworld/js/audio.js
+++ b/magpie/waterworld/js/audio.js
@@ -96,11 +96,11 @@ export class WaterAudio {
   }
 
   _startMusic() {
-    // a shy pentatonic music box: minor penta on D, tape-wobbled
-    const scale = [146.83, 174.61, 196.0, 220.0, 261.63, 293.66, 349.23];
+    // a sunny pentatonic music box: major penta on C, tape-wobbled
+    const scale = [261.63, 293.66, 329.63, 392.0, 440.0, 523.25, 587.33];
     const step = () => {
       if (!this.ctx || this.ctx.state !== 'running') return;
-      if (Math.random() < 0.65) {
+      if (Math.random() < 0.75) {
         const f = scale[Math.floor(Math.random() * scale.length)];
         const t = this._now();
         const { o, g } = this._osc('triangle', f, this.echo);
@@ -113,7 +113,7 @@ export class WaterAudio {
         o.start(t); o.stop(t + 2); wob.stop(t + 2);
       }
     };
-    this._musicTimer = setInterval(step, 900);
+    this._musicTimer = setInterval(step, 700);
   }
 
   stopMusic() { if (this._musicTimer) clearInterval(this._musicTimer); this._musicTimer = null; }

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -68,9 +68,9 @@ export class WaterworldGame {
     this.scene.fog = new THREE.FogExp2(P8.navy, 0.02);
     this.camera = new THREE.PerspectiveCamera(70, 16 / 9, 0.1, 400);
 
-    // light through water: cool hemisphere + a weak sun shaft
-    this.scene.add(new THREE.HemisphereLight(0x66aaff, 0x0a1030, 1.1));
-    const sun = new THREE.DirectionalLight(0xaaddff, 0.9);
+    // light through water: a friendly bright blue, dimming with depth
+    this.scene.add(new THREE.HemisphereLight(0x77bbff, 0x102048, 1.35));
+    const sun = new THREE.DirectionalLight(0xbbe6ff, 1.0);
     sun.position.set(20, 80, 10);
     this.scene.add(sun);
 
@@ -492,7 +492,7 @@ export class WaterworldGame {
     this.air = AIR_MAX;
     this.banks++;
     this.ui.audio?.bank(n);
-    this.ui.toast(`⬆ BANKED ×${n}  +${gained}${mult > 1 ? `  (×${mult.toFixed(2)})` : ''}`, 'gold');
+    this.ui.toast(`🎉 BANKED ×${n}  +${gained}${mult > 1 ? `  (×${mult.toFixed(2)} haul bonus!)` : ''}`, 'gold');
     this.ui.announce(`Banked ${n} items for ${gained} points. Air refilled.`);
     if (hadChest) { this._win(); return; }
     // banking stirs the dock: more eels, and eventually the fatbergs move
@@ -610,11 +610,13 @@ export class WaterworldGame {
       this.scene.fog.density = 0.011;
     } else {
       const deepT = Math.min(1, Math.max(0, (depth - 25) / 40));
-      const fogC = new THREE.Color(P8.navy).lerp(new THREE.Color(P8.black), deepT * 0.9);
+      const fogC = new THREE.Color(P8.navy)
+        .lerp(new THREE.Color(P8.blue), 0.30 * (1 - deepT))   // cheery shallows
+        .lerp(new THREE.Color(P8.black), deepT * 0.85);
       this.scene.fog.color.copy(fogC);
       this.scene.background.copy(fogC);
       const lampBoost = this.tools.has('arclamp') ? 0.45 : 1;
-      this.scene.fog.density = (0.018 + deepT * 0.03 * lampBoost);
+      this.scene.fog.density = (0.016 + deepT * 0.03 * lampBoost);
     }
     if (!this.tools.has('arclamp')) this.headlamp.intensity = 40;
     this.lightCone.material.opacity = this.ir ? 0
@@ -684,7 +686,7 @@ export class WaterworldGame {
       const f = FACTS[type];
       this._factShowing = true;
       this.ui.fact(f.name.toUpperCase(), f.text, f.icon);
-      setTimeout(() => { this._factShowing = false; }, 5200);
+      setTimeout(() => { this._factShowing = false; }, 9500);
     }
     this._hintTimer -= dt;
     if (this._hintTimer < 0) {
@@ -696,8 +698,63 @@ export class WaterworldGame {
     this.ui.hud(this.hudState());
   }
 
+  // The objective: one line, always on screen, with a live arrow. The
+  // player should never wonder what to do next or which way to swim.
+  _objective() {
+    if (this.over) return null;
+    const bell = this.dock.bell.position;
+    const nearest = (list) => {
+      let best = null, bd = 1e9;
+      for (const it of list) {
+        const d = it.mesh.position.distanceTo(this.pos);
+        if (d < bd) { bd = d; best = it; }
+      }
+      return best;
+    };
+    const carryingChest = this.hasChest || this.cargo.some(c => c.type === 'captains_chest');
+    if (carryingChest) return { icon: '🏴‍☠️', text: 'Bank the chest at the bell!', target: bell };
+    if (this.air < 30) return { icon: '💨', text: 'Air low — swim to the bell!', target: bell };
+    if (this.whaleActive) {
+      if (!this.tools.has('grapple')) {
+        const part = nearest(this.quest.filter(q => !q.taken && (q.id === 'magnet' || q.id === 'rope')));
+        if (part) return { icon: '🪝', text: 'Craft a grapple: find magnet + rope', target: part.mesh.position };
+      }
+      return { icon: '🐋', text: 'Follow the whale to the chest!', target: this.chest.mesh.position };
+    }
+    if (this.cargo.length >= 4) return { icon: '⬆', text: `Great haul! Bank ${this.cargo.length} finds at the bell`, target: bell };
+    if (this.banks === 0 && this.cargo.length >= 3) return { icon: '🔔', text: 'Nice! Now bank them at the glowing bell', target: bell };
+    if (this.tools.has('fizzlance')) {
+      const berg = this.fatbergs.find(f => f.blocking);
+      if (berg) return { icon: '🫧', text: 'Hold B by a fatberg to fizz it away', target: berg.mesh.position };
+    }
+    const grabbable = this.salvage.filter(s => !s.collected && !s.hidden && (!s.heavy || this.tools.has('grapple')));
+    const s = nearest(grabbable);
+    if (this.banks === 0) {
+      return { icon: '✨', text: `Grab ${Math.max(0, 3 - this.cargo.length)} more shiny finds — press B to ping!`, target: s?.mesh.position ?? bell };
+    }
+    const gear = nearest(this.quest.filter(q => !q.taken));
+    if (gear && (!s || gear.mesh.position.distanceTo(this.pos) < s.mesh.position.distanceTo(this.pos))) {
+      return { icon: '💗', text: 'Pink glow = gear! Collect it to craft tools', target: gear.mesh.position };
+    }
+    return { icon: '✨', text: 'Ping (B) and gather salvage', target: s?.mesh.position ?? bell };
+  }
+
   hudState() {
+    const obj = this._objective();
+    let objOut = null;
+    if (obj && obj.target) {
+      const dx = obj.target.x - this.pos.x, dz = obj.target.z - this.pos.z;
+      let rel = Math.atan2(-dz, dx) - this.yaw;
+      while (rel > Math.PI) rel -= Math.PI * 2;
+      while (rel < -Math.PI) rel += Math.PI * 2;
+      objOut = {
+        icon: obj.icon, text: obj.text,
+        dist: Math.round(Math.hypot(dx, dz)),
+        deg: Math.round(-rel * 180 / Math.PI),
+      };
+    }
     return {
+      obj: objOut,
       air: this.air / AIR_MAX, hull: this.hull, hullMax: HULL_MAX,
       score: this.score, cargo: this.cargo.length,
       cargoValue: this.cargo.reduce((a, c) => a + c.value, 0),

--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -22,6 +22,31 @@ let pendingRestore;
 const sdk = window.MinigameSDK ? new MinigameSDK() : null;
 
 // ---------------------------------------------------------------- UI glue
+// Nothing important is allowed to vanish: every toast and fact also lands
+// in the ship's log (📜), where it stays for the whole dive.
+const logEntries = [];
+function addLog(text, cls = '') {
+  logEntries.unshift({ text, cls, at: game ? Math.round(game.elapsed) : 0 });
+  if (logEntries.length > 80) logEntries.pop();
+  const badge = $('log-btn');
+  if (!$('log-panel').classList.contains('show')) badge.classList.add('unread');
+}
+function renderLog() {
+  const list = $('log-list');
+  list.innerHTML = '';
+  for (const e of logEntries) {
+    const li = document.createElement('li');
+    li.className = e.cls;
+    const t = document.createElement('span');
+    t.className = 'log-t';
+    t.textContent = `${String(Math.floor(e.at / 60)).padStart(2, '0')}:${String(e.at % 60).padStart(2, '0')}`;
+    li.appendChild(t);
+    li.appendChild(document.createTextNode(' ' + e.text));
+    list.appendChild(li);
+  }
+  if (!logEntries.length) list.innerHTML = '<li>Nothing logged yet — go find something!</li>';
+}
+
 function toast(text, cls = '') {
   const box = $('toasts');
   const t = document.createElement('div');
@@ -29,7 +54,9 @@ function toast(text, cls = '') {
   t.textContent = text;
   box.appendChild(t);
   while (box.children.length > 4) box.removeChild(box.firstChild);
-  setTimeout(() => { t.classList.add('out'); setTimeout(() => t.remove(), 600); }, 2600);
+  const life = cls === 'hint' ? 8000 : 6000;
+  setTimeout(() => { t.classList.add('out'); setTimeout(() => t.remove(), 600); }, life);
+  addLog(text, cls);
 }
 
 let factTimer = null;
@@ -40,15 +67,41 @@ function fact(title, text, icon) {
   $('fact-text').textContent = text;
   f.classList.add('show');
   if (factTimer) clearTimeout(factTimer);
-  factTimer = setTimeout(() => f.classList.remove('show'), 5000);
+  // stays a good long while — and it's tappable away, never lost (see log)
+  factTimer = setTimeout(() => f.classList.remove('show'), 14000);
+  addLog(`${icon || '📜'} ${title} — ${text}`, 'gold');
   announce(`${title}. ${text}`);
 }
 
 function hint(text) { toast('💡 ' + text, 'hint'); }
 
+function flash(cls) {
+  const el = $('flash');
+  el.className = '';
+  void el.offsetWidth;          // restart the animation
+  el.className = cls;
+}
+
 function announce(text) { window.__mgA11y?.announce?.(text); }
 
+let lastHull, lastScore, lastObjText;
 function hud(s) {
+  // the guide banner: what to do, which way, how far
+  if (s.obj) {
+    $('obj-text').textContent = `${s.obj.icon} ${s.obj.text}`;
+    $('obj-arrow').style.transform = `rotate(${s.obj.deg}deg)`;
+    $('obj-dist').textContent = s.obj.dist + 'm';
+    if (s.obj.text !== lastObjText) {
+      lastObjText = s.obj.text;
+      announce(`New goal: ${s.obj.text}`);
+      addLog(`${s.obj.icon} GOAL: ${s.obj.text}`, 'hint');
+    }
+  }
+  // feel the moment: red flash on damage, gold shimmer on scoring
+  if (lastHull !== undefined && s.hull < lastHull) flash('hurt');
+  if (lastScore !== undefined && s.score > lastScore) flash('gain');
+  lastHull = s.hull; lastScore = s.score;
+
   $('air-fill').style.width = Math.max(0, s.air * 100) + '%';
   $('air-fill').classList.toggle('low', s.air < 0.25);
   $('hull').textContent = '▮'.repeat(Math.max(0, s.hull)) + '▯'.repeat(Math.max(0, s.hullMax - s.hull));
@@ -68,10 +121,10 @@ function hud(s) {
 
 function complete(result) {
   const el = $('endcard');
-  $('end-title').textContent = result.success ? '★ TREASURE RAISED ★' : 'SUB LOST';
+  $('end-title').textContent = result.success ? '🎉 TREASURE RAISED! 🎉' : '💫 WHAT A DIVE!';
   $('end-body').textContent = result.success
-    ? `The captain’s chest is aboard the bell. Score ${result.score} — ${result.stats.codex} codex entries logged.`
-    : `Score ${result.score}. The dock keeps its secrets a while longer.`;
+    ? `The captain’s chest is aboard the bell! Score ${result.score}, with ${result.stats.codex} pieces of London history in your log. Marvellous.`
+    : `Score ${result.score} and ${result.stats.codex} history entries logged — the dock will still be there tomorrow. Dive again!`;
   el.classList.add('show');
   audio.stopMusic();
   if (sdk && EMBED) {
@@ -184,6 +237,20 @@ function startGame() {
 
 $('splash').addEventListener('pointerdown', startGame);
 $('ir-btn').addEventListener('pointerdown', (e) => { e.stopPropagation(); game?.toggleIR(); });
+$('fact').addEventListener('pointerdown', () => $('fact').classList.remove('show'));
+$('log-btn').addEventListener('pointerdown', (e) => {
+  e.stopPropagation();
+  const panel = $('log-panel');
+  const opening = !panel.classList.contains('show');
+  if (opening) renderLog();
+  panel.classList.toggle('show', opening);
+  $('log-btn').classList.remove('unread');
+  $('log-btn').setAttribute('aria-expanded', String(opening));
+});
+$('log-close').addEventListener('click', () => {
+  $('log-panel').classList.remove('show');
+  $('log-btn').setAttribute('aria-expanded', 'false');
+});
 $('endcard').addEventListener('pointerdown', () => {
   if (!EMBED && game?.over) location.reload();
 });
@@ -192,6 +259,12 @@ $('end-again').addEventListener('click', () => location.reload());
 window.addEventListener('resize', () => game?.resize());
 
 buildPad();
+// touch-first: show the pad on anything that can touch, not only
+// pointer:coarse — hybrids and tablets count
+if (matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window ||
+    navigator.maxTouchPoints > 0) {
+  $('pad').dataset.touch = '1';
+}
 
 // canvas a11y: name it and keep a live description of the dive
 const describe = () => {

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -127,6 +127,25 @@ try {
   if (eelDelta > 1) pass(`eel gave chase (closed ${eelDelta.toFixed(1)} units)`);
   else fail(`eel did not chase (delta ${eelDelta.toFixed(2)})`);
 
+  // the guide layer: objective banner always has a goal and a live arrow
+  const obj = await page.evaluate(() => ({
+    text: document.getElementById('obj-text').textContent,
+    dist: document.getElementById('obj-dist').textContent,
+    arrow: document.getElementById('obj-arrow').style.transform,
+  }));
+  if (obj.text.length > 4 && /\d+m/.test(obj.dist) && /rotate/.test(obj.arrow)) {
+    pass(`objective banner live: "${obj.text}" ${obj.dist}`);
+  } else fail('objective banner empty: ' + JSON.stringify(obj));
+
+  // the ship's log keeps everything; opening it shows entries
+  await page.evaluate(() => document.getElementById('log-btn')
+    .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true })));
+  const logCount = await page.evaluate(() =>
+    document.querySelectorAll('#log-panel.show #log-list li').length);
+  if (logCount >= 1) pass(`ship's log open with ${logCount} entries`);
+  else fail('log panel empty or closed');
+  await page.click('#log-close');
+
   // the living water: fish schools must exist and actually swirl
   const fish = await page.evaluate(async () => {
     const fx = window.__waterworld.game.fx;

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -42,7 +42,7 @@
   #hud {
     position: absolute; top: 0; left: 0; right: 0;
     display: flex; flex-wrap: wrap; align-items: center; gap: 0.5em 1em;
-    padding: max(0.4em, env(safe-area-inset-top)) 4.5em 0.4em 0.7em;
+    padding: max(0.4em, env(safe-area-inset-top)) 8rem 0.4em 0.7em;
     font-size: clamp(11px, 2.4vmin, 16px);
     letter-spacing: 0.06em;
     color: #ffec27;
@@ -75,9 +75,35 @@
   }
   #ir-btn:focus-visible { outline: 2px solid #29adff; outline-offset: 2px; }
 
+  /* ------- objective banner: always on, always pointing ------- */
+  #objective {
+    position: absolute; left: 50%; top: 3.2em;
+    transform: translateX(-50%);
+    display: flex; align-items: center; gap: 0.5em;
+    max-width: 94%;
+    padding: 0.35em 0.9em;
+    background: rgba(10, 25, 60, 0.85);
+    border: 2px solid #29adff;
+    border-radius: 2em;
+    font-size: clamp(13px, 3.4vmin, 18px);
+    color: #fff1e8;
+    text-shadow: 1px 1px 0 #000;
+    box-shadow: 0 0 12px rgba(41,173,255,0.45);
+    z-index: 21; pointer-events: none;
+    white-space: nowrap; overflow: hidden;
+  }
+  #obj-text { overflow: hidden; text-overflow: ellipsis; }
+  #obj-arrow {
+    display: inline-block;
+    color: #ffec27; font-size: 1.25em;
+    transition: transform 0.25s;
+    text-shadow: 0 0 8px rgba(255,236,39,0.8);
+  }
+  #obj-dist { color: #29adff; font-size: 0.85em; }
+
   /* ------- toasts + facts ------- */
   #toasts {
-    position: absolute; left: 50%; top: 18%;
+    position: absolute; left: 50%; top: 6.4em;
     transform: translateX(-50%);
     display: flex; flex-direction: column; align-items: center; gap: 0.3em;
     z-index: 22; pointer-events: none;
@@ -99,6 +125,67 @@
   .toast.gold { border-color: #ffec27; color: #ffec27; }
   .toast.hint { border-color: #83769c; color: #c2c3c7; font-style: italic; }
   .toast.out { opacity: 0; }
+
+  /* ------- ship's log ------- */
+  #log-btn {
+    position: absolute;
+    top: max(0.4em, env(safe-area-inset-top));
+    right: 4.6em;
+    z-index: 21;
+    font: inherit; font-size: clamp(12px, 2.6vmin, 16px);
+    background: rgba(0,0,0,0.5); color: #29adff;
+    border: 1px solid #29adff; padding: 0.15em 0.55em;
+    min-width: 44px; min-height: 28px; cursor: pointer;
+  }
+  #log-btn.unread::after { content: '●'; color: #ffec27; margin-left: 0.25em; }
+  #log-btn:focus-visible { outline: 2px solid #ffec27; outline-offset: 2px; }
+  #log-panel {
+    position: absolute; inset: 3.6em 0.6em auto 0.6em;
+    max-height: 62dvh;
+    display: none; flex-direction: column;
+    background: rgba(8, 18, 45, 0.96);
+    border: 2px solid #29adff;
+    z-index: 45;
+  }
+  #log-panel.show { display: flex; }
+  #log-head {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 0.4em 0.8em;
+    color: #ffec27; letter-spacing: 0.12em;
+    border-bottom: 1px solid #29adff;
+  }
+  #log-close {
+    font: inherit; background: none; color: #ff77a8;
+    border: 1px solid #ff77a8; min-width: 44px; min-height: 32px; cursor: pointer;
+  }
+  #log-list {
+    list-style: none; overflow-y: auto;
+    padding: 0.5em 0.8em; margin: 0;
+    font-size: clamp(12px, 2.8vmin, 15px); line-height: 1.5;
+    color: #c2c3c7;
+  }
+  #log-list li { margin-bottom: 0.35em; }
+  #log-list li.gold { color: #ffec27; }
+  #log-list li.good { color: #00e436; }
+  #log-list li.bad { color: #ff004d; }
+  #log-list li.warn { color: #ffa300; }
+  .log-t { color: #83769c; font-size: 0.85em; margin-right: 0.3em; }
+
+  /* ------- feedback flashes ------- */
+  #flash {
+    position: absolute; inset: 0;
+    pointer-events: none; z-index: 28; opacity: 0;
+  }
+  #flash.hurt { animation: flash-red 0.45s ease-out; }
+  #flash.gain { animation: flash-gold 0.6s ease-out; }
+  @keyframes flash-red {
+    0% { opacity: 0.5; box-shadow: inset 0 0 12vmin #ff004d; background: rgba(255,0,77,0.15); }
+    100% { opacity: 0; }
+  }
+  @keyframes flash-gold {
+    0% { opacity: 0.45; box-shadow: inset 0 0 10vmin #ffec27; }
+    100% { opacity: 0; }
+  }
 
   #fact {
     position: absolute; left: 50%; bottom: 24%;
@@ -142,29 +229,36 @@
   }
   #end-again:focus-visible { outline: 3px solid #29adff; outline-offset: 2px; }
 
-  /* ------- touch pad (standalone only; the shell brings its own) ------- */
+  /* ------- touch pad (shown on any touch device; the shell brings its
+     own and tells us to hide this one) ------- */
   #pad {
     position: absolute; left: 0; right: 0;
-    bottom: max(0.6em, env(safe-area-inset-bottom));
-    display: flex; justify-content: space-between; align-items: flex-end;
-    padding: 0 4vw; z-index: 25;
+    bottom: max(0.8em, env(safe-area-inset-bottom));
+    display: none; justify-content: space-between; align-items: flex-end;
+    padding: 0 2vw; z-index: 25;
     pointer-events: none;
+    /* em-driven sizing: the whole pad scales to the screen so nothing
+       ever hangs off the edge of a narrow phone */
+    font-size: clamp(10px, 3.4vw, 16px);
   }
-  @media (pointer: fine) { #pad { display: none; } }
-  #dirs { display: grid; grid-template-columns: repeat(3, 3.2em); grid-template-rows: repeat(3, 3.2em); }
+  #pad[data-touch="1"] { display: flex; }
+  #dirs { display: grid; grid-template-columns: repeat(3, 3.9em); grid-template-rows: repeat(3, 3.9em); gap: 2px; }
   #pad button {
     pointer-events: auto;
-    font: inherit; font-size: 1.1em;
-    background: rgba(29,43,83,0.55); color: #29adff;
-    border: 1px solid #29adff;
-    min-width: 44px; min-height: 44px;
+    font: inherit; font-size: 1.4em; font-weight: bold;
+    background: rgba(29,43,83,0.6); color: #29adff;
+    border: 2px solid #29adff; border-radius: 0.5em;
+    min-width: 48px; min-height: 48px;
     touch-action: none;
   }
-  #pad button.held { background: rgba(41,173,255,0.5); color: #fff1e8; }
+  #pad button.held { background: rgba(41,173,255,0.55); color: #fff1e8; }
   #p-up { grid-area: 1 / 2; } #p-left { grid-area: 2 / 1; }
   #p-right { grid-area: 2 / 3; } #p-down { grid-area: 3 / 2; }
-  #acts { display: flex; gap: 0.8em; }
-  #acts button { border-radius: 50%; width: 3.6em; height: 3.6em; color: #ffec27; border-color: #ffec27; }
+  #acts { display: flex; gap: 1em; align-items: center; }
+  #acts button { border-radius: 50%; width: 4.4em; height: 4.4em; color: #ffec27; border-color: #ffec27; }
+  #acts .btn-label {
+    display: block; font-size: 0.5em; font-weight: normal; letter-spacing: 0.05em;
+  }
 
   .sr-only {
     position: absolute; top: 0; left: 0; width: 1px; height: 1px;
@@ -187,6 +281,23 @@
     <span id="inv">·</span>
   </div>
   <button id="ir-btn" type="button" aria-label="toggle thermal sight" aria-pressed="false">IR</button>
+  <button id="log-btn" type="button" aria-label="ship's log" aria-expanded="false">📜</button>
+
+  <div id="objective" aria-hidden="true">
+    <span id="obj-arrow">➤</span>
+    <span id="obj-text">✨ Dive in!</span>
+    <span id="obj-dist"></span>
+  </div>
+
+  <div id="log-panel" role="dialog" aria-label="Ship's log">
+    <div id="log-head">
+      <span>📜 SHIP'S LOG</span>
+      <button id="log-close" type="button" aria-label="close log">✕</button>
+    </div>
+    <ul id="log-list"></ul>
+  </div>
+
+  <div id="flash" aria-hidden="true"></div>
 
   <div id="toasts"></div>
 
@@ -199,11 +310,11 @@
   <div id="splash" class="overlay">
     <h2>WATERWORLD</h2>
     <p>— DOCKLANDS DEEP —</p>
-    <p>The old dock flooded a century ago and kept everything it swallowed.
-       Pilot the sub. Ping the dark. Raise what London lost.</p>
-    <p>STEER: pad · THRUST: A · SONAR/TOOL: B · THERMAL: I / IR<br>
-       Bank salvage at the diving bell before your air runs out.</p>
-    <p class="press">▶ PRESS A OR TAP TO DIVE ◀</p>
+    <p>🫧 A sunny dive into a drowned London dock! Ping for treasure,
+       tickle history out of the mud, and bring it home to the glowing bell.</p>
+    <p>➤ The glowing arrow always knows the way.<br>
+       ▲▼◀▶ steer &nbsp;·&nbsp; A thrust &nbsp;·&nbsp; B sonar &nbsp;·&nbsp; 📜 log &nbsp;·&nbsp; IR heat-vision</p>
+    <p class="press">▶ TAP ANYWHERE TO DIVE ◀</p>
   </div>
 
   <div id="paused" class="overlay"><h2>PAUSED</h2><p>The story has the helm.</p></div>
@@ -222,8 +333,8 @@
       <button id="p-down" type="button" aria-label="pitch down">▼</button>
     </div>
     <div id="acts">
-      <button id="p-b" type="button" aria-label="sonar ping and tools">B</button>
-      <button id="p-a" type="button" aria-label="thrust">A</button>
+      <button id="p-b" type="button" aria-label="sonar ping and tools">B<span class="btn-label">SONAR</span></button>
+      <button id="p-a" type="button" aria-label="thrust">A<span class="btn-label">GO!</span></button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
UX pass answering "must be mobile first, more upbeat, easy to navigate, and vanishing text is not world building":

- **Guide banner:** persistent objective pill — one plain sentence, a live arrow that rotates with the sub's heading, distance in metres. A goal ladder walks new players in and later points at gear, fatbergs, the whale's chest, or home when air is low.
- **Ship's log (📜):** every toast, fact and goal lands in a timestamped scrollable log; facts linger 14s and are tap-to-dismiss; unread dot on the button. Nothing is ever lost.
- **Cheery:** brighter light, blue shallows, major-key music box, upbeat copy, gold flash on scoring / red flash on damage.
- **Mobile-first:** touch pad on any touch-capable device, em-scaled so it can't hang off a narrow phone, labelled A GO!/B SONAR buttons, HUD clearance pinned in rem — verified by geometry assertions at 390×844.

Playtest grows objective-banner and log assertions; shell e2e and html-validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_