### PR TITLE
Waterworld: fragment-shader atmosphere — compositing pass, living surface, caustics

### DIFF
--- a/magpie/waterworld/README.md
+++ b/magpie/waterworld/README.md
@@ -5,8 +5,12 @@ Submarine salvage adventure in a flooded former London dock.
 officially retired):** smooth deep-sea bioluminescence — full-resolution
 antialiased rendering (ACES tone mapping), smooth-shaded organic forms
 (lathe-turned hull, blobby fatbergs, plump seal), soft round particles,
-god rays, emissive undertones per structure family. Vendored three.js
-r169, procedural lo-fi WebAudio, no external assets.
+god rays, emissive undertones per structure family — and a shader
+compositing pass (`js/post.js`): screen-space crepuscular rays,
+depth-based water absorption, teal grade, vignette, breathing light and
+fine grain, plus an animated water-surface shader overhead and GPU
+caustic webs dancing on the shallow floor. Vendored three.js r169,
+procedural lo-fi WebAudio, no external assets.
 
 ## The loop
 

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -11,6 +11,7 @@ import {
   makeGhostWhale, makeSeal, makeDuck, BOUNDS, SHELF_Y, DEEP_Y, floorYAt, tint,
 } from './world.js';
 import { UnderwaterFX, glowSprite, currentAt } from './fx.js';
+import { Composite } from './post.js';
 import { FACTS, QUEST_ITEMS, TOOLS, HINTS } from './facts.js';
 
 const AIR_MAX = 100;
