### PR TITLE
Waterworld: the un-ploddening — push-your-luck economy, dash, sonar chart, skyline

### DIFF
--- a/magpie/waterworld/js/audio.js
+++ b/magpie/waterworld/js/audio.js
@@ -264,6 +264,21 @@ export class WaterAudio {
     o.start(t); o.stop(t + 0.8); vib.stop(t + 0.8);
   }
 
+  whoosh() {
+    // dash: a throaty push of water
+    if (!this.ctx) return;
+    const t = this._now();
+    const n = this._noise(0.5);
+    const bp = this.ctx.createBiquadFilter();
+    bp.type = 'bandpass'; bp.Q.value = 0.7;
+    bp.frequency.setValueAtTime(900, t);
+    bp.frequency.exponentialRampToValueAtTime(180, t + 0.4);
+    const g = this.ctx.createGain();
+    n.connect(bp).connect(g).connect(this.master);
+    this._env(g, t, 0.3, 0.02, 0.42);
+    n.start(t);
+  }
+
   clicks() {
     // dolphin: a falling train of bright little ticks
     if (!this.ctx) return;

--- a/magpie/waterworld/js/fx.js
+++ b/magpie/waterworld/js/fx.js
@@ -96,7 +96,7 @@ class School {
     scene.add(this.points);
   }
 
-  step(dt, t, sub, threats) {
+  step(dt, t, sub, threats, tide = 1) {
     const { n, pos, vel } = this;
     const K = 7;                       // sampled neighbours per boid
     const maxV = 8.5;
@@ -132,7 +132,7 @@ class School {
       // the gyre carries everyone
       _tmp.set(pos[ix], pos[ix + 1], pos[ix + 2]);
       currentAt(_tmp, t, _tmp);
-      ax += _tmp.x * 0.35; ay += _tmp.y * 0.35; az += _tmp.z * 0.35;
+      ax += _tmp.x * 0.35 * tide; ay += _tmp.y * 0.35 * tide; az += _tmp.z * 0.35 * tide;
 
       vel[ix] += ax * dt * 4; vel[ix + 1] += ay * dt * 4; vel[ix + 2] += az * dt * 4;
       const sp = Math.hypot(vel[ix], vel[ix + 1], vel[ix + 2]);
@@ -261,7 +261,8 @@ export class UnderwaterFX {
   }
 
   // hotSpots: [{x,y,z}] — fatbergs and the sub's engine, fed by game.js
-  step(dt, t, subPos, threats, camDepth, hotSpots = []) {
+  step(dt, t, subPos, threats, camDepth, hotSpots = [], tide = 1) {
+    this._tide = tide;
     // god rays live near the surface and die with depth
     const depthFade = Math.max(0, Math.min(1, 1 - (camDepth - 10) / 34));
     for (const r of this.rays) {
@@ -281,7 +282,7 @@ export class UnderwaterFX {
 
     this._drift(this.debris, dt, t, 1.0, 0);
 
-    for (const s of this.schools) s.step(dt, t, subPos, threats);
+    for (const s of this.schools) s.step(dt, t, subPos, threats, tide);
 
     // vent bubbles rise and recycle
     for (const v of this.vents) {
@@ -326,9 +327,10 @@ export class UnderwaterFX {
       _tmp.set(pos.getX(i), pos.getY(i), pos.getZ(i));
       const p = _tmp.clone();
       currentAt(p, t, _tmp);
-      let x = p.x + _tmp.x * carry * dt;
+      const tide = this._tide || 1;
+      let x = p.x + _tmp.x * carry * tide * dt;
       let y = p.y + (_tmp.y * carry + rise) * dt;
-      let z = p.z + _tmp.z * carry * dt;
+      let z = p.z + _tmp.z * carry * tide * dt;
       if (x < BOUNDS.minX) x = BOUNDS.maxX; if (x > BOUNDS.maxX) x = BOUNDS.minX;
       if (z < BOUNDS.minZ) z = BOUNDS.maxZ; if (z > BOUNDS.maxZ) z = BOUNDS.minZ;
       if (y > -2) y = -58; if (y < -60) y = -3;

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -89,6 +89,20 @@ export class WaterworldGame {
     this._sealAt = 45;
     this.duck = null;
     this._duckDone = false;
+
+    // the decision layer: combos, dash, spillable cargo, events
+    this.combo = 0;
+    this._comboT = -99;
+    this._dashCd = 0;
+    this._lastA = -99;
+    this._fovKick = 0;
+    this.spilled = [];           // dropped cargo, briefly recoverable
+    this.tide = 1;
+    this._tideT = 55;
+    this._tideLeft = 0;
+    this._cacheT = 80;
+    this.cache = null;
+    this._bankOrder = false;     // the CAPTAIN decides when to bank
   }
 
   // ------------------------------------------------------------- setup
@@ -354,7 +368,26 @@ export class WaterworldGame {
     if (k in this.keys) this.keys[k] = down;
     // taking any control surface takes the helm for a few seconds
     if (down && k !== 'b') this.manualUntil = this.elapsed + 4;
+    if (k === 'a' && down) {
+      if (this.elapsed - this._lastA < 0.35) this.dash();
+      this._lastA = this.elapsed;
+    }
     if (k === 'b' && down) this._doPing();
+  }
+
+  // DASH: a hard push of water. Double-tap A (or double-tap the screen).
+  // Costs a breath of air, so it's a spend, not a freebie.
+  dash() {
+    if (this.over || this._dashCd > 0) return;
+    this._dashCd = 2.2;
+    const fwd = new THREE.Vector3(
+      Math.cos(this.pitch) * Math.cos(this.yaw), Math.sin(this.pitch),
+      -Math.cos(this.pitch) * Math.sin(this.yaw));
+    this.vel.addScaledVector(fwd, 30);
+    this.air = Math.max(0, this.air - 1.5);
+    this._fovKick = 1;
+    this.ui.audio?.whoosh();
+    for (let i = 0; i < 4; i++) this._bubbleT = -1;   // a burst in the wake
   }
 
   // A brush across the water is a course order from the captain: bank
@@ -564,11 +597,16 @@ export class WaterworldGame {
     for (const s of this.salvage) {
       if (!s.collected && !s.hidden && s.mesh.position.distanceTo(this.pos) < R) {
         glintAt(s.mesh.position, P8.yellow);
+        s._known = true;                       // and the CHART remembers it
       }
     }
     for (const q of this.quest) {
-      if (!q.taken && q.mesh.position.distanceTo(this.pos) < R) glintAt(q.mesh.position, P8.pink);
+      if (!q.taken && q.mesh.position.distanceTo(this.pos) < R) {
+        glintAt(q.mesh.position, P8.pink);
+        q._known = true;
+      }
     }
+    for (const m of this.mines) if (m.live && m.mesh.position.distanceTo(this.pos) < R) m._known = true;
     // stun close eels
     for (const e of this.eels) {
       if (e.pos.distanceTo(this.pos) < 10) {
@@ -604,6 +642,25 @@ export class WaterworldGame {
   _damage(n, why) {
     if (this.over) return;
     this.hull -= n;
+    this.combo = 0;
+    // PUSH YOUR LUCK: a hit knocks half your unbanked haul loose. It
+    // floats there, recoverable, fading — bank early or dive braver.
+    if (this.cargo.length >= 2) {
+      const dropN = Math.ceil(this.cargo.length / 2);
+      const dropped = this.cargo.splice(this.cargo.length - dropN, dropN);
+      for (const c of dropped) {
+        const m = glowSprite(0xffd75e, 2.2, 0.9);
+        m.position.copy(this.pos).add(new THREE.Vector3(
+          (Math.random() - 0.5) * 4, (Math.random() - 0.5) * 3, (Math.random() - 0.5) * 4));
+        m.userData.irHot = true;
+        this.scene.add(m);
+        this.spilled.push({ ...c, mesh: m, age: 0,
+          vel: new THREE.Vector3((Math.random() - 0.5) * 5, 2 + Math.random() * 2,
+            (Math.random() - 0.5) * 5) });
+      }
+      this.ui.toast(`💥 ${dropN} CARGO KNOCKED LOOSE — grab it quick!`, 'bad');
+      this.ui.announce(`${dropN} pieces of cargo knocked loose. They will not float forever.`);
+    }
     this.ui.audio?.hurt();
     this.ui.toast('💥 HULL ' + '▮'.repeat(Math.max(0, this.hull)) + '▯'.repeat(Math.max(0, HULL_MAX - this.hull)), 'bad');
     if (why) this.ui.announce(why);
@@ -615,10 +672,17 @@ export class WaterworldGame {
   _collect(s) {
     s.collected = true;
     this.scene.remove(s.mesh);
-    this.cargo.push({ type: s.type, value: s.value });
-    this.ui.audio?.pickup(s.value);
+    // COMBO: quick successive grabs are worth more — routes matter
+    if (this.elapsed - this._comboT < 8) this.combo++;
+    else this.combo = 1;
+    this._comboT = this.elapsed;
+    const value = Math.round(s.value * (1 + 0.15 * (this.combo - 1)));
+    this.cargo.push({ type: s.type, value });
+    this.ui.audio?.pickup(value);
     const f = FACTS[s.type];
-    this.ui.toast(`${f.icon} ${f.name.toUpperCase()} +${s.value}`, 'good');
+    this.ui.toast(
+      `${f.icon} ${f.name.toUpperCase()} +${value}` +
+      (this.combo >= 2 ? `  🔥COMBO ×${this.combo}` : ''), 'good');
     if (!this.codex.has(s.type)) {
       this.codex.add(s.type);
       this._factQueue.push(s.type);
@@ -655,8 +719,11 @@ export class WaterworldGame {
     if (!this.cargo.length) { this.air = AIR_MAX; return; }
     const n = this.cargo.length;
     const base = this.cargo.reduce((a, c) => a + c.value, 0);
-    const mult = 1 + 0.15 * (n - 1);
+    // the haul bonus is now worth chasing — and worth risking
+    const mult = Math.min(3, 1 + 0.25 * (n - 1));
     const gained = Math.round(base * mult);
+    this._bankOrder = false;
+    this.combo = 0;
     this.score += gained;
     this.bankedValue += gained;
     for (const c of this.cargo) this.bankedTypes.add(c.type);
@@ -750,12 +817,12 @@ export class WaterworldGame {
       Math.sin(this.pitch),
       -Math.cos(this.pitch) * Math.sin(this.yaw));
     const thrusting = k.a || this._autoThrust;
-    const thrust = thrusting ? 26 : 7;   // always some way on
+    const thrust = thrusting ? 34 : 9;   // brisker: ploddy is literal speed
     this.vel.addScaledVector(fwd, thrust * dt);
     this.vel.multiplyScalar(Math.pow(0.14, dt));            // water drag
     this.vel.y += Math.sin(this.elapsed * 0.8) * 0.06 * dt; // gentle swell
     currentAt(this.pos, this.elapsed, _cur);                 // the gyre tugs
-    this.vel.addScaledVector(_cur, 0.35 * dt);
+    this.vel.addScaledVector(_cur, 0.35 * this.tide * dt);
     this.pos.addScaledVector(this.vel, dt);
 
     // -------- containment: walls, floor, surface
@@ -818,7 +885,8 @@ export class WaterworldGame {
       this.scene.fog.color.copy(fogC);
       this.scene.background.copy(fogC);
       const lampBoost = this.tools.has('arclamp') ? 0.45 : 1;
-      this.scene.fog.density = (0.016 + deepT * 0.03 * lampBoost);
+      // thinner fog: the basin should read as a place, not a box
+      this.scene.fog.density = (0.0115 + deepT * 0.026 * lampBoost);
     }
     if (!this.tools.has('arclamp')) this.headlamp.intensity = 40;
     this.lightCone.material.opacity = this.ir ? 0
@@ -839,7 +907,7 @@ export class WaterworldGame {
     const hot = this.ir
       ? [...this.fatbergs.map(f => f.mesh.position), this.pos]
       : [];
-    this.fx.step(dt, this.elapsed, this.pos, threats, -this.camera.position.y, hot);
+    this.fx.step(dt, this.elapsed, this.pos, threats, -this.camera.position.y, hot, this.tide);
     const faunaEv = this.fauna.step(dt, this.elapsed, this.pos);
     if (faunaEv.dolphinsNear) {
       if (!this.codex.has('dolphin_visit')) {
@@ -903,6 +971,8 @@ export class WaterworldGame {
       if (!q.taken) q.mesh.userData.spin.rotation.y += dt * 2;
     }
 
+    this._stepEvents(dt);
+    this._stepSpilled(dt);
     this._stepEels(dt);
     this._stepFatbergs(dt);
     this._stepMines(dt);
@@ -954,8 +1024,14 @@ export class WaterworldGame {
       }
       return { icon: '🐋', text: 'Follow the whale to the chest!', target: this.chest.mesh.position };
     }
-    if (this.cargo.length >= 4) return { icon: '⬆', text: `Great haul! Bank ${this.cargo.length} finds at the bell`, target: bell };
-    if (this.banks === 0 && this.cargo.length >= 3) return { icon: '🔔', text: 'Nice! Now bank them at the glowing bell', target: bell };
+    // banking is the CAPTAIN'S call (the 🔔 button) — the helm only
+    // suggests it, it never decides for you
+    if (this._bankOrder && this.cargo.length) {
+      return { icon: '🔔', text: 'Aye — taking the haul home!', target: bell };
+    }
+    if (this.banks === 0 && this.cargo.length >= 3) return { icon: '🔔', text: 'Nice haul riding! Tap 🔔 BANK when ready', target: bell };
+    const spill = this.spilled[0];
+    if (spill) return { icon: '⚠', text: 'Your spilled cargo is fading — grab it!', target: spill.mesh.position };
     if (this.tools.has('fizzlance')) {
       const berg = this.fatbergs.find(f => f.blocking);
       if (berg) return { icon: '🫧', text: 'Hold B by a fatberg to fizz it away', target: berg.mesh.position };
@@ -997,7 +1073,108 @@ export class WaterworldGame {
       codex: this.codex.size, codexTotal: Object.keys(FACTS).length,
       whale: this.whaleActive, chest: this.hasChest, over: this.over, won: this.won,
       ir: this.ir, auto: this.autopilot,
+      haulMult: Math.min(3, 1 + 0.25 * Math.max(0, this.cargo.length - 1)),
+      combo: this.combo, dashReady: this._dashCd <= 0,
+      tide: this.tide > 1, spilled: this.spilled.length,
     };
+  }
+
+  // ------------------------------------------------------------- events
+  // The dock has moods now: tides that double the current, and sunken
+  // caches that surface for sixty seconds. Urgency makes decisions.
+  _stepEvents(dt) {
+    if (this._dashCd > 0) this._dashCd -= dt;
+    if (this._fovKick > 0) {
+      this._fovKick = Math.max(0, this._fovKick - dt * 2);
+      this.camera.fov = 70 + 11 * this._fovKick;
+      this.camera.updateProjectionMatrix();
+    }
+    // the world above appears as you rise; clouds drift always
+    this.dock.sky.visible = this.pos.y > -26;
+    for (const c of this.dock.sky.userData.clouds) c.position.x += dt * 1.2;
+
+    // tide surge
+    if (this._tideLeft > 0) {
+      this._tideLeft -= dt;
+      if (this._tideLeft <= 0) {
+        this.tide = 1;
+        this.ui.toast('🌊 The tide slackens.', 'hint');
+      }
+    } else {
+      this._tideT -= dt;
+      if (this._tideT <= 0 && !this.over) {
+        this._tideT = 75 + Math.random() * 45;
+        this._tideLeft = 25;
+        this.tide = 2.6;
+        this.ui.toast('🌊 THE TIDE TURNS — ride the current!', 'warn');
+        this.ui.announce('The tide is turning. The current runs strong for a while.');
+      }
+    }
+    // sunken cache
+    if (this.cache) {
+      this.cache.beacon.material.opacity = 0.4 + 0.3 * Math.sin(this.elapsed * 5);
+      const left = this.cache.until - this.elapsed;
+      if (left <= 0) {
+        for (const s of this.cache.items) {
+          if (!s.collected) { s.collected = true; this.scene.remove(s.mesh); }
+        }
+        this.scene.remove(this.cache.beacon);
+        this.cache = null;
+        this.ui.toast('The silt takes the cache back.', 'hint');
+      } else if (this.cache.items.every(s => s.collected)) {
+        this.scene.remove(this.cache.beacon);
+        this.cache = null;
+        this.score += 30;
+        this.ui.toast('📦 CACHE CLEARED +30', 'gold');
+      }
+    } else {
+      this._cacheT -= dt;
+      if (this._cacheT <= 0 && !this.over) {
+        this._cacheT = 110 + Math.random() * 60;
+        const cx = -60 + Math.random() * 130, cz = (Math.random() - 0.5) * 110;
+        const types = ['roman_coin', 'ships_bell', 'tea_chest'];
+        const items = types.map((type, i) => {
+          const g = makeSalvageMesh(type);
+          g.position.set(cx + (i - 1) * 3, floorYAt(cx, cz) + 0.4, cz + (i % 2) * 3);
+          const halo = glowSprite(0x7ef2ff, 2.4, 0.5);
+          halo.position.y = 0.8;
+          g.add(halo);
+          this.scene.add(g);
+          const rec = { type, mesh: g, collected: false, heavy: false, hidden: false,
+            value: FACTS[type].value, _known: true };
+          this.salvage.push(rec);
+          return rec;
+        });
+        const beacon = glowSprite(0x7ef2ff, 14, 0.5);
+        beacon.position.set(cx, floorYAt(cx, cz) + 8, cz);
+        beacon.userData.irHot = true;
+        this.scene.add(beacon);
+        this.cache = { items, beacon, until: this.elapsed + 60, x: cx, z: cz };
+        this.ui.toast('📦 THE SILT SHIFTS — a cache is exposed! 60s', 'gold');
+        this.ui.announce('A sunken cache is exposed nearby, but only for a minute.');
+      }
+    }
+  }
+
+  _stepSpilled(dt) {
+    for (let i = this.spilled.length - 1; i >= 0; i--) {
+      const s = this.spilled[i];
+      s.age += dt;
+      s.mesh.position.addScaledVector(s.vel, dt);
+      s.vel.multiplyScalar(1 - dt * 1.6);
+      s.vel.y -= dt * 0.5;                      // it slowly settles
+      s.mesh.material.opacity = 0.9 * Math.max(0, 1 - s.age / 18);
+      if (s.mesh.position.distanceTo(this.pos) < 3.2) {
+        this.cargo.push({ type: s.type, value: s.value });
+        this.ui.audio?.pickup(s.value);
+        this.ui.toast('↩ CARGO RECOVERED', 'good');
+        this.scene.remove(s.mesh);
+        this.spilled.splice(i, 1);
+      } else if (s.age > 18) {
+        this.scene.remove(s.mesh);
+        this.spilled.splice(i, 1);
+      }
+    }
   }
 
   _stepEels(dt) {

--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -107,7 +107,11 @@ function hud(s) {
   $('hull').textContent = '▮'.repeat(Math.max(0, s.hull)) + '▯'.repeat(Math.max(0, s.hullMax - s.hull));
   $('score').textContent = String(s.score).padStart(5, '0');
   $('depth').textContent = s.depth + 'm';
-  $('cargo').textContent = s.cargo ? `⚓${s.cargo} (+${s.cargoValue})` : '⚓—';
+  $('cargo').textContent = s.cargo
+    ? `⚓${s.cargo} ×${s.haulMult.toFixed(2)}${s.combo >= 2 ? ` 🔥${s.combo}` : ''}`
+    : '⚓—';
+  const bankBtn = $('bank-btn');
+  bankBtn.hidden = !s.cargo || s.over;
   $('codex').textContent = `📖${s.codex}/${s.codexTotal}`;
   const held = [
     ...s.tools.map(t => ({ grapple: '🪝', arclamp: '💡', fizzlance: '🫧' }[t] || '🔧')),
@@ -210,10 +214,14 @@ document.addEventListener('keyup', (e) => {
       }
     }
   });
+  let lastTapAt = 0;
   const endGesture = (e) => {
     if (gesture && game && !gesture.moved && performance.now() - gesture.t0 < 400) {
       audio.ensure();
-      game._doPing();                      // a tap is a ping
+      const now = performance.now();
+      if (now - lastTapAt < 320) game.dash();   // double-tap = DASH
+      else game._doPing();                      // a tap is a ping
+      lastTapAt = now;
     }
     gesture = null;
   };
@@ -333,6 +341,110 @@ $('help-btn').addEventListener('pointerdown', (e) => {
 $('help-close').addEventListener('click', () => {
   $('help-panel').classList.remove('show');
   $('help-btn').setAttribute('aria-expanded', 'false');
+});
+
+// The captain's banking order — the ONE decision the helm never makes
+$('bank-btn').addEventListener('pointerdown', (e) => {
+  e.stopPropagation();
+  if (!game) return;
+  game._bankOrder = true;
+  game.autopilot = true;
+  game.manualUntil = 0;
+  audio.ensure();
+  toast('🔔 Aye aye — making for the bell!', 'gold');
+  announce('Taking the haul to the bell.');
+});
+
+// The sonar chart: what the pings have taught us, drawn top-down
+function drawMap() {
+  if (!game) return;
+  const cv = $('map-canvas');
+  const g2 = cv.getContext('2d');
+  const W = cv.width, H = cv.height;
+  const X = (x) => ((x + 120) / 240) * (W - 30) + 15;
+  const Z = (z) => ((z + 80) / 160) * (H - 30) + 15;
+  // water: shallow west, deep east
+  const grad = g2.createLinearGradient(0, 0, W, 0);
+  grad.addColorStop(0, '#0d3a5c'); grad.addColorStop(0.55, '#0a2748'); grad.addColorStop(1, '#050f26');
+  g2.fillStyle = grad;
+  g2.fillRect(0, 0, W, H);
+  g2.strokeStyle = '#7ef2ff'; g2.lineWidth = 2;
+  g2.strokeRect(6, 6, W - 12, H - 12);
+  const dot = (x, z, color, r = 5) => {
+    g2.fillStyle = color;
+    g2.beginPath(); g2.arc(X(x), Z(z), r, 0, Math.PI * 2); g2.fill();
+  };
+  // culvert mouths
+  g2.fillStyle = '#1f8f4e';
+  for (const m of game.dock.culverts) g2.fillRect(X(m.x) - 8, Z(-80) - 4, 16, 8);
+  // hulls above
+  g2.fillStyle = 'rgba(220,230,240,0.7)';
+  for (const h of game.fauna.hulls) {
+    g2.save();
+    g2.translate(X(h.position.x), Z(h.position.z));
+    g2.rotate(-h.rotation.y);
+    g2.fillRect(-16, -5, 32, 10);
+    g2.restore();
+  }
+  // what the sonar has charted
+  for (const s of game.salvage) {
+    if (s._known && !s.collected && !s.hidden) dot(s.mesh.position.x, s.mesh.position.z, '#ffd75e');
+  }
+  for (const q of game.quest) {
+    if (q._known && !q.taken) dot(q.mesh.position.x, q.mesh.position.z, '#ff77a8', 6);
+  }
+  for (const m of game.mines) {
+    if (m._known && m.live) {
+      g2.strokeStyle = '#ff2244'; g2.lineWidth = 3;
+      const mx = X(m.mesh.position.x), mz = Z(m.mesh.position.z);
+      g2.beginPath();
+      g2.moveTo(mx - 6, mz - 6); g2.lineTo(mx + 6, mz + 6);
+      g2.moveTo(mx + 6, mz - 6); g2.lineTo(mx - 6, mz + 6);
+      g2.stroke();
+    }
+  }
+  for (const f of game.fatbergs) dot(f.mesh.position.x, f.mesh.position.z, '#e8b07a', f.r * 1.6);
+  if (game.cache) {
+    g2.strokeStyle = '#7ef2ff'; g2.lineWidth = 2;
+    g2.beginPath(); g2.arc(X(game.cache.x), Z(game.cache.z),
+      10 + 4 * Math.sin(performance.now() / 200), 0, Math.PI * 2);
+    g2.stroke();
+  }
+  // the bell
+  const b = game.dock.bell.position;
+  dot(b.x, b.z, '#ffec27', 9);
+  g2.fillStyle = '#442';
+  g2.font = '14px sans-serif'; g2.textAlign = 'center';
+  g2.fillText('🔔', X(b.x), Z(b.z) + 5);
+  // whale, if she's up
+  if (game.whaleActive) dot(game.whale.position.x, game.whale.position.z, 'rgba(200,240,255,0.8)', 8);
+  // YOU: an arrow showing heading
+  g2.save();
+  g2.translate(X(game.pos.x), Z(game.pos.z));
+  g2.rotate(-game.yaw + Math.PI / 2);
+  g2.fillStyle = '#29adff';
+  g2.beginPath();
+  g2.moveTo(0, -11); g2.lineTo(7, 8); g2.lineTo(-7, 8);
+  g2.closePath(); g2.fill();
+  g2.restore();
+}
+let mapTimer = null;
+$('map-btn').addEventListener('pointerdown', (e) => {
+  e.stopPropagation();
+  const panel = $('map-panel');
+  const opening = !panel.classList.contains('show');
+  panel.classList.toggle('show', opening);
+  $('map-btn').setAttribute('aria-expanded', String(opening));
+  if (opening) {
+    drawMap();
+    mapTimer = setInterval(drawMap, 300);
+    announce('Sonar chart open.');
+  } else if (mapTimer) { clearInterval(mapTimer); mapTimer = null; }
+});
+$('map-close').addEventListener('click', () => {
+  $('map-panel').classList.remove('show');
+  $('map-btn').setAttribute('aria-expanded', 'false');
+  if (mapTimer) { clearInterval(mapTimer); mapTimer = null; }
 });
 
 // canvas a11y: name it and keep a live description of the dive

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -730,10 +730,104 @@ export function makeWeeds(scene, count = 110) {
   return stalks;
 }
 
+// The world above the water: a Docklands skyline ringing the basin, a
+// gradient sky dome, drifting clouds. Grouped so the game can show it
+// only when the player is shallow enough to care.
+export function makeSky(scene) {
+  const g = new THREE.Group();
+  // sky dome: warm horizon rising to blue, sun glow baked in
+  const dome = new THREE.Mesh(
+    new THREE.SphereGeometry(330, 24, 12),
+    new THREE.ShaderMaterial({
+      side: THREE.BackSide, fog: false, depthWrite: false,
+      uniforms: { uSun: { value: new THREE.Vector3(0.24, 0.94, 0.12) } },
+      vertexShader: `varying vec3 vDir; void main(){ vDir = normalize(position);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0); }`,
+      fragmentShader: `varying vec3 vDir; uniform vec3 uSun;
+        void main(){
+          float h = clamp(vDir.y, 0.0, 1.0);
+          vec3 col = mix(vec3(0.95,0.82,0.62), vec3(0.35,0.62,0.92), pow(h, 0.55));
+          col += vec3(1.0,0.9,0.7) * pow(max(dot(vDir, normalize(uSun)), 0.0), 60.0) * 0.8;
+          gl_FragColor = vec4(col, 1.0);
+        }`,
+    }));
+  g.add(dome);
+  // the skyline: warehouses, towers, gantry cranes — dark shapes on the rim
+  const sil = (w, h, d, x, z, ry = 0) => {
+    const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d),
+      mat(0x2a3648, { fog: false }));
+    m.position.set(x, h / 2, z);
+    m.rotation.y = ry;
+    g.add(m);
+    return m;
+  };
+  for (let x = -150; x <= 150; x += 18 + Math.random() * 14) {
+    sil(10 + Math.random() * 12, 5 + Math.random() * 22, 8, x, BOUNDS.minZ - 30);
+    sil(10 + Math.random() * 12, 4 + Math.random() * 16, 8, x, BOUNDS.maxZ + 30);
+  }
+  for (let z = -70; z <= 70; z += 24 + Math.random() * 12) {
+    sil(8, 6 + Math.random() * 24, 10 + Math.random() * 10, BOUNDS.maxX + 34, z);
+    sil(8, 4 + Math.random() * 12, 10 + Math.random() * 10, BOUNDS.minX - 34, z);
+  }
+  // two gantry cranes, the Docklands signature
+  for (const [cx, cz] of [[-60, BOUNDS.minZ - 26], [90, BOUNDS.maxZ + 26]]) {
+    sil(3, 26, 3, cx, cz);
+    const jib = sil(24, 2, 2, cx + 9, cz);
+    jib.position.y = 25;
+    sil(2, 8, 2, cx + 20, cz).position.y = 20;
+  }
+  // clouds: big soft sprites on a slow drift
+  g.userData.clouds = [];
+  for (let i = 0; i < 4; i++) {
+    const c = new THREE.Sprite(new THREE.SpriteMaterial({
+      map: softDot(), color: 0xffffff, transparent: true, opacity: 0.5,
+      depthWrite: false, fog: false,
+    }));
+    c.scale.set(60 + Math.random() * 50, 18 + Math.random() * 10, 1);
+    c.position.set((Math.random() - 0.5) * 400, 50 + Math.random() * 40, (Math.random() - 0.5) * 400);
+    g.add(c);
+    g.userData.clouds.push(c);
+  }
+  scene.add(g);
+  return g;
+}
+
+// Underwater horizon interest: looming pilings and wreck ribs near the
+// walls, fog-shrouded — the eye always finds a silhouette out there.
+export function makeHorizon(scene) {
+  const g = new THREE.Group();
+  const spots = [[-100, -60], [-95, 50], [110, -50], [40, -70], [-40, 70], [115, 60]];
+  for (const [x, z] of spots) {
+    const n = 3 + Math.floor(Math.random() * 4);
+    for (let i = 0; i < n; i++) {
+      const h = 10 + Math.random() * 20;
+      const p = new THREE.Mesh(new THREE.CylinderGeometry(0.7, 0.9, h, 10),
+        mat(0x1c2836));
+      p.position.set(x + (Math.random() - 0.5) * 10,
+        floorYAt(x, z) + h / 2, z + (Math.random() - 0.5) * 10);
+      p.rotation.z = (Math.random() - 0.5) * 0.15;
+      g.add(p);
+    }
+  }
+  // two wreck ribcages: arcs of curved dark ribs
+  for (const [x, z, ry] of [[-85, -35, 0.4], [100, 25, -1.1]]) {
+    for (let i = 0; i < 7; i++) {
+      const rib = new THREE.Mesh(new THREE.TorusGeometry(7 - i * 0.2, 0.5, 8, 14, Math.PI), mat(0x22303c));
+      rib.position.set(x + i * 2.6 * Math.cos(ry), floorYAt(x, z), z + i * 2.6 * Math.sin(ry));
+      rib.rotation.y = ry + Math.PI / 2;
+      g.add(rib);
+    }
+  }
+  scene.add(g);
+  return g;
+}
+
 // The whole static set. Returns collider list for the physics step.
 export function buildDock(scene) {
   const floor = makeFloor(scene);
   const surface = makeWaterSurface(scene);
+  const sky = makeSky(scene);
+  makeHorizon(scene);
   const quay = makeQuayWalls(scene);
   const culverts = makeCulverts(scene);
   const crane = makeCrane(scene);
@@ -756,7 +850,7 @@ export function buildDock(scene) {
     { x: -40, y: SHELF_Y + 4, z: 30, r: 10 },    // barge
     { x: 85, y: DEEP_Y + 6, z: -30, r: 11 },     // warehouse
   ];
-  return { culverts, crane, barge, warehouse, bell, weeds, colliders, floor, surface };
+  return { culverts, crane, barge, warehouse, bell, weeds, colliders, floor, surface, sky };
 }
 
 // ---------------------------------------------------------------- particles

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -76,6 +76,47 @@ try {
   if (!subParts.length) pass('sub v2: props, planes, rudder, beacon all present');
   else fail('sub missing parts: ' + subParts.join(','));
 
+  // DASH: double-tap A must spike the speed
+  const dashed = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    const v0 = g.vel.length();
+    g.setKey('a', true); g.setKey('a', false);
+    g.setKey('a', true); g.setKey('a', false);
+    await new Promise(r => setTimeout(r, 120));
+    return { v0, v1: g.vel.length() };
+  });
+  if (dashed.v1 > dashed.v0 + 10) pass(`dash spikes speed (${dashed.v0.toFixed(1)} → ${dashed.v1.toFixed(1)})`);
+  else fail(`dash inert: ${JSON.stringify(dashed)}`);
+
+  // PUSH-YOUR-LUCK: damage with cargo aboard spills recoverable loot
+  const spilled = await page.evaluate(() => {
+    const g = window.__waterworld.game;
+    g.cargo.push({ type: 'clay_pipe', value: 10 }, { type: 'green_bottle', value: 10 },
+      { type: 'tea_chest', value: 20 }, { type: 'cannonball', value: 25 });
+    g._damage(0, 'test knock');
+    return { spilled: g.spilled.length, kept: g.cargo.length };
+  });
+  if (spilled.spilled >= 2 && spilled.kept >= 1) pass(`hit spills cargo (${spilled.spilled} loose, ${spilled.kept} kept)`);
+  else fail('spill mechanic broken: ' + JSON.stringify(spilled));
+  await page.evaluate(() => {
+    const g = window.__waterworld.game;
+    g.spilled.forEach(s => g.scene.remove(s.mesh));
+    g.spilled = []; g.cargo = []; g.hull = 4;
+  });
+
+  // LEGIBILITY: the sonar chart opens and draws
+  await page.evaluate(() => document.getElementById('map-btn')
+    .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true })));
+  const mapOpen = await page.evaluate(() => {
+    const cv = document.getElementById('map-canvas');
+    const shown = document.getElementById('map-panel').classList.contains('show');
+    const px = cv.getContext('2d').getImageData(cv.width / 2, cv.height / 2, 1, 1).data;
+    return { shown, drawn: px[0] + px[1] + px[2] > 0 };
+  });
+  if (mapOpen.shown && mapOpen.drawn) pass('sonar chart opens and draws');
+  else fail('sonar chart broken: ' + JSON.stringify(mapOpen));
+  await page.click('#map-close');
+
   // POSE CONTINUITY: the craft's quaternion must never jump between
   // frames. The old Euler read-back pose flipped representations ~67
   // times per slow diving turn (measured); a brushed turn with pitch is

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -30,7 +30,7 @@
   #hud {
     position: absolute; top: 0; left: 0; right: 0;
     display: flex; flex-wrap: wrap; align-items: center; gap: 0.5em 1em;
-    padding: max(0.4em, env(safe-area-inset-top)) 14rem 0.4em 0.7em;
+    padding: max(0.4em, env(safe-area-inset-top)) 17rem 0.4em 0.7em;
     font-size: clamp(11px, 2.4vmin, 16px);
     letter-spacing: 0.06em;
     color: #ffec27;
@@ -127,6 +127,42 @@
   /* ------- ship's log ------- */
   #log-btn { color: #29adff; border-color: #29adff; }
   #log-btn.unread::after { content: '●'; color: #ffec27; margin-left: 0.25em; }
+  #map-btn { color: #7ef2ff; border-color: #7ef2ff; }
+
+  /* the captain's banking order: appears whenever a haul is riding */
+  #bank-btn {
+    position: absolute;
+    right: 0.7em;
+    bottom: max(7.5em, calc(env(safe-area-inset-bottom) + 7em));
+    z-index: 26;
+    width: 4.4em; height: 4.4em;
+    border-radius: 50%;
+    font: inherit; font-size: clamp(13px, 3vmin, 17px); font-weight: bold;
+    background: rgba(40, 30, 0, 0.72); color: #ffec27;
+    border: 2px solid #ffec27;
+    box-shadow: 0 0 14px rgba(255, 236, 39, 0.5);
+    cursor: pointer;
+    animation: bank-breathe 1.6s ease-in-out infinite;
+  }
+  #bank-btn span { display: block; font-size: 0.55em; letter-spacing: 0.08em; }
+  #bank-btn:focus-visible { outline: 3px solid #29adff; outline-offset: 2px; }
+  @keyframes bank-breathe { 50% { box-shadow: 0 0 22px rgba(255,236,39,0.8); } }
+
+  #map-panel {
+    position: absolute; inset: 3.6em 0.6em auto 0.6em;
+    max-height: 78dvh;
+    display: none; flex-direction: column;
+    background: rgba(6, 14, 34, 0.97);
+    border: 2px solid #7ef2ff;
+    z-index: 47;
+  }
+  #map-panel.show { display: flex; }
+  #map-canvas { width: 100%; height: auto; display: block; }
+  #map-legend {
+    padding: 0.4em 0.8em;
+    font-size: clamp(10px, 2.4vmin, 13px);
+    color: #9fb6c8; border-top: 1px solid #29527a;
+  }
   #log-panel {
     position: absolute; inset: 3.6em 0.6em auto 0.6em;
     max-height: 62dvh;
@@ -305,7 +341,18 @@
     <button id="auto-btn" class="chip" type="button" aria-label="toggle autopilot" aria-pressed="true">⚓AUTO</button>
     <button id="help-btn" class="chip" type="button" aria-label="how to play" aria-expanded="false">？</button>
     <button id="log-btn" class="chip" type="button" aria-label="ship's log" aria-expanded="false">📜</button>
+    <button id="map-btn" class="chip" type="button" aria-label="sonar chart" aria-expanded="false">🗺</button>
     <button id="ir-btn" class="chip" type="button" aria-label="toggle thermal sight" aria-pressed="false">IR</button>
+  </div>
+  <button id="bank-btn" type="button" aria-label="take the haul to the bell" hidden>🔔<span>BANK</span></button>
+
+  <div id="map-panel" role="dialog" aria-label="Sonar chart">
+    <div class="panel-head">
+      <span>🗺 SONAR CHART</span>
+      <button id="map-close" type="button" aria-label="close chart">✕</button>
+    </div>
+    <canvas id="map-canvas" width="640" height="440"></canvas>
+    <div id="map-legend">🟡 salvage · 💗 gear · 🔴 mine · 🟠 fatberg · 🔵 you · 🔔 bell · ⬜ boats — sonar pings chart the world</div>
   </div>
   <button id="pad-toggle" type="button" aria-label="show d-pad controls" aria-pressed="false">🎮</button>
 
@@ -316,7 +363,11 @@
     </div>
     <ul id="help-list">
       <li><strong>Brush the water</strong> — set a new course. She follows it, then resumes the hunt.</li>
-      <li><strong>Tap the water</strong> — sonar ping: lights up treasure, stuns eels up close, pops mines at a safe distance.</li>
+      <li><strong>Tap the water</strong> — sonar ping: lights up treasure, stuns eels up close, pops mines at a safe distance. Pinged things stay on your 🗺 chart.</li>
+      <li><strong>Double-tap</strong> (or double-tap A) — DASH: a burst of speed for a breath of air.</li>
+      <li><strong>🔔 BANK</strong> — the haul multiplier grows with every item you carry (×3 tops!) — but a hit knocks half your cargo loose. Banking is YOUR call.</li>
+      <li><strong>Grab fast for COMBOS</strong> — quick successive finds are worth more.</li>
+      <li><strong>Watch the water</strong> — tides surge the current, and sometimes the silt exposes a cache for sixty seconds.</li>
       <li><strong>➤ The banner arrow</strong> always points at your current goal.</li>
       <li><strong>⚓AUTO</strong> — autopilot on/off. Off = you have the boat.</li>
       <li><strong>🎮</strong> — summon the d-pad if you want stick-and-button control (▲▼◀▶ steer · A thrust · B sonar/tools).</li>


### PR DESCRIPTION
Gameplay regime change addressing "not fun, ploddy, can't tell what's going on, tiny box":

- **Decisions:** steep visible haul multiplier (×1…×3) vs. hits that knock half your cargo loose (floating, recoverable, fading); banking is the player's call via a 🔔 BANK button — the autopilot routes but no longer decides. Combo chains (+15%/link) reward fast routes.
- **Speed:** base speed +30%; DASH on double-tap (screen or A) with FOV kick, air cost, 2.2s cooldown.
- **Legibility:** 🗺 sonar chart — live top-down map of everything pings have charted (salvage, gear, mines, fatbergs, hulls, cache, whale, bell, own heading); pings write to the chart permanently.
- **Urgency:** tide surges (2.6× current, 25s) and sunken caches exposed for exactly 60s with beacon + clear bonus.
- **The rim:** Docklands skyline silhouettes + gantry cranes above the waterline, gradient sky dome, drifting clouds; underwater pilings and wreck ribcages on the fog horizon; fog thinned ~25%.

Playtest at 30 assertions (dash/spill/chart added); shell e2e and html-validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_