### PR TITLE
Waterworld: fix helm angle-snapping, demote d-pad, add help panel

### DIFF
--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -63,6 +63,9 @@ export class WaterworldGame {
     this._autoThrust = false;
     this._autoFizz = false;
     this._helmActive = false;
+    this._smYaw = 0;             // low-passed desired heading — the
+    this._smPitch = 0;           // helm may never snap between poses
+    this._terrainLift = false;   // hysteresis, not a flickering flag
 
     // visitors
     this.seal = null;
@@ -343,6 +346,9 @@ export class WaterworldGame {
   // and even works the fizz lance when she's alongside a fatberg.
   _helm(dt) {
     this._helmActive = true;
+    // re-engaging after manual or a brush: start the filter from where
+    // the boat actually is, or the first frame swings from stale state
+    if (!this._helmWasActive) { this._smYaw = this.yaw; this._smPitch = this.pitch; }
     let desYaw, desPitch;
     const exploring = this._explore && this.elapsed < this._explore.until;
     const obj = exploring ? null : this._objective();
@@ -354,8 +360,10 @@ export class WaterworldGame {
       const dx = obj.target.x - this.pos.x, dz = obj.target.z - this.pos.z;
       const dy = (obj.target.y ?? this.pos.y) - this.pos.y;
       dist = Math.hypot(dx, dz);
-      desYaw = Math.atan2(-dz, dx);
-      desPitch = Math.max(-0.65, Math.min(0.65, Math.atan2(dy, Math.max(dist, 2))));
+      // deadband: right on top of the target, bearing is noise — hold
+      // the heading and settle vertically instead of chasing atan2 jitter
+      desYaw = dist < 5 ? this.yaw : Math.atan2(-dz, dx);
+      desPitch = Math.max(-0.65, Math.min(0.65, Math.atan2(dy, Math.max(dist, 5))));
     } else {
       this._helmActive = false;
       return;
@@ -379,9 +387,16 @@ export class WaterworldGame {
           this.pos.z - c.z).normalize(), (c.r + 7 - d) / 6);
       }
     }
-    // terrain ahead: pull up early, duck under the surface
+    // terrain ahead: pull up early — WITH hysteresis, or the lift flag
+    // flickers every frame and the boat wags between two pitches
     const px = this.pos.x + dir.x * 12, pz = this.pos.z + dir.z * 12;
-    if (this.pos.y - 3.5 < floorYAt(px, pz)) dir.y = Math.max(dir.y, 0.6);
+    const clearance = this.pos.y - floorYAt(px, pz);
+    if (this._terrainLift) {
+      if (clearance > 7) this._terrainLift = false;
+    } else if (clearance < 3.5) {
+      this._terrainLift = true;
+    }
+    if (this._terrainLift) dir.y = Math.max(dir.y, 0.6);
     if (this.pos.y > BOUNDS.surface - 2) dir.y = Math.min(dir.y, -0.1);
     if (px < BOUNDS.minX + 8 || px > BOUNDS.maxX - 8 ||
         pz < BOUNDS.minZ + 8 || pz > BOUNDS.maxZ - 8) {
@@ -391,14 +406,26 @@ export class WaterworldGame {
     dir.normalize();
     desYaw = Math.atan2(-dir.z, dir.x);
     desPitch = Math.max(-0.8, Math.min(0.8, Math.asin(Math.max(-1, Math.min(1, dir.y)))));
-    // steer smoothly, remember the turn for the rudder animation
-    let dYaw = desYaw - this.yaw;
+    // LOW-PASS the desired heading before steering toward it. Raw desire
+    // can flip pose-to-pose (avoidance engaging, a target passing under
+    // the keel) and steering straight at it made the boat oscillate
+    // between two angles with no in-between — the reported glitch. The
+    // filtered desire cannot step, so the boat cannot snap.
+    let sd = desYaw - this._smYaw;
+    while (sd > Math.PI) sd -= Math.PI * 2;
+    while (sd < -Math.PI) sd += Math.PI * 2;
+    this._smYaw += sd * Math.min(1, 3.5 * dt);
+    while (this._smYaw > Math.PI) this._smYaw -= Math.PI * 2;
+    while (this._smYaw < -Math.PI) this._smYaw += Math.PI * 2;
+    this._smPitch += (desPitch - this._smPitch) * Math.min(1, 3.5 * dt);
+    // steer toward the FILTERED desire, remember the turn for the rudder
+    let dYaw = this._smYaw - this.yaw;
     while (dYaw > Math.PI) dYaw -= Math.PI * 2;
     while (dYaw < -Math.PI) dYaw += Math.PI * 2;
     const turn = Math.max(-1.5 * dt, Math.min(1.5 * dt, dYaw));
     this.yaw += turn;
     this._helmTurn = Math.max(-0.5, Math.min(0.5, dYaw));
-    this.pitch += Math.max(-1.1 * dt, Math.min(1.1 * dt, desPitch - this.pitch));
+    this.pitch += Math.max(-1.1 * dt, Math.min(1.1 * dt, this._smPitch - this.pitch));
     this._autoThrust = exploring || dist > 7;
     // she pings as she hunts — the sonar chimes are half the mood
     if (this._pingCooldown <= 0 && this.elapsed - this._lastAutoPing > 7 && !exploring) {
@@ -674,6 +701,7 @@ export class WaterworldGame {
     this._helmActive = false;
     const manual = this.elapsed < this.manualUntil;
     if (this.autopilot && !manual && !this.over) this._helm(dt);
+    this._helmWasActive = this._helmActive;
 
     // -------- steering: yaw/pitch on the pad, thrust on A
     const turn = 1.9 * dt, pitchRate = 1.4 * dt;
@@ -713,7 +741,7 @@ export class WaterworldGame {
 
     // -------- pose the sub + camera
     this.sub.position.copy(this.pos);
-    const roll = (k.left ? 0.25 : 0) - (k.right ? 0.25 : 0);
+    const roll = (k.left ? 0.25 : 0) - (k.right ? 0.25 : 0) + (this._helmTurn || 0) * 0.45;
     this.sub.rotation.set(0, this.yaw, 0);
     this.sub.rotateZ(this.pitch * 0.7);
     this.sub.rotation.x += (roll - this.sub.rotation.x) * 0.2;
@@ -729,7 +757,12 @@ export class WaterworldGame {
     const camTarget = this.pos.clone().addScaledVector(fwd, -10).add(new THREE.Vector3(0, 3.5, 0));
     camTarget.y = Math.min(camTarget.y, BOUNDS.surface + 1);
     this.camera.position.lerp(camTarget, 1 - Math.pow(0.001, dt));
-    this.camera.lookAt(this.pos.clone().addScaledVector(fwd, 6));
+    // the gaze is smoothed too: a lookAt chasing a jittery forward
+    // vector is half of any "camera snapping" complaint
+    const lookTarget = this.pos.clone().addScaledVector(fwd, 6);
+    this._camLook = this._camLook || lookTarget.clone();
+    this._camLook.lerp(lookTarget, 1 - Math.pow(0.004, dt));
+    this.camera.lookAt(this._camLook);
 
     // -------- fog and light by depth (the deep is DARK without the lamp)
     const depth = -this.pos.y;

--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -242,6 +242,7 @@ function buildPad() {
 function applyControls(controls) {
   const hostOwns = controls?.provider === 'host';
   $('pad').style.display = hostOwns ? 'none' : '';
+  $('pad-toggle').style.display = hostOwns ? 'none' : '';
 }
 
 // ---------------------------------------------------------------- boot
@@ -269,7 +270,10 @@ function startGame() {
     };
   }
   game.start();
-  announce('Dive started. Steer with the pad, A to thrust, B for sonar.');
+  announce('Dive started. Brush the water to steer, tap to ping the sonar.');
+  setTimeout(() => {
+    if (game && !game.over) hint('Brush the water to steer her, Captain — tap ？ for everything else');
+  }, 2500);
 }
 
 $('splash').addEventListener('pointerdown', startGame);
@@ -305,12 +309,31 @@ $('end-again').addEventListener('click', () => location.reload());
 window.addEventListener('resize', () => game?.resize());
 
 buildPad();
-// touch-first: show the pad on anything that can touch, not only
-// pointer:coarse — hybrids and tablets count
+// Touch-first means GESTURES first: brush to steer, tap to ping. The
+// d-pad is the last resort, parked behind the 🎮 chip until summoned.
 if (matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window ||
     navigator.maxTouchPoints > 0) {
-  $('pad').dataset.touch = '1';
+  $('pad-toggle').dataset.touch = '1';
 }
+$('pad-toggle').addEventListener('pointerdown', (e) => {
+  e.stopPropagation();
+  const open = !$('pad').classList.contains('open');
+  $('pad').classList.toggle('open', open);
+  $('pad-toggle').classList.toggle('on', open);
+  $('pad-toggle').setAttribute('aria-pressed', String(open));
+  if (open) toast('🎮 D-pad out — ▲▼◀▶ steer · A thrust · B sonar', 'hint');
+});
+$('help-btn').addEventListener('pointerdown', (e) => {
+  e.stopPropagation();
+  const panel = $('help-panel');
+  const opening = !panel.classList.contains('show');
+  panel.classList.toggle('show', opening);
+  $('help-btn').setAttribute('aria-expanded', String(opening));
+});
+$('help-close').addEventListener('click', () => {
+  $('help-panel').classList.remove('show');
+  $('help-btn').setAttribute('aria-expanded', 'false');
+});
 
 // canvas a11y: name it and keep a live description of the dive
 const describe = () => {

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -76,6 +76,43 @@ try {
   if (!subParts.length) pass('sub v2: props, planes, rudder, beacon all present');
   else fail('sub missing parts: ' + subParts.join(','));
 
+  // helm smoothness: park right on top of a target and make sure the
+  // heading settles instead of flip-flopping between two angles (the
+  // reported drift glitch)
+  const wobble = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    const s = g.salvage.find(s => !s.collected && !s.hidden && s.heavy);   // can't collect it
+    window.__waterworld.teleport(s.mesh.position.x, s.mesh.position.y + 2, s.mesh.position.z);
+    await new Promise(r => setTimeout(r, 1200));   // let the filter settle
+    const yaws = [];
+    for (let i = 0; i < 8; i++) {
+      await new Promise(r => setTimeout(r, 200));
+      yaws.push(g.yaw);
+    }
+    let reversals = 0;
+    for (let i = 2; i < yaws.length; i++) {
+      const a = yaws[i - 1] - yaws[i - 2], b = yaws[i] - yaws[i - 1];
+      if (Math.abs(a) > 0.06 && Math.abs(b) > 0.06 && Math.sign(a) !== Math.sign(b)) reversals++;
+    }
+    return reversals;
+  });
+  if (wobble <= 1) pass(`helm settles over a target (${wobble} heading reversals)`);
+  else fail(`helm oscillates: ${wobble} heading reversals in 1.6s`);
+
+  // help is one tap away, and the pad hides behind its chip
+  await page.evaluate(() => document.getElementById('help-btn')
+    .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true })));
+  const helpOpen = await page.evaluate(() =>
+    document.getElementById('help-panel').classList.contains('show') &&
+    document.querySelectorAll('#help-list li').length >= 8);
+  if (helpOpen) pass('help panel opens with the full function list');
+  else fail('help panel broken');
+  await page.click('#help-close');
+  const padHidden = await page.evaluate(() =>
+    getComputedStyle(document.getElementById('pad')).display === 'none');
+  if (padHidden) pass('d-pad parked by default (last resort)');
+  else fail('d-pad visible by default');
+
   // hand steering takes priority from here — determinism for the rest
   await page.evaluate(() => {
     window.__waterworld.game.autopilot = false;

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -42,7 +42,7 @@
   #hud {
     position: absolute; top: 0; left: 0; right: 0;
     display: flex; flex-wrap: wrap; align-items: center; gap: 0.5em 1em;
-    padding: max(0.4em, env(safe-area-inset-top)) 13rem 0.4em 0.7em;
+    padding: max(0.4em, env(safe-area-inset-top)) 14rem 0.4em 0.7em;
     font-size: clamp(11px, 2.4vmin, 16px);
     letter-spacing: 0.06em;
     color: #ffec27;
@@ -59,25 +59,35 @@
   @keyframes blink { 50% { opacity: 0.35; } }
   #hull { color: #ff77a8; }
   #inv { color: #ffccaa; }
-  #ir-btn {
+  /* the chip rail: every mode/panel control in one predictable place */
+  #chips {
     position: absolute;
     top: max(0.4em, env(safe-area-inset-top));
-    right: 0.7em;
+    right: 0.5em;
+    display: flex; gap: 0.35em;
     z-index: 21;
-    font: inherit; font-size: clamp(10px, 2.2vmin, 14px); letter-spacing: 0.1em;
-    background: rgba(0,0,0,0.5); color: #83769c;
-    border: 1px solid #83769c; padding: 0.15em 0.6em;
-    min-width: 44px; min-height: 28px; cursor: pointer;
   }
+  .chip {
+    font: inherit; font-size: clamp(11px, 2.4vmin, 14px); letter-spacing: 0.06em;
+    background: rgba(0,0,0,0.55); color: #83769c;
+    border: 1px solid #83769c; border-radius: 0.4em;
+    padding: 0.15em 0.5em;
+    min-width: 44px; min-height: 32px; cursor: pointer;
+  }
+  .chip:focus-visible { outline: 2px solid #29adff; outline-offset: 2px; }
   #ir-btn.on {
     color: #ffa300; border-color: #ffa300;
     box-shadow: 0 0 8px rgba(255,163,0,0.6);
   }
-  #ir-btn:focus-visible { outline: 2px solid #29adff; outline-offset: 2px; }
+  #auto-btn.on {
+    color: #00e436; border-color: #00e436;
+    box-shadow: 0 0 8px rgba(0,228,54,0.5);
+  }
+  #help-btn { color: #29adff; border-color: #29adff; }
 
   /* ------- objective banner: always on, always pointing ------- */
   #objective {
-    position: absolute; left: 50%; top: 3.2em;
+    position: absolute; left: 50%; top: 5.6em;
     transform: translateX(-50%);
     display: flex; align-items: center; gap: 0.5em;
     max-width: 94%;
@@ -103,7 +113,7 @@
 
   /* ------- toasts + facts ------- */
   #toasts {
-    position: absolute; left: 50%; top: 6.4em;
+    position: absolute; left: 50%; top: 9.6em;
     transform: translateX(-50%);
     display: flex; flex-direction: column; align-items: center; gap: 0.3em;
     z-index: 22; pointer-events: none;
@@ -127,33 +137,8 @@
   .toast.out { opacity: 0; }
 
   /* ------- ship's log ------- */
-  #log-btn {
-    position: absolute;
-    top: max(0.4em, env(safe-area-inset-top));
-    right: 4.6em;
-    z-index: 21;
-    font: inherit; font-size: clamp(12px, 2.6vmin, 16px);
-    background: rgba(0,0,0,0.5); color: #29adff;
-    border: 1px solid #29adff; padding: 0.15em 0.55em;
-    min-width: 44px; min-height: 28px; cursor: pointer;
-  }
+  #log-btn { color: #29adff; border-color: #29adff; }
   #log-btn.unread::after { content: '●'; color: #ffec27; margin-left: 0.25em; }
-  #auto-btn {
-    position: absolute;
-    top: max(0.4em, env(safe-area-inset-top));
-    right: 8.4rem;
-    z-index: 21;
-    font: inherit; font-size: clamp(10px, 2.2vmin, 13px); letter-spacing: 0.06em;
-    background: rgba(0,0,0,0.5); color: #5f574f;
-    border: 1px solid #5f574f; padding: 0.15em 0.5em;
-    min-width: 44px; min-height: 28px; cursor: pointer;
-  }
-  #auto-btn.on {
-    color: #00e436; border-color: #00e436;
-    box-shadow: 0 0 8px rgba(0,228,54,0.5);
-  }
-  #auto-btn:focus-visible { outline: 2px solid #29adff; outline-offset: 2px; }
-  #log-btn:focus-visible { outline: 2px solid #ffec27; outline-offset: 2px; }
   #log-panel {
     position: absolute; inset: 3.6em 0.6em auto 0.6em;
     max-height: 62dvh;