@@ -109,6 +110,10 @@ export class WaterworldGame {
     const sun = new THREE.DirectionalLight(0xbbe6ff, 1.0);
     sun.position.set(20, 80, 10);
     this.scene.add(sun);
+    this._sunDir = sun.position.clone().normalize();
+
+    // the compositing pass: crepuscular rays, absorption, grade, grain
+    this.post = new Composite(this.renderer, this.scene, this.camera, { lite: this.lite });
 
     this.dock = buildDock(this.scene);
 
@@ -186,6 +191,7 @@ export class WaterworldGame {
     // pixelated look is retired)
     const w = this.canvas.clientWidth || 480, h = this.canvas.clientHeight || 270;
     this.renderer.setSize(w, h, false);
+    this.post?.setSize(w, h);
     this.camera.aspect = w / h;
     this.camera.updateProjectionMatrix();
   }
@@ -801,6 +807,16 @@ export class WaterworldGame {
     if (!this.tools.has('arclamp')) this.headlamp.intensity = 40;
     this.lightCone.material.opacity = this.ir ? 0
       : (this.tools.has('arclamp') ? 0.13 : 0.06);
+    this._deepT = this.ir ? 0 : Math.min(1, Math.max(0, (depth - 25) / 40));
+
+    // shader clocks: the caustic webs and the living surface
+    const floorShader = this.dock.floor.material.userData.shader;
+    if (floorShader) floorShader.uniforms.uTime.value = this.elapsed;
+    const surf = this.dock.surface.material;
+    if (surf.uniforms) {
+      surf.uniforms.uTime.value = this.elapsed;
+      surf.uniforms.uCam.value.copy(this.camera.position);
+    }
 
     // -------- the living water
     const threats = [this.pos, ...this.eels.map(e => e.pos)];
@@ -1260,7 +1276,14 @@ export class WaterworldGame {
 
   // ------------------------------------------------------------- loop
   render() {
-    this.renderer.render(this.scene, this.camera);
+    if (this.post) {
+      const camDepth = -this.camera.position.y;
+      const rayAmt = Math.max(0, Math.min(1, 1 - (camDepth - 10) / 34));
+      this.post.render(this.elapsed, this._sunDir,
+        { deep: this._deepT || 0, ir: this.ir, rayAmt });
+    } else {
+      this.renderer.render(this.scene, this.camera);
+    }
   }
 
   _frame(t) {

--- a/magpie/waterworld/js/post.js
+++ b/magpie/waterworld/js/post.js
@@ -1,0 +1,163 @@
+// Waterworld post — the compositing pass. The scene renders into a
+// target, then one fullscreen fragment shader does the atmosphere:
+//
+//   · screen-space crepuscular rays (radial-blurred brightness toward
+//     the sun's screen position — real occluded light shafts)
+//   · depth-based water absorption (distance drinks red, then green)
+//   · a gentle teal-shadow grade, vignette, breathing light, fine grain
+//
+// Hand-rolled (no EffectComposer): one render target, one triangle.
+
+import * as THREE from '../../../trees/vendor/three.module.min.js';
+
+const VERT = /* glsl */`
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position.xy, 0.0, 1.0);
+}`;
+
+const FRAG = /* glsl */`
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D tScene;
+uniform sampler2D tDepth;
+uniform float uTime;
+uniform float uDeep;      // 0 shallow … 1 deep basin
+uniform float uIR;        // thermal sight: grading stands down
+uniform float uHasDepth;
+uniform vec2  uSun;       // sun position in uv space
+uniform float uSunVis;    // 0 when the sun is behind the camera
+uniform float uRayAmt;    // shafts fade with depth
+uniform vec2  uRes;
+uniform float uNear;
+uniform float uFar;
+
+float linDepth(vec2 uv) {
+  float z = texture2D(tDepth, uv).x;
+  return (2.0 * uNear) / (uFar + uNear - z * (uFar - uNear));
+}
+
+void main() {
+  vec3 col = texture2D(tScene, vUv).rgb;
+
+  // -- absorption: the water itself eats warm light with distance
+  if (uHasDepth > 0.5 && uIR < 0.5) {
+    float d = clamp(linDepth(vUv) * 2.4, 0.0, 1.0);
+    vec3 deepTint = mix(vec3(0.10, 0.32, 0.48), vec3(0.02, 0.06, 0.14), uDeep);
+    col = mix(col, deepTint, d * 0.28);
+    col.r *= 1.0 - d * 0.2;
+  }
+
+  // -- crepuscular rays: march toward the sun, gather what glows
+  if (uSunVis > 0.001 && uIR < 0.5) {
+    vec2 stp = (uSun - vUv) / float(RAY_SAMPLES);
+    vec2 p = vUv;
+    float illum = 0.0;
+    float decay = 1.0;
+    for (int i = 0; i < RAY_SAMPLES; i++) {
+      p += stp;
+      vec3 s = texture2D(tScene, p).rgb;
+      illum += max(dot(s, vec3(0.30, 0.55, 0.15)) - 0.5, 0.0) * decay;
+      decay *= 0.93;
+    }
+    col += vec3(0.50, 0.72, 0.90)
+      * (illum / float(RAY_SAMPLES)) * 5.0 * uRayAmt * uSunVis;
+  }
+
+  // -- grade: teal lift in the shadows, soft rolloff up top
+  if (uIR < 0.5) {
+    col = pow(col, vec3(0.96));
+    col += vec3(-0.006, 0.006, 0.020);
+  }
+
+  // -- vignette, breathing light, fine grain
+  col *= 1.12;
+  vec2 q = vUv - 0.5;
+  col *= 1.0 - dot(q, q) * 0.30;
+  col *= 1.0 + 0.015 * sin(uTime * 0.4);
+  float g = fract(sin(dot(vUv * uRes + uTime * 61.0, vec2(12.9898, 78.233))) * 43758.5453);
+  col += (g - 0.5) * 0.013;
+
+  gl_FragColor = vec4(col, 1.0);
+}`;
+
+export class Composite {
+  constructor(renderer, scene, camera, opts = {}) {
+    this.renderer = renderer;
+    this.scene = scene;
+    this.camera = camera;
+    this.lite = !!opts.lite;
+    this.enabled = true;
+
+    const gl2 = renderer.capabilities.isWebGL2;
+    this.rt = new THREE.WebGLRenderTarget(2, 2, {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      depthBuffer: true,
+    });
+    if (gl2) {
+      this.rt.depthTexture = new THREE.DepthTexture(2, 2);
+    }
+
+    this.mat = new THREE.ShaderMaterial({
+      defines: { RAY_SAMPLES: this.lite ? 10 : 22 },
+      uniforms: {
+        tScene: { value: this.rt.texture },
+        tDepth: { value: this.rt.depthTexture || this.rt.texture },
+        uTime: { value: 0 },
+        uDeep: { value: 0 },
+        uIR: { value: 0 },
+        uHasDepth: { value: gl2 ? 1 : 0 },
+        uSun: { value: new THREE.Vector2(0.5, 1.2) },
+        uSunVis: { value: 1 },
+        uRayAmt: { value: 1 },
+        uRes: { value: new THREE.Vector2(2, 2) },
+        uNear: { value: camera.near },
+        uFar: { value: camera.far },
+      },
+      vertexShader: VERT,
+      fragmentShader: FRAG,
+      depthTest: false,
+      depthWrite: false,
+    });
+    // one oversized triangle beats a quad (no diagonal seam)
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(
+      new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]), 3));
+    geo.setAttribute('uv', new THREE.BufferAttribute(
+      new Float32Array([0, 0, 2, 0, 0, 2]), 2));
+    this.quad = new THREE.Mesh(geo, this.mat);
+    this.quad.frustumCulled = false;
+    this.postScene = new THREE.Scene();
+    this.postScene.add(this.quad);
+    this.postCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    this._sunWorld = new THREE.Vector3();
+  }
+
+  setSize(w, h) {
+    const pr = this.renderer.getPixelRatio();
+    this.rt.setSize(Math.floor(w * pr), Math.floor(h * pr));
+    this.mat.uniforms.uRes.value.set(w * pr, h * pr);
+  }
+
+  // sunDir: normalized direction TOWARD the sun in world space
+  render(time, sunDir, { deep = 0, ir = false, rayAmt = 1 } = {}) {
+    const u = this.mat.uniforms;
+    u.uTime.value = time;
+    u.uDeep.value = deep;
+    u.uIR.value = ir ? 1 : 0;
+    u.uRayAmt.value = rayAmt;
+    // project a far point along the sun direction into screen uv space
+    this._sunWorld.copy(this.camera.position).addScaledVector(sunDir, 200);
+    const p = this._sunWorld.project(this.camera);
+    const behind = p.z > 1 || p.z < -1;
+    u.uSunVis.value = behind ? 0 : Math.max(0, 1 - Math.hypot(p.x * 0.5, p.y * 0.5) * 0.55);
+    u.uSun.value.set(p.x * 0.5 + 0.5, p.y * 0.5 + 0.5);
+
+    this.renderer.setRenderTarget(this.rt);
+    this.renderer.render(this.scene, this.camera);
+    this.renderer.setRenderTarget(null);
+    this.renderer.render(this.postScene, this.postCam);
+  }
+}

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -384,6 +384,63 @@ export function floorYAt(x, z) {
   return y;
 }
 
+// The surface, seen from below: an animated fragment shader — layered
+// travelling waves, a bright sun patch, distance fade. The ceiling of
+// the whole world, and it moves.
+export function makeWaterSurface(scene) {
+  const geo = new THREE.PlaneGeometry(
+    (BOUNDS.maxX - BOUNDS.minX) * 1.4, (BOUNDS.maxZ - BOUNDS.minZ) * 1.8, 1, 1);
+  geo.rotateX(Math.PI / 2);          // face DOWN at the player
+  const mat = new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    uniforms: {
+      uTime: { value: 0 },
+      uCam: { value: new THREE.Vector3() },
+      uSunDir: { value: new THREE.Vector3(0.24, 0.94, 0.12) },
+    },
+    vertexShader: /* glsl */`
+      varying vec3 vW;
+      void main() {
+        vW = (modelMatrix * vec4(position, 1.0)).xyz;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }`,
+    fragmentShader: /* glsl */`
+      precision highp float;
+      varying vec3 vW;
+      uniform float uTime;
+      uniform vec3 uCam;
+      uniform vec3 uSunDir;
+      void main() {
+        vec2 p = vW.xz;
+        float t = uTime;
+        // layered travelling waves — cheap, endless, never tiles
+        float w = 0.0;
+        w += sin(p.x * 0.055 + t * 0.9 + sin(p.y * 0.083 - t * 0.6));
+        w += sin(p.y * 0.071 - t * 0.7 + sin(p.x * 0.047 + t * 0.8)) * 0.8;
+        w += sin((p.x + p.y) * 0.031 + t * 0.5) * 0.6;
+        w += sin(length(p) * 0.09 - t * 1.1) * 0.3;
+        float shimmer = 0.5 + w * 0.18;
+        // the sun through the surface: a soft bright patch
+        vec3 toCam = normalize(uCam - vW);
+        vec2 sunXZ = uCam.xz + uSunDir.xz / max(uSunDir.y, 0.05) * (-uCam.y);
+        float sun = exp(-length(p - sunXZ) * 0.012);
+        vec3 col = mix(vec3(0.15, 0.42, 0.62), vec3(0.75, 0.92, 1.0), shimmer * 0.5);
+        col += vec3(1.0, 0.95, 0.8) * sun * (0.9 + 0.25 * w);
+        // fade with distance so the plane never shows an edge
+        float dist = length(vW - uCam);
+        float a = clamp(1.4 - dist / 160.0, 0.0, 1.0) * 0.85;
+        gl_FragColor = vec4(col, a);
+      }`,
+  });
+  const m = new THREE.Mesh(geo, mat);
+  m.position.y = -0.3;
+  m.renderOrder = 2;
+  scene.add(m);
+  return m;
+}
+
 function makeFloor(scene) {
   const geo = new THREE.PlaneGeometry(
     BOUNDS.maxX - BOUNDS.minX, BOUNDS.maxZ - BOUNDS.minZ, 48, 32);
@@ -402,8 +459,30 @@ function makeFloor(scene) {
   }
   geo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
   geo.computeVertexNormals();
-  const m = new THREE.Mesh(geo,
-    new THREE.MeshLambertMaterial({ vertexColors: true }));
+  // caustics live IN the floor's fragment shader: animated light webs
+  // dancing on the silt, fading out with depth (sunlight runs out)
+  const floorMat = new THREE.MeshLambertMaterial({ vertexColors: true });
+  floorMat.onBeforeCompile = (shader) => {
+    shader.uniforms.uTime = { value: 0 };
+    floorMat.userData.shader = shader;
+    shader.vertexShader = shader.vertexShader
+      .replace('#include <common>', '#include <common>\nvarying vec3 vWPos;')
+      .replace('#include <begin_vertex>',
+        '#include <begin_vertex>\nvWPos = (modelMatrix * vec4(position, 1.0)).xyz;');
+    shader.fragmentShader = shader.fragmentShader
+      .replace('#include <common>', '#include <common>\nvarying vec3 vWPos;\nuniform float uTime;')
+      .replace('#include <emissivemap_fragment>', /* glsl */`#include <emissivemap_fragment>
+        {
+          vec2 cp = vWPos.xz * 0.16;
+          float ct = uTime * 0.55;
+          float c1 = sin(cp.x + ct + sin(cp.y * 1.31 - ct * 0.73));
+          float c2 = sin(cp.y - ct * 0.82 + sin(cp.x * 1.72 + ct));
+          float web = pow(max(0.0, c1 * c2), 3.0);
+          float sunFade = clamp(1.0 - (-vWPos.y - 34.0) / 28.0, 0.0, 1.0);
+          totalEmissiveRadiance += vec3(0.30, 0.55, 0.62) * web * sunFade * 0.75;
+        }`);
+  };
+  const m = new THREE.Mesh(geo, floorMat);
   scene.add(m);
   return m;
 }
