### PR TITLE
CLAUDE.md: reports must use ASD-STE100 Simplified Technical English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+only report to me in ASD-STE100 Simplified Technical English.
+
 # CLAUDE.md - Guide for 🐥 Minigames
 <!-- Rebuild trigger: 2025-10-22 14:30 UTC -->
 <!-- Major revision 2026-06-10: stripped stale 2025 changelogs, corrected facts per docs/fable-audit/, added Data Ethics rule -->

--- a/lucid/CLAUDE.md
+++ b/lucid/CLAUDE.md
@@ -1,3 +1,5 @@
+only report to me in ASD-STE100 Simplified Technical English.
+
 # CLAUDE.md - Lucid SDF/CSG System
 
 ## Quick Reference

--- a/yeti/CLAUDE.md
+++ b/yeti/CLAUDE.md
@@ -1,3 +1,5 @@
+only report to me in ASD-STE100 Simplified Technical English.
+
 # CLAUDE.md - Yeti Bestiary
 
 ## Core Principle: Zero Code Dependencies


### PR DESCRIPTION
Adds the instruction "only report to me in ASD-STE100 Simplified Technical English." at the top of the three CLAUDE.md files (root, lucid/, yeti/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_