@@ -163,16 +148,33 @@
     z-index: 45;
   }
   #log-panel.show { display: flex; }
-  #log-head {
+  .panel-head {
     display: flex; justify-content: space-between; align-items: center;
     padding: 0.4em 0.8em;
     color: #ffec27; letter-spacing: 0.12em;
     border-bottom: 1px solid #29adff;
   }
-  #log-close {
+  .panel-head button {
     font: inherit; background: none; color: #ff77a8;
     border: 1px solid #ff77a8; min-width: 44px; min-height: 32px; cursor: pointer;
   }
+  #help-panel {
+    position: absolute; inset: 3.6em 0.6em auto 0.6em;
+    max-height: 72dvh;
+    display: none; flex-direction: column;
+    background: rgba(8, 18, 45, 0.97);
+    border: 2px solid #29adff;
+    z-index: 46;
+  }
+  #help-panel.show { display: flex; }
+  #help-list {
+    list-style: none; overflow-y: auto;
+    padding: 0.6em 0.9em; margin: 0;
+    font-size: clamp(12px, 2.9vmin, 15px); line-height: 1.55;
+    color: #c2c3c7;
+  }
+  #help-list li { margin-bottom: 0.55em; }
+  #help-list strong { color: #ffec27; font-weight: bold; }
   #log-list {
     list-style: none; overflow-y: auto;
     padding: 0.5em 0.8em; margin: 0;