@@ -547,7 +626,8 @@ export function makeWeeds(scene, count = 110) {
 
 // The whole static set. Returns collider list for the physics step.
 export function buildDock(scene) {
-  makeFloor(scene);
+  const floor = makeFloor(scene);
+  const surface = makeWaterSurface(scene);
   const quay = makeQuayWalls(scene);
   const culverts = makeCulverts(scene);
   const crane = makeCrane(scene);
@@ -570,7 +650,7 @@ export function buildDock(scene) {
     { x: -40, y: SHELF_Y + 4, z: 30, r: 10 },    // barge
     { x: 85, y: DEEP_Y + 6, z: -30, r: 11 },     // warehouse
   ];
-  return { culverts, crane, barge, warehouse, bell, weeds, colliders };
+  return { culverts, crane, barge, warehouse, bell, weeds, colliders, floor, surface };
 }
 
 // ---------------------------------------------------------------- particles


### PR DESCRIPTION
High-perf frag shaders and artful atmospheric compositing, all hand-rolled against the vendored three.js (no EffectComposer, no new deps):

- **Compositing pass (`js/post.js`):** scene → render target with depth texture → one fullscreen triangle: screen-space crepuscular rays (radial-marched toward the sun's projected position, genuinely occluded by geometry, fading with depth/sun angle), depth-based water absorption (red drinks first), teal-shadow grade, vignette, breathing light, fine grain. 22 samples (10 in `?lite`); WebGL1 falls back cleanly; IR mode stands the grading down.
- **The surface, from below:** a ShaderMaterial ceiling over the basin — four layered travelling waves that never tile, a sun patch derived from camera + sun direction, distance-faded edges.
- **GPU caustics:** animated light webs injected into the floor's own Lambert shader (`onBeforeCompile` → `totalEmissiveRadiance`), world-positioned across the silt dunes, fading below ~34m.

Graded from screenshots, not source (first pass came out too dark; absorption eased, vignette halved, +12% gain). Full playtest, shell e2e, html-validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_