### PR TITLE
Waterworld: fix drift oscillation for real — Euler flip in the pose, now quaternions

### DIFF
--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -16,6 +16,19 @@ import { FACTS, QUEST_ITEMS, TOOLS, HINTS } from './facts.js';
 const AIR_MAX = 100;
 const HULL_MAX = 4;
 const _cur = new THREE.Vector3();
+// The sub's pose is composed from QUATERNIONS, never read back from
+// Euler angles. The old code did `rotation.set(yaw)` + `rotateZ(pitch)`
+// and then read-modified `rotation.x` — but a yaw+pitch composition has
+// two equivalent Euler representations, and near the flip boundary the
+// extracted angles alternate between them frame to frame. Writing .x
+// back then slammed the craft between two orientations with no
+// in-between: the reported drift glitch.
+const _qYaw = new THREE.Quaternion();
+const _qPitch = new THREE.Quaternion();
+const _qRoll = new THREE.Quaternion();
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
+const Z_AXIS = new THREE.Vector3(0, 0, 1);
+const X_AXIS = new THREE.Vector3(1, 0, 0);
 
 export class WaterworldGame {
   // ui: { hud(state), toast(text, cls), fact(title, text, icon),
@@ -65,6 +78,7 @@ export class WaterworldGame {
     this._helmActive = false;
     this._smYaw = 0;             // low-passed desired heading — the
     this._smPitch = 0;           // helm may never snap between poses
+    this._smRoll = 0;            // roll as a SCALAR, never read from Eulers
     this._terrainLift = false;   // hysteresis, not a flickering flag
 
     // visitors
@@ -739,12 +753,14 @@ export class WaterworldGame {
       }
     }
 
-    // -------- pose the sub + camera
+    // -------- pose the sub + camera (quaternion compose — see top note)
     this.sub.position.copy(this.pos);
-    const roll = (k.left ? 0.25 : 0) - (k.right ? 0.25 : 0) + (this._helmTurn || 0) * 0.45;
-    this.sub.rotation.set(0, this.yaw, 0);
-    this.sub.rotateZ(this.pitch * 0.7);
-    this.sub.rotation.x += (roll - this.sub.rotation.x) * 0.2;
+    const rollTarget = (k.left ? 0.25 : 0) - (k.right ? 0.25 : 0) + (this._helmTurn || 0) * 0.45;
+    this._smRoll += (rollTarget - this._smRoll) * Math.min(1, 6 * dt);
+    _qYaw.setFromAxisAngle(Y_AXIS, this.yaw);
+    _qPitch.setFromAxisAngle(Z_AXIS, this.pitch * 0.7);
+    _qRoll.setFromAxisAngle(X_AXIS, this._smRoll);
+    this.sub.quaternion.copy(_qYaw).multiply(_qPitch).multiply(_qRoll);
     const ud = this.sub.userData;
     ud.prop.rotation.x += dt * (thrusting ? 24 : 6);
     ud.prop2.rotation.x -= dt * (thrusting ? 24 : 6);      // counter-rotating

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -76,6 +76,28 @@ try {
   if (!subParts.length) pass('sub v2: props, planes, rudder, beacon all present');
   else fail('sub missing parts: ' + subParts.join(','));
 
+  // POSE CONTINUITY: the craft's quaternion must never jump between
+  // frames. The old Euler read-back pose flipped representations ~67
+  // times per slow diving turn (measured); a brushed turn with pitch is
+  // exactly the manoeuvre that exposed it.
+  await page.mouse.move(215, 430);
+  await page.mouse.down();
+  await page.mouse.move(120, 520, { steps: 5 });   // hard turn + dive
+  await page.mouse.up();
+  const poseJump = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    const prev = g.sub.quaternion.clone();
+    let worst = 0;
+    for (let i = 0; i < 25; i++) {
+      await new Promise(r => setTimeout(r, 80));
+      worst = Math.max(worst, prev.angleTo(g.sub.quaternion));
+      prev.copy(g.sub.quaternion);
+    }
+    return worst;
+  });
+  if (poseJump < 0.6) pass(`craft pose continuous through a turn (max step ${poseJump.toFixed(3)} rad)`);
+  else fail(`craft pose SNAPS: ${poseJump.toFixed(2)} rad between samples`);
+
   // helm smoothness: park right on top of a target and make sure the
   // heading settles instead of flip-flopping between two angles (the
   // reported drift glitch)


### PR DESCRIPTION
The oscillation between two angles was a rotation-representation bug on the craft, not the autopilot: the pose code composed yaw+pitch (a quaternion op that re-extracts Eulers) and then read `rotation.x` back and wrote it. A yaw+pitch composition has two equivalent Euler representations; near the flip boundary the extraction alternates between them per frame, and the write-back slammed the boat between the two orientations. Reproduced deterministically in Node: **67 read-back flips in one slow diving turn**.

The pose is now composed purely from quaternions (qYaw·qPitch·qRoll) with roll kept as a smoothed scalar — nothing in the pose path extracts Euler angles from a composed orientation.

Regression lock in the playtest: brush a hard diving turn, sample the sub's quaternion every 80ms — max frame-to-frame step measured **0.077 rad** (a flip is ~3.14; threshold 0.6). Full playtest (27 assertions) and shell e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_