@@ -256,7 +258,23 @@
        ever hangs off the edge of a narrow phone */
     font-size: clamp(10px, 3.4vw, 16px);
   }
-  #pad[data-touch="1"] { display: flex; }
+  #pad.open { display: flex; }
+  /* the d-pad is the LAST resort on mobile — brush and tap come first.
+     It hides behind this chip until summoned. */
+  #pad-toggle {
+    position: absolute;
+    left: 0.6em;
+    bottom: max(0.8em, env(safe-area-inset-bottom));
+    z-index: 26;
+    display: none;
+    font: inherit; font-size: clamp(14px, 3vmin, 18px);
+    background: rgba(0,0,0,0.55); color: #83769c;
+    border: 1px solid #83769c; border-radius: 50%;
+    width: 52px; height: 52px; cursor: pointer;
+  }
+  #pad-toggle[data-touch="1"] { display: block; }
+  #pad-toggle.on { color: #29adff; border-color: #29adff; }
+  #pad-toggle:focus-visible { outline: 2px solid #29adff; outline-offset: 2px; }
   #dirs { display: grid; grid-template-columns: repeat(3, 3.9em); grid-template-rows: repeat(3, 3.9em); gap: 2px; }
   #pad button {
     pointer-events: auto;
@@ -295,9 +313,32 @@
     <span id="codex">📖0/12</span>
     <span id="inv">·</span>
   </div>
