### PR TITLE
Waterworld: hulls above, dolphins, sharks, reef fish, electric eels — and you can see out

### DIFF
--- a/magpie/waterworld/js/audio.js
+++ b/magpie/waterworld/js/audio.js
@@ -264,6 +264,34 @@ export class WaterAudio {
     o.start(t); o.stop(t + 0.8); vib.stop(t + 0.8);
   }
 
+  clicks() {
+    // dolphin: a falling train of bright little ticks
+    if (!this.ctx) return;
+    const t = this._now();
+    for (let i = 0; i < 7; i++) {
+      const { o, g } = this._osc('sine', 2400 - i * 180, this.master);
+      this._env(g, t + i * 0.06, 0.05, 0.004, 0.05);
+      o.start(t + i * 0.06); o.stop(t + i * 0.06 + 0.08);
+    }
+  }
+
+  zap() {
+    // electric eel: a crackle of filtered noise over a snapping drop
+    if (!this.ctx) return;
+    const t = this._now();
+    const n = this._noise(0.25);
+    const hp = this.ctx.createBiquadFilter();
+    hp.type = 'highpass'; hp.frequency.value = 1800;
+    const g = this.ctx.createGain();
+    n.connect(hp).connect(g).connect(this.master);
+    this._env(g, t, 0.22, 0.004, 0.22);
+    n.start(t);
+    const { o, g: g2 } = this._osc('square', 320, this.master);
+    o.frequency.exponentialRampToValueAtTime(70, t + 0.16);
+    this._env(g2, t, 0.14, 0.004, 0.16);
+    o.start(t); o.stop(t + 0.2);
+  }
+
   sealBark() {
     if (!this.ctx) return;
     const t = this._now();

--- a/magpie/waterworld/js/facts.js
+++ b/magpie/waterworld/js/facts.js
@@ -70,6 +70,24 @@ export const FACTS = {
     value: 50,
     text: 'The 2017 Whitechapel fatberg was 250 metres long and weighed about 130 tonnes. A chunk of it went on display at the Museum of London.',
   },
+  dolphin_visit: {
+    name: 'Thames dolphins',
+    icon: '🐬',
+    value: 0,
+    text: 'Bottlenose dolphins and porpoises really do follow fish up the Thames — sightings run from Gravesend to Putney.',
+  },
+  shark_visit: {
+    name: 'Thames sharks',
+    icon: '🦈',
+    value: 0,
+    text: 'The Thames estuary has real sharks — tope, starry smooth-hound and spurdog. The smooth-hounds mostly eat crabs.',
+  },
+  eel_zap: {
+    name: 'London eels',
+    icon: '⚡',
+    value: 0,
+    text: 'The Thames once ran thick with eels — jellied eels fed the East End, and Eel Pie Island still carries the name. Electric ones are… a local embellishment.',
+  },
   seal_visit: {
     name: 'Thames seal',
     icon: '🦭',

--- a/magpie/waterworld/js/fauna.js
+++ b/magpie/waterworld/js/fauna.js
@@ -1,0 +1,186 @@
+// Waterworld fauna — the life that makes looking UP worth it: moored
+// hulls hanging in the ceiling light, a dolphin pod that breaches the
+// surface, sharks that circle out of curiosity (Thames sharks are real
+// and mostly eat crabs), and bright reef fish darting round the wrecks.
+// Ambience with presence; the only gameplay it touches is wonder.
+
+import * as THREE from '../../../trees/vendor/three.module.min.js';
+import {
+  BOUNDS, floorYAt, makeBoatHull, makeDolphin, makeShark, makeReefFish,
+} from './world.js';
+import { currentAt } from './fx.js';
+
+const _v = new THREE.Vector3();
+
+export class Fauna {
+  constructor(scene, opts = {}) {
+    this.scene = scene;
+    this.lite = !!opts.lite;
+
+    // --- moored boats at the surface, each swinging round its mooring
+    this.hulls = [];
+    const moorings = [
+      { kind: 'barge', x: -25, z: 55 },
+      { kind: 'tug', x: 30, z: -50 },
+      { kind: 'narrowboat', x: 75, z: 25 },
+    ];
+    for (const m of moorings) {
+      const h = makeBoatHull(m.kind);
+      h.position.set(m.x, -0.35, m.z);
+      h.rotation.y = Math.random() * Math.PI;
+      h.userData.home = { x: m.x, z: m.z };
+      h.userData.phase = Math.random() * 9;
+      scene.add(h);
+      this.hulls.push(h);
+    }
+    // crude but honest colliders so the sub can bump a hull
+    this.colliders = this.hulls.map(h => ({
+      x: h.position.x, y: -1.5, z: h.position.z,
+      r: h.userData.spec.beam * 0.9 + 2,
+    }));
+
+    // --- the dolphin pod: a leader on an endless curve, two followers
+    this.dolphins = [];
+    for (let i = 0; i < 3; i++) {
+      const d = makeDolphin();
+      d.userData.irColor = 0xcc7744;      // warm-blooded, like the seal
+      d.userData.lag = i * 0.55;
+      scene.add(d);
+      this.dolphins.push(d);
+    }
+    this._podT = Math.random() * 20;
+
+    // --- sharks: slow deep patrols, occasionally curious
+    this.sharks = [];
+    const beats = [
+      { cx: 55, cz: 20, rx: 45, rz: 30, y: -20 },
+      { cx: -20, cz: -30, rx: 55, rz: 28, y: -16 },
+    ];
+    for (let i = 0; i < (this.lite ? 1 : 2); i++) {
+      const s = makeShark();
+      s.userData.irColor = 0x44586e;      // cold fish, faint trace
+      scene.add(s);
+      this.sharks.push({
+        mesh: s, beat: beats[i % beats.length],
+        phase: Math.random() * 9, curious: 0, angle: 0,
+      });
+    }
+
+    // --- reef fish: bright loners round the wrecks
+    this.fish = [];
+    const fishColors = [0xff7a3c, 0xffd23c, 0x3cc8ff, 0xff5ca8, 0x7dff6e, 0xb48cff];
+    const homes = [[-40, 30], [60, 40], [85, -30], [-70, -20], [10, 55]];
+    const n = this.lite ? 6 : 12;
+    for (let i = 0; i < n; i++) {
+      const f = makeReefFish(fishColors[i % fishColors.length]);
+      const [hx, hz] = homes[i % homes.length];
+      const home = new THREE.Vector3(
+        hx + (Math.random() - 0.5) * 14,
+        floorYAt(hx, hz) + 3 + Math.random() * 6,
+        hz + (Math.random() - 0.5) * 14);
+      f.position.copy(home);
+      f.userData.home = home;
+      f.userData.target = home.clone();
+      f.userData.phase = Math.random() * 9;
+      this.scene.add(f);
+      this.fish.push(f);
+    }
+  }
+
+  // Returns proximity events for the game to narrate.
+  step(dt, t, sub) {
+    const out = { dolphinsNear: false, sharksNear: false };
+
+    // hulls: bob, roll a little, swing slowly round the mooring
+    for (const h of this.hulls) {
+      const u = h.userData;
+      h.position.y = -0.35 + Math.sin(t * 0.5 + u.phase) * 0.14;
+      h.rotation.z = Math.sin(t * 0.4 + u.phase * 2) * 0.03;
+      h.rotation.y += dt * 0.012;
+      h.position.x = u.home.x + Math.sin(t * 0.05 + u.phase) * 2.5;
+      h.position.z = u.home.z + Math.cos(t * 0.045 + u.phase) * 2.5;
+    }
+    for (let i = 0; i < this.hulls.length; i++) {
+      this.colliders[i].x = this.hulls[i].position.x;
+      this.colliders[i].z = this.hulls[i].position.z;
+    }
+
+    // dolphins: the pod arcs through the upper water and BREACHES —
+    // through the surface sheet and back with a roll of the fluke
+    this._podT += dt * 0.55;
+    for (const d of this.dolphins) {
+      const k = this._podT - d.userData.lag;
+      const px = -10 + 75 * Math.sin(k * 0.35);
+      const pz = 45 * Math.sin(k * 0.23 + 1.3);
+      const py = -3.8 + 4.4 * Math.sin(k * 1.15);   // tops out ABOVE the sheet
+      _v.set(px, Math.min(py, 1.0), pz);
+      const step = _v.clone().sub(d.position);
+      d.position.lerp(_v, 1 - Math.pow(0.001, dt));
+      if (step.lengthSq() > 0.001) {
+        d.lookAt(d.position.clone().add(step));
+        d.rotateY(-Math.PI / 2);
+      }
+      d.userData.fluke.rotation.z = Math.sin(t * 7 + d.userData.lag * 4) * 0.4;
+      if (d.position.distanceTo(sub) < 24) out.dolphinsNear = true;
+    }
+
+    // sharks: patrol an ellipse; if the sub is close, circle IT a while
+    for (const s of this.sharks) {
+      const m = s.mesh;
+      let target;
+      const dSub = m.position.distanceTo(sub);
+      if (s.curious > 0) {
+        s.curious -= dt;
+        s.angle += dt * 0.7;
+        target = _v.set(sub.x + Math.cos(s.angle) * 8,
+          sub.y + 1.5 + Math.sin(s.angle * 1.7), sub.z + Math.sin(s.angle) * 8);
+      } else {
+        if (dSub < 16 && Math.sin(t * 0.11 + s.phase) > 0.55) s.curious = 11;
+        s.phase += dt * 0.14;
+        target = _v.set(
+          s.beat.cx + Math.cos(s.phase) * s.beat.rx,
+          s.beat.y + Math.sin(s.phase * 1.9) * 4,
+          s.beat.cz + Math.sin(s.phase) * s.beat.rz);
+      }
+      target.y = Math.max(floorYAt(target.x, target.z) + 3, Math.min(-3, target.y));
+      const step = target.clone().sub(m.position);
+      const dist = step.length();
+      if (dist > 0.3) {
+        m.position.addScaledVector(step.normalize(), Math.min(7.5, dist) * dt);
+        m.lookAt(m.position.clone().add(step));
+        m.rotateY(-Math.PI / 2);
+      }
+      m.userData.tail.rotation.y = Math.sin(t * 4.5 + s.phase) * 0.45;
+      if (dSub < 15) out.sharksNear = true;
+    }
+
+    // reef fish: hop between spots near home, flee the sub
+    for (const f of this.fish) {
+      const u = f.userData;
+      if (f.position.distanceTo(u.target) < 1 || Math.random() < dt * 0.25) {
+        u.target.copy(u.home).add(_v.set(
+          (Math.random() - 0.5) * 12, (Math.random() - 0.5) * 5, (Math.random() - 0.5) * 12));
+      }
+      const fromSub = f.position.distanceTo(sub);
+      if (fromSub < 6) {
+        u.target.copy(f.position).addScaledVector(
+          _v.copy(f.position).sub(sub).normalize(), 10);
+      }
+      u.target.y = Math.max(floorYAt(u.target.x, u.target.z) + 1.5, Math.min(-2.5, u.target.y));
+      const step = _v.copy(u.target).sub(f.position);
+      const dist = step.length();
+      if (dist > 0.2) {
+        const speed = fromSub < 6 ? 9 : 2.6;
+        f.position.addScaledVector(step.normalize(), Math.min(speed, dist * 2) * dt);
+        f.lookAt(f.position.clone().add(step));
+        f.rotateY(-Math.PI / 2);
+      }
+      // the gyre nudges everyone
+      currentAt(f.position, t, _v);
+      f.position.addScaledVector(_v, 0.3 * dt);
+      f.userData.tail.rotation.y = Math.sin(t * 9 + u.phase) * 0.6;
+    }
+
+    return out;
+  }
+}

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -13,6 +13,7 @@ import {
 } from './world.js';
 import { UnderwaterFX, glowSprite, currentAt } from './fx.js';
 import { Composite } from './post.js';
+import { Fauna } from './fauna.js';
 import { FACTS, QUEST_ITEMS, TOOLS, HINTS } from './facts.js';
 
 const AIR_MAX = 100;
@@ -159,6 +160,9 @@ export class WaterworldGame {
 
     // the living water: currents, fish, god rays, plankton, vents, plumes
     this.fx = new UnderwaterFX(this.scene, { lite: this.lite });
+    // …and the big life: hulls above, dolphins, sharks, reef fish
+    this.fauna = new Fauna(this.scene, { lite: this.lite });
+    this.dock.colliders.push(...this.fauna.colliders);
     this.ir = false;
     this._irMats = new Map();
     this._irUsedOnce = false;
@@ -274,8 +278,16 @@ export class WaterworldGame {
       this.scene.add(head);
       if (this.ir) { this._irApply(head); segs.forEach(s => this._irApply(s)); }
       const cx = 30 + Math.random() * 70, cz = (Math.random() - 0.5) * 120;
+      // ELECTRIC: crackling arc sprites flicker along the body
+      const arcs = [];
+      for (let a = 0; a < 3; a++) {
+        const arc = glowSprite(0x9fdcff, 1.3, 0.85);
+        arc.userData.irHot = true;
+        (a === 0 ? head : segs[(a * 2) % segs.length]).add(arc);
+        arcs.push(arc);
+      }
       this.eels.push({
-        head, segs,
+        head, segs, arcs,
         pos: new THREE.Vector3(cx, floorYAt(cx, cz) + 6 + Math.random() * 10, cz),
         angle: Math.random() * Math.PI * 2,
         center: new THREE.Vector3(cx, 0, cz),
@@ -751,7 +763,8 @@ export class WaterworldGame {
     this.pos.z = Math.max(BOUNDS.minZ + 2, Math.min(BOUNDS.maxZ - 2, this.pos.z));
     const fy = floorYAt(this.pos.x, this.pos.z) + 1.4;
     if (this.pos.y < fy) { this.pos.y = fy; this.vel.y = Math.abs(this.vel.y) * 0.3; }
-    if (this.pos.y > BOUNDS.surface) { this.pos.y = BOUNDS.surface; this.vel.y = -Math.abs(this.vel.y) * 0.3; }
+    // you can porpoise: the sail may break the surface for a moment
+    if (this.pos.y > -0.9) { this.pos.y = -0.9; this.vel.y = -Math.abs(this.vel.y) * 0.3; }
     for (const c of this.dock.colliders) {
       const d = this.pos.distanceTo(c);
       if (d < c.r) {
@@ -779,7 +792,9 @@ export class WaterworldGame {
     ud.beacon.visible = Math.sin(this.elapsed * 4.5) > -0.35;   // masthead blink
 
     const camTarget = this.pos.clone().addScaledVector(fwd, -10).add(new THREE.Vector3(0, 3.5, 0));
-    camTarget.y = Math.min(camTarget.y, BOUNDS.surface + 1);
+    // near the top the camera may ride just above the waterline, so
+    // porpoising actually shows you OUT for a breath
+    camTarget.y = Math.min(camTarget.y, BOUNDS.surface + 2.6);
     this.camera.position.lerp(camTarget, 1 - Math.pow(0.001, dt));
     // the gaze is smoothed too: a lookAt chasing a jittery forward
     // vector is half of any "camera snapping" complaint
@@ -825,6 +840,24 @@ export class WaterworldGame {
       ? [...this.fatbergs.map(f => f.mesh.position), this.pos]
       : [];
     this.fx.step(dt, this.elapsed, this.pos, threats, -this.camera.position.y, hot);
+    const faunaEv = this.fauna.step(dt, this.elapsed, this.pos);
+    if (faunaEv.dolphinsNear) {
+      if (!this.codex.has('dolphin_visit')) {
+        this.codex.add('dolphin_visit');
+        this._factQueue.push('dolphin_visit');
+      }
+      if (this.elapsed - (this._lastClicks || 0) > 15) {
+        this._lastClicks = this.elapsed;
+        this.ui.audio?.clicks();
+        this.ui.announce('Dolphins nearby — you can hear their clicks.');
+      }
+    }
+    if (faunaEv.sharksNear && !this.codex.has('shark_visit')) {
+      this.codex.add('shark_visit');
+      this._factQueue.push('shark_visit');
+      this.ui.toast('🦈 A shark is circling. It mostly eats crabs. Mostly.', 'warn');
+      this.ui.announce('A shark is circling the sub, out of curiosity.');
+    }
 
     // -------- air + hull economy
     this.air -= dt * (thrusting ? 1.7 : 1.1) * (1 + this.banks * 0.06);
@@ -990,8 +1023,19 @@ export class WaterworldGame {
         if (toPlayer < 2.6 && e.bite <= 0) {
           e.bite = 1.6;
           this.ui.audio?.growl();
-          this._damage(1, 'An eel gets its teeth into the hull');
+          this.ui.audio?.zap();
+          this._damage(1, 'An electric eel jolts the hull — every gauge flickers');
+          if (!this.codex.has('eel_zap')) {
+            this.codex.add('eel_zap');
+            this._factQueue.push('eel_zap');
+          }
         }
+      }
+      // the crackle: arcs flicker at random, harder when hunting
+      const hunting = e.pos.distanceTo(this.pos) < 22;
+      for (const arc of e.arcs) {
+        arc.visible = Math.random() < (hunting ? 0.45 : 0.18);
+        if (arc.visible) arc.scale.setScalar(0.8 + Math.random() * (hunting ? 1.6 : 1.0));
       }
       // pose: head faces travel, segments follow like a chain
       e.head.position.copy(e.pos);

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -215,6 +215,112 @@ export function makeSub() {
   return g;
 }
 
+// A moored boat, seen from below: dark rounded hull hanging in the
+// bright ceiling. kind: 'tug' | 'narrowboat' | 'barge'.
+export function makeBoatHull(kind) {
+  const g = new THREE.Group();
+  const spec = {
+    tug: { L: 16, beam: 6, draft: 3.2, color: 0x7a2f20 },
+    narrowboat: { L: 20, beam: 3.4, draft: 1.6, color: 0x1e4030 },
+    barge: { L: 26, beam: 8, draft: 2.6, color: 0x24303e },
+  }[kind] || { L: 18, beam: 6, draft: 2.5, color: 0x333333 };
+  // bottom half-ellipsoid hull
+  const hull = new THREE.Mesh(
+    new THREE.SphereGeometry(1, 26, 14, 0, Math.PI * 2, Math.PI / 2, Math.PI / 2),
+    mat(spec.color));
+  hull.scale.set(spec.L / 2, spec.draft, spec.beam / 2);
+  g.add(hull);
+  // keel strake, rudder, a still prop
+  const keel = new THREE.Mesh(new THREE.BoxGeometry(spec.L * 0.7, 0.3, 0.35), mat(0x1a1a1a));
+  keel.position.y = -spec.draft * 0.96;
+  g.add(keel);
+  const rudder = new THREE.Mesh(new THREE.BoxGeometry(0.2, spec.draft * 0.8, 1.2), mat(0x1a1a1a));
+  rudder.position.set(-spec.L / 2 + 0.4, -spec.draft * 0.5, 0);
+  g.add(rudder);
+  ball(g, 0.5, 0x2a2a2a, -spec.L / 2 + 1.4, -spec.draft * 0.55, 0);
+  // waterline shimmer: a pale band right at the surface
+  const band = new THREE.Mesh(new THREE.CylinderGeometry(1.001, 1.001, 0.25, 26, 1, true),
+    mat(0xd8ecf4, { emissive: 0x5a7f90 }));
+  band.scale.set(spec.L / 2, 1, spec.beam / 2);
+  band.position.y = 0.05;
+  g.add(band);
+  g.userData.spec = spec;
+  return g;
+}
+
+// A dolphin — grey above, pale below, permanently mid-smile.
+export function makeDolphin() {
+  const g = new THREE.Group();
+  const body = ball(g, 1, 0x8fa8b8, 0, 0, 0);
+  body.scale.set(2.1, 0.62, 0.55);
+  const belly = ball(g, 0.92, 0xdfeaf2, 0.1, -0.12, 0);
+  belly.scale.set(1.9, 0.5, 0.48);
+  const snout = new THREE.Mesh(new THREE.ConeGeometry(0.3, 1.0, 14), mat(0x8fa8b8));
+  snout.rotation.z = -Math.PI / 2;
+  snout.position.set(2.2, 0.05, 0);
+  g.add(snout);
+  const fin = ball(g, 0.55, 0x76909f, -0.2, 0.72, 0);   // dorsal
+  fin.scale.set(0.55, 0.9, 0.12);
+  fin.rotation.z = -0.5;
+  for (const s of [1, -1]) {
+    const fl = ball(g, 0.42, 0x76909f, 0.7, -0.3, s * 0.5);
+    fl.scale.set(0.9, 0.14, 0.5);
+    fl.rotation.y = s * 0.5;
+  }
+  const fluke = ball(g, 0.5, 0x76909f, -2.2, 0.05, 0);
+  fluke.scale.set(0.5, 0.14, 1.5);
+  g.userData.fluke = fluke;
+  ball(g, 0.08, 0x111111, 1.55, 0.18, 0.32);
+  ball(g, 0.08, 0x111111, 1.55, 0.18, -0.32);
+  return g;
+}
+
+// A shark — longer, lower, and not actually interested in you.
+export function makeShark() {
+  const g = new THREE.Group();
+  const body = ball(g, 1, 0x5c707e, 0, 0, 0);
+  body.scale.set(2.7, 0.7, 0.6);
+  const belly = ball(g, 0.9, 0xc4ccd2, 0.1, -0.18, 0);
+  belly.scale.set(2.4, 0.5, 0.5);
+  const snout = ball(g, 0.55, 0x5c707e, 2.5, 0, 0);
+  snout.scale.set(1.2, 0.55, 0.7);
+  const dorsal = ball(g, 0.8, 0x4a5a66, -0.1, 0.95, 0);
+  dorsal.scale.set(0.7, 1.0, 0.1);
+  dorsal.rotation.z = -0.35;
+  for (const s of [1, -1]) {
+    const p = ball(g, 0.6, 0x4a5a66, 0.9, -0.35, s * 0.7);
+    p.scale.set(0.9, 0.1, 0.55);
+    p.rotation.y = s * 0.6;
+    p.rotation.z = s * -0.15;
+  }
+  const tail = new THREE.Group();
+  const tUp = ball(tail, 0.7, 0x4a5a66, 0, 0.5, 0);
+  tUp.scale.set(0.5, 1.1, 0.1);
+  tUp.rotation.z = 0.5;
+  const tDn = ball(tail, 0.45, 0x4a5a66, 0, -0.3, 0);
+  tDn.scale.set(0.4, 0.7, 0.1);
+  tDn.rotation.z = -0.4;
+  tail.position.set(-2.8, 0, 0);
+  g.add(tail);
+  g.userData.tail = tail;
+  ball(g, 0.09, 0x0a0a0a, 2.1, 0.15, 0.4);
+  ball(g, 0.09, 0x0a0a0a, 2.1, 0.15, -0.4);
+  return g;
+}
+
+// A bright little reef fish for the close-up shots the schools can't do.
+export function makeReefFish(color) {
+  const g = new THREE.Group();
+  const body = ball(g, 0.4, color, 0, 0, 0, { emissive: new THREE.Color(color).multiplyScalar(0.25).getHex() });
+  body.scale.set(1.5, 1.0, 0.4);
+  const tail = ball(g, 0.28, color, -0.68, 0, 0);
+  tail.scale.set(0.6, 0.9, 0.1);
+  g.userData.tail = tail;
+  ball(g, 0.05, 0x111111, 0.42, 0.1, 0.13);
+  ball(g, 0.05, 0x111111, 0.42, 0.1, -0.13);
+  return g;
+}
+
 // A curious Thames seal — pure delight, zero threat. Now properly plump.
 export function makeSeal() {
   const g = new THREE.Group();


### PR DESCRIPTION
The surface zone becomes a destination:

- **Moored hulls** (tug, narrowboat, barge) hang at the surface as silhouettes in the ceiling light — keels, rudders, waterline bands, bobbing and swinging on their moorings, with real colliders.
- **You can see out:** the sub can porpoise and the chase camera rides just above the waterline near the top — the hulls read from above the water against the sky.
- **Dolphin pod** breaching through the surface sheet, click-train audio, true Thames-dolphins codex entry (warm in IR — mammals).
- **Sharks** on deep patrol that circle a close sub out of curiosity; true codex entry (tope/smooth-hound/spurdog; the smooth-hounds mostly eat crabs).
- **Reef fish:** a dozen bright glowing mesh fish darting round the wrecks, fleeing the sub.
- **ELECTRIC eels:** crackling arc sprites along every body, harder when hunting; bites zap with a new synth voice and unlock a jellied-eels/Eel Pie Island codex entry.

Codex grows to 16. Playtest, shell e2e, html-validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_