-  <button id="ir-btn" type="button" aria-label="toggle thermal sight" aria-pressed="false">IR</button>
-  <button id="log-btn" type="button" aria-label="ship's log" aria-expanded="false">📜</button>
-  <button id="auto-btn" type="button" aria-label="toggle autopilot" aria-pressed="true">⚓AUTO</button>
+  <div id="chips">
+    <button id="auto-btn" class="chip" type="button" aria-label="toggle autopilot" aria-pressed="true">⚓AUTO</button>
+    <button id="help-btn" class="chip" type="button" aria-label="how to play" aria-expanded="false">？</button>
+    <button id="log-btn" class="chip" type="button" aria-label="ship's log" aria-expanded="false">📜</button>
+    <button id="ir-btn" class="chip" type="button" aria-label="toggle thermal sight" aria-pressed="false">IR</button>
+  </div>
+  <button id="pad-toggle" type="button" aria-label="show d-pad controls" aria-pressed="false">🎮</button>
+
+  <div id="help-panel" role="dialog" aria-label="How to play">
+    <div class="panel-head">
+      <span>🧭 HOW TO CAPTAIN</span>
+      <button id="help-close" type="button" aria-label="close help">✕</button>
+    </div>
+    <ul id="help-list">
+      <li><strong>Brush the water</strong> — set a new course. She follows it, then resumes the hunt.</li>
+      <li><strong>Tap the water</strong> — sonar ping: lights up treasure, stuns eels up close, pops mines at a safe distance.</li>
+      <li><strong>➤ The banner arrow</strong> always points at your current goal.</li>
+      <li><strong>⚓AUTO</strong> — autopilot on/off. Off = you have the boat.</li>
+      <li><strong>🎮</strong> — summon the d-pad if you want stick-and-button control (▲▼◀▶ steer · A thrust · B sonar/tools).</li>
+      <li><strong>IR</strong> — thermal sight: fatbergs and mines glow warm through the dark. Ghosts run cold.</li>
+      <li><strong>📜</strong> — the ship's log keeps every fact and event of the dive.</li>
+      <li>Swim into <strong>shiny things</strong> to collect them; the <strong>glowing bell</strong> banks cargo and refills air.</li>
+      <li><strong>Pink glows are gear</strong> — two parts auto-craft a tool: grapple, arc lamp, fizz lance (hold B by a fatberg).</li>
+      <li>Keyboard: WASD/arrows · Space thrust · Esc/X sonar · I thermal.</li>
+    </ul>
+  </div>
 
   <div id="objective" aria-hidden="true">
     <span id="obj-arrow">➤</span>
@@ -306,7 +347,7 @@
   </div>
 
   <div id="log-panel" role="dialog" aria-label="Ship's log">
-    <div id="log-head">
+    <div class="panel-head">
       <span>📜 SHIP'S LOG</span>
       <button id="log-close" type="button" aria-label="close log">✕</button>
     </div>
@@ -330,7 +371,7 @@
        tickle history out of the mud, and bring it home to the glowing bell.</p>
     <p>⚓ She sails herself, Captain — <strong>brush the water</strong> to set
        a new course, <strong>tap</strong> to ping the sonar.<br>
-       Or take the helm: ▲▼◀▶ steer · A thrust · B sonar · 📜 log · IR heat</p>
+       ？ help · 📜 log · IR heat-vision · 🎮 summons a d-pad if you want one</p>
     <p class="press">▶ TAP ANYWHERE TO DIVE ◀</p>
   </div>
 


### PR DESCRIPTION
Fixes from a real-phone field report: drifting oscillated between two angles with no in-betweening; the d-pad dominated the screen; other functions were undiscoverable.

- **The glitch:** three causes fixed — bearing deadband over targets (atan2 noise), hysteresis on the terrain-avoid flag (was flickering per-frame), and a low-pass filter on the helm's desired heading (seeded from the boat's real pose on re-engage) so the commanded angle physically cannot snap. Camera gaze smoothed too; helm turns now bank the hull. Locked by a playtest assertion: zero heading reversals parked over a target.
- **D-pad last resort:** brush = course order, tap = ping; the pad hides behind a 🎮 chip. Shell host-pad contract unchanged.
- **Discoverability:** ？ chip opens a HOW TO CAPTAIN card listing every function; chip rail consolidated (⚓AUTO ？ 📜 IR); objective banner moved below the HUD rows it previously covered; one-time coach hint.

Playtest at 26 assertions; shell e2e and html-validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_