### PR TITLE
Waterworld: THE RISING — story campaign + reviewer-tribe fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ npm-debug.log*
 # Environment files
 .env
 .env.local
+_tmp_review_*.mjs

--- a/magpie/waterworld/README.md
+++ b/magpie/waterworld/README.md
@@ -12,6 +12,29 @@ fine grain, plus an animated water-surface shader overhead and GPU
 caustic webs dancing on the shallow floor. Vendored three.js r169,
 procedural lo-fi WebAudio, no external assets.
 
+## The story — THE RISING (js/quests.js)
+
+Your first banking wakes the sentient fatbergs; they mean to take the
+city. Build a coalition of three, then win the finale:
+
+- **Whale ghosts:** gather three ancestor bones → bury them at the
+  Steelyard stone (Hanseatic ground — Cannon Street Station stands on it,
+  which is true) → craft the loudspeaker (magnet + dynamo coil) → sing
+  the lament → sink the PALE & SONS candle-drone barge by ping-detonating
+  depth charges under its patrol line.
+- **Eel Federation:** parley with the Amp and Volt elders (a gentle ping
+  up close) → recover the three torn Eel Pie Charter fragments → return
+  the charter: the island was held IN COMMON. The tribes unite.
+- **The River Folk:** raise the East India Company strongbox with the
+  grapple (hook + rope). Five uncut rubies: SPEND them at the bell
+  (hull +1, air +25) or RETURN them to the river — return three and the
+  river folk take the third seat.
+
+**Finale:** the berg armada rises. Ghost whales converge on your last
+sonar ping — ping to herd bergs into Blight Corner over the methane
+vents, then spark the eel pylon. Democracy is saved; a wet wipe lands in
+the Mayor's lunch. The end.
+
 ## The loop
 
 Ping the sonar (B) → glints reveal salvage → touch to collect → bank cargo
@@ -25,14 +48,14 @@ Adventure-style crafting, auto-combined when both halves are aboard:
 
 | combo | tool | unlocks |
 |---|---|---|
-| magnet + rope | grapple | heavy salvage, including the chest |
+| hook + rope | grapple | heavy salvage, including the strongbox |
+| magnet + dynamo coil | loudspeaker | the whale lament at the Steelyard |
 | lamp + wet cell | arc lamp | seeing anything in the deep basin |
 | soda crate + brass nozzle | fizz lance | dissolving fatbergs (hold B nearby) |
 
-Bank enough of the dock's past and the **ghost whale** — a particle-cloud
-whale, no mesh — appears and leads you east to the pirate captain's chest.
-Grapple it, bank it, win. Lose the hull (eel bites, mines, fatberg hugs,
-running out of air) and the dive ends with a partial score.
+Victory belongs to the campaign (see THE RISING above). Lose the hull
+(eel bites, mines, fatberg hugs, running out of air) and the dive ends
+with a partial score.
 
 Sonar also stuns eels up close and safely detonates mines at a distance.
 

--- a/magpie/waterworld/js/facts.js
+++ b/magpie/waterworld/js/facts.js
@@ -105,8 +105,10 @@ export const FACTS = {
 // Quest items — combine in pairs, adventure-style. Auto-crafts when you
 // hold both halves.
 export const QUEST_ITEMS = {
-  magnet: { name: 'Bar magnet', icon: '🧲', pairsWith: 'rope', makes: 'grapple' },
-  rope: { name: 'Tarred rope', icon: '🪢', pairsWith: 'magnet', makes: 'grapple' },
+  hook: { name: 'Boat hook', icon: '🪝', pairsWith: 'rope', makes: 'grapple' },
+  rope: { name: 'Tarred rope', icon: '🪢', pairsWith: 'hook', makes: 'grapple' },
+  magnet: { name: 'Bar magnet', icon: '🧲', pairsWith: 'coil', makes: 'loudspeaker' },
+  coil: { name: 'Dynamo coil', icon: '🌀', pairsWith: 'magnet', makes: 'loudspeaker' },
   lamp: { name: 'Arc lamp', icon: '🏮', pairsWith: 'battery', makes: 'arclamp' },
   battery: { name: 'Wet cell', icon: '🔋', pairsWith: 'lamp', makes: 'arclamp' },
   soda: { name: 'Soda crate', icon: '📦', pairsWith: 'nozzle', makes: 'fizzlance' },
@@ -115,8 +117,12 @@ export const QUEST_ITEMS = {
 
 export const TOOLS = {
   grapple: {
-    name: 'Magnet grapple', icon: '🪝',
-    text: 'Magnet + rope. Hauls heavy salvage — even a pirate chest — off the dock floor.',
+    name: 'Boat-hook grapple', icon: '🪝',
+    text: 'Hook + rope. Hauls heavy salvage — even a strongbox — off the dock floor.',
+  },
+  loudspeaker: {
+    name: 'Whale-song loudspeaker', icon: '🔊',
+    text: 'Magnet + dynamo coil: electricity and iron. Loud enough for a lament the dead can hear.',
   },
   arclamp: {
     name: 'Arc lamp', icon: '💡',

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -14,6 +14,10 @@ import {
 import { UnderwaterFX, glowSprite, currentAt } from './fx.js';
 import { Composite } from './post.js';
 import { Fauna } from './fauna.js';
+import { Campaign } from './quests.js';
+import {
+  makeSteelyard, makeBone, makeFragment, makeElderEel, makeDroneBarge, makePylon,
+} from './world.js';
 import { FACTS, QUEST_ITEMS, TOOLS, HINTS } from './facts.js';
 
 const AIR_MAX = 100;
@@ -51,6 +55,8 @@ export class WaterworldGame {
     this.pos = new THREE.Vector3(-88, -16, 8);
     this.vel = new THREE.Vector3();
     this.yaw = 0; this.pitch = 0;
+    this.airMax = AIR_MAX;
+    this.hullMax = HULL_MAX;
     this.air = AIR_MAX;
     this.hull = HULL_MAX;
     this.score = 0;
@@ -103,6 +109,16 @@ export class WaterworldGame {
     this._cacheT = 80;
     this.cache = null;
     this._bankOrder = false;     // the CAPTAIN decides when to bank
+    this.touchy = !!opts.touch;  // input-aware copy: 'tap' vs 'press B'
+
+    // THE RISING: the story campaign (quests.js)
+    this.campaign = new Campaign(this);
+    this.bones = [];
+    this.fragments = [];
+    this.elders = [];
+    this.podWhales = [];
+    this._bellNagT = 0;
+    this._chargeRespawn = [];
   }
 
   // ------------------------------------------------------------- setup
@@ -262,9 +278,13 @@ export class WaterworldGame {
       this.scene.add(g);
       this.quest.push({ id, mesh: g, taken: false });
     };
-    // shallow, findable: the grapple and the fizz lance
+    // shallow, findable — every item placed in OPEN water (a quest item
+    // inside a collision volume made the game unwinnable once; the
+    // playtest now asserts reachability for all of them)
+    put('hook', -25, 48);
+    put('rope', -56, 12);
     put('magnet', -75, 30);
-    put('rope', -42, 27, SHELF_Y + 8);      // on the barge deck
+    put('coil', 96, -14);
     put('soda', -12, -22);
     put('nozzle', 58, 38, DEEP_Y + 24);     // hanging off the crane jib
     // behind the fatbergs: the lamp for the deep
@@ -579,8 +599,11 @@ export class WaterworldGame {
   _doPing() {
     if (this.over || this._pingCooldown > 0) return;
     this._pingCooldown = 0.9;
+    this.air = Math.max(0, this.air - 0.8);   // sonar spends a breath
     this._pingAge = 0;
+    this._lastPingAt = this.pos.clone();       // the whales herd HERE
     this.fx?.pingPulse();          // the plankton answer the sonar
+    this._campaignPing();
     this.pingRing.visible = true;
     this.pingRing.position.copy(this.pos);
     this.ui.audio?.ping();
@@ -655,8 +678,9 @@ export class WaterworldGame {
         m.userData.irHot = true;
         this.scene.add(m);
         this.spilled.push({ ...c, mesh: m, age: 0,
-          vel: new THREE.Vector3((Math.random() - 0.5) * 5, 2 + Math.random() * 2,
-            (Math.random() - 0.5) * 5) });
+          lockUntil: this.elapsed + 2.5,   // no instant self-refund
+          vel: new THREE.Vector3((Math.random() - 0.5) * 11, 3 + Math.random() * 4,
+            (Math.random() - 0.5) * 11) });
       }
       this.ui.toast(`💥 ${dropN} CARGO KNOCKED LOOSE — grab it quick!`, 'bad');
       this.ui.announce(`${dropN} pieces of cargo knocked loose. They will not float forever.`);
@@ -670,6 +694,15 @@ export class WaterworldGame {
   }
 
   _collect(s) {
+    if (s.type === 'captains_chest') { this._collectStrongbox(s); return; }
+    if (this.cargo.length >= 8) {
+      if (!this._fullNag || this.elapsed - this._fullNag > 5) {
+        this._fullNag = this.elapsed;
+        this.ui.toast('⚓ HOLD FULL — bank before you take more!', 'warn');
+        this.ui.announce('The hold is full. Bank the haul first.');
+      }
+      return;
+    }
     s.collected = true;
     this.scene.remove(s.mesh);
     // COMBO: quick successive grabs are worth more — routes matter
@@ -716,8 +749,8 @@ export class WaterworldGame {
   }
 
   _bank() {
-    if (!this.cargo.length) { this.air = AIR_MAX; return; }
-    const n = this.cargo.length;
+    if (!this.cargo.length) { this.air = this.airMax; return; }
+    const n0 = this.airMax; this.air = n0; const n = this.cargo.length;
     const base = this.cargo.reduce((a, c) => a + c.value, 0);
     // the haul bonus is now worth chasing — and worth risking
     const mult = Math.min(3, 1 + 0.25 * (n - 1));
@@ -727,14 +760,11 @@ export class WaterworldGame {
     this.score += gained;
     this.bankedValue += gained;
     for (const c of this.cargo) this.bankedTypes.add(c.type);
-    const hadChest = this.cargo.some(c => c.type === 'captains_chest');
     this.cargo = [];
-    this.air = AIR_MAX;
     this.banks++;
     this.ui.audio?.bank(n);
     this.ui.toast(`🎉 BANKED ×${n}  +${gained}${mult > 1 ? `  (×${mult.toFixed(2)} haul bonus!)` : ''}`, 'gold');
     this.ui.announce(`Banked ${n} items for ${gained} points. Air refilled.`);
-    if (hadChest) { this._win(); return; }
     // confetti — a banked haul is a little party
     this.fx.confetti(this.scene, this.pos.clone());
     // banking stirs the dock: more eels, and eventually the fatbergs move
@@ -742,10 +772,8 @@ export class WaterworldGame {
     if (this.banks === 2 && !this.duck && !this._duckDone) this._spawnDuck();
     if (this.eels.length < 7) this._spawnEels(1);
     if (this.banks >= 2) this._spawnRampantFatberg();
-    // the whale comes when the dock has given up enough of its past
-    if (!this.whaleActive && (this.bankedTypes.size >= 6 || this.bankedValue >= 320)) {
-      this._wakeWhale();
-    }
+    // the first banking wakes what sleeps below
+    this.campaign.begin();
   }
 
   _wakeWhale() {
@@ -929,13 +957,13 @@ export class WaterworldGame {
 
     // -------- air + hull economy
     this.air -= dt * (thrusting ? 1.7 : 1.1) * (1 + this.banks * 0.06);
-    if (this.air < 25 && !this._lowAirWarned) {
+    if (this.air < this.airMax * 0.25 && !this._lowAirWarned) {
       this._lowAirWarned = true;
       this.ui.audio?.alarm();
       this.ui.toast('⚠ AIR LOW — BACK TO THE BELL', 'warn');
       this.ui.announce('Air is low. Return to the diving bell.');
     }
-    if (this.air >= 25) this._lowAirWarned = false;
+    if (this.air >= this.airMax * 0.25) this._lowAirWarned = false;
     if (this.air <= 0) {
       this.air = 0;
       this._drownT = (this._drownT || 0) + dt;
@@ -945,8 +973,16 @@ export class WaterworldGame {
     // -------- the bell: bank + breathe
     const bellPos = this.dock.bell.position;
     if (this.pos.distanceTo(bellPos) < 9) {
-      if (this.air < AIR_MAX - 1 || this.cargo.length) this._bank();
-      this.air = Math.min(AIR_MAX, this.air + dt * 40);
+      // banking is the captain's act: the 🔔 order, or hands on the helm.
+      // The autopilot may only breathe here — it never banks for you.
+      const captains = this._bankOrder || !this.autopilot || this.elapsed < this.manualUntil;
+      if (captains && this.cargo.length) this._bank();
+      else if (this.cargo.length && this.elapsed - this._bellNagT > 6) {
+        this._bellNagT = this.elapsed;
+        this.ui.toast('🔔 At the bell — tap BANK to cash the haul', 'hint');
+      }
+      this.air = Math.min(this.airMax, this.air + dt * 40);
+      this._maybeRubyCourt();
     }
     this.dock.bell.userData.ring.rotation.z += dt * 0.8;
 
@@ -977,6 +1013,7 @@ export class WaterworldGame {
     this._stepFatbergs(dt);
     this._stepMines(dt);
     this._stepWhale(dt);
+    this._stepCampaign(dt);
     this._maybeSeal(dt);
     this._stepDuck(dt);
     this._stepParticles(dt);
@@ -1014,16 +1051,7 @@ export class WaterworldGame {
       }
       return best;
     };
-    const carryingChest = this.hasChest || this.cargo.some(c => c.type === 'captains_chest');
-    if (carryingChest) return { icon: '🏴‍☠️', text: 'Bank the chest at the bell!', target: bell };
     if (this.air < 30) return { icon: '💨', text: 'Air low — swim to the bell!', target: bell };
-    if (this.whaleActive) {
-      if (!this.tools.has('grapple')) {
-        const part = nearest(this.quest.filter(q => !q.taken && (q.id === 'magnet' || q.id === 'rope')));
-        if (part) return { icon: '🪝', text: 'Craft a grapple: find magnet + rope', target: part.mesh.position };
-      }
-      return { icon: '🐋', text: 'Follow the whale to the chest!', target: this.chest.mesh.position };
-    }
     // banking is the CAPTAIN'S call (the 🔔 button) — the helm only
     // suggests it, it never decides for you
     if (this._bankOrder && this.cargo.length) {
@@ -1032,6 +1060,8 @@ export class WaterworldGame {
     if (this.banks === 0 && this.cargo.length >= 3) return { icon: '🔔', text: 'Nice haul riding! Tap 🔔 BANK when ready', target: bell };
     const spill = this.spilled[0];
     if (spill) return { icon: '⚠', text: 'Your spilled cargo is fading — grab it!', target: spill.mesh.position };
+    const story = this.campaign.objective();
+    if (story) return story;
     if (this.tools.has('fizzlance')) {
       const berg = this.fatbergs.find(f => f.blocking);
       if (berg) return { icon: '🫧', text: 'Hold B by a fatberg to fizz it away', target: berg.mesh.position };
@@ -1039,13 +1069,15 @@ export class WaterworldGame {
     const grabbable = this.salvage.filter(s => !s.collected && !s.hidden && (!s.heavy || this.tools.has('grapple')));
     const s = nearest(grabbable);
     if (this.banks === 0) {
-      return { icon: '✨', text: `Grab ${Math.max(0, 3 - this.cargo.length)} more shiny finds — press B to ping!`, target: s?.mesh.position ?? bell };
+      const n = Math.max(1, 3 - this.cargo.length);
+      const verb = this.touchy ? 'tap the water to ping!' : 'press B to ping!';
+      return { icon: '✨', text: `Grab ${n} more shiny ${n === 1 ? 'find' : 'finds'} — ${verb}`, target: s?.mesh.position ?? bell };
     }
     const gear = nearest(this.quest.filter(q => !q.taken));
     if (gear && (!s || gear.mesh.position.distanceTo(this.pos) < s.mesh.position.distanceTo(this.pos))) {
       return { icon: '💗', text: 'Pink glow = gear! Collect it to craft tools', target: gear.mesh.position };
     }
-    return { icon: '✨', text: 'Ping (B) and gather salvage', target: s?.mesh.position ?? bell };
+    return { icon: '✨', text: this.touchy ? 'Tap to ping, gather salvage' : 'Ping (B) and gather salvage', target: s?.mesh.position ?? bell };
   }
 
   hudState() {
@@ -1064,7 +1096,7 @@ export class WaterworldGame {
     }
     return {
       obj: objOut,
-      air: this.air / AIR_MAX, hull: this.hull, hullMax: HULL_MAX,
+      air: this.air / this.airMax, hull: this.hull, hullMax: this.hullMax,
       score: this.score, cargo: this.cargo.length,
       cargoValue: this.cargo.reduce((a, c) => a + c.value, 0),
       depth: Math.round(-this.pos.y),
@@ -1076,6 +1108,8 @@ export class WaterworldGame {
       haulMult: Math.min(3, 1 + 0.25 * Math.max(0, this.cargo.length - 1)),
       combo: this.combo, dashReady: this._dashCd <= 0,
       tide: this.tide > 1, spilled: this.spilled.length,
+      seats: this.campaign.stage === 'dormant' ? null : this.campaign.hudSeats(),
+      storyStage: this.campaign.stage,
     };
   }
 
@@ -1164,6 +1198,7 @@ export class WaterworldGame {
       s.vel.multiplyScalar(1 - dt * 1.6);
       s.vel.y -= dt * 0.5;                      // it slowly settles
       s.mesh.material.opacity = 0.9 * Math.max(0, 1 - s.age / 18);
+      if (this.elapsed < s.lockUntil) continue;   // it has to drift first
       if (s.mesh.position.distanceTo(this.pos) < 3.2) {
         this.cargo.push({ type: s.type, value: s.value });
         this.ui.audio?.pickup(s.value);
@@ -1443,6 +1478,428 @@ export class WaterworldGame {
     }
   }
 
+  // ------------------------------------------------------- THE RISING
+  _spawnCampaignSites() {
+    // the Steelyard stone: remembered ground, north-west shallows
+    this.steelyard = makeSteelyard();
+    this.steelyard.position.set(-98, floorYAt(-98, -62), -62);
+    this.scene.add(this.steelyard);
+    const syGlow = glowSprite(0xbfd4e8, 7, 0.4);
+    syGlow.position.y = 4;
+    this.steelyard.add(syGlow);
+    // three ancestor bones, scattered where whales would rest
+    for (const [x, z] of [[-15, 62], [52, -58], [88, 48]]) {
+      const b = makeBone();
+      b.position.set(x, floorYAt(x, z) + 0.8, z);
+      const halo = glowSprite(0xe8f4ff, 3.4, 0.45);
+      halo.position.y = 1.5;
+      b.add(halo);
+      this.scene.add(b);
+      this.bones.push({ mesh: b, taken: false });
+    }
+    // the elder eels: Amp tribe (lime) west, Volt tribe (blue) east
+    for (const [tribe, tint, x, z] of [['Amp', 0x00e436, -66, -66], ['Volt', 0x29adff, 96, -44]]) {
+      const m = makeElderEel(tint);
+      m.position.set(x, floorYAt(x, z) + 6, z);
+      m.userData.irColor = 0x38506e;
+      this.scene.add(m);
+      this.elders.push({ tribe, mesh: m, phase: Math.random() * 9, home: m.position.clone() });
+    }
+    // the torn charter, in three glass cases
+    for (const [x, z] of [[-45, -40], [30, 66], [72, -12]]) {
+      const f = makeFragment();
+      f.position.set(x, floorYAt(x, z) + 0.4, z);
+      const halo = glowSprite(0x7ef2ff, 3, 0.5);
+      halo.position.y = 1;
+      f.add(halo);
+      this.scene.add(f);
+      this.fragments.push({ mesh: f, taken: false });
+    }
+    // PALE & SONS drone barge, on its delivery run at the surface
+    this.candleBarge = makeDroneBarge();
+    this.candleBarge.position.set(-110, -0.4, -22);
+    this.scene.add(this.candleBarge);
+    this._bargeDir = 1;
+    // two salvaged depth charges bobbing near its lane
+    this.charges = [];
+    for (const x of [-35, 45]) {
+      const c = makeMine();
+      c.scale.setScalar(0.8);
+      c.position.set(x, -6, -22);
+      const halo = glowSprite(0xffa300, 2.4, 0.4);
+      halo.userData.irHot = true;
+      c.add(halo);
+      this.scene.add(c);
+      this.charges.push({ mesh: c, live: true, x });
+    }
+    // the strongbox is visible from the start — a promise on the chart
+    this.chest.hidden = false;
+    this.chest.mesh.visible = true;
+    this.chest._known = true;
+  }
+
+  _collectStrongbox(s) {
+    if (!this.tools.has('grapple')) {
+      if (!s._nagged || this.elapsed - s._nagged > 6) {
+        s._nagged = this.elapsed;
+        this.ui.toast('TOO HEAVY — craft the grapple (hook + rope)', 'warn');
+      }
+      return;
+    }
+    s.collected = true;
+    this.scene.remove(s.mesh);
+    this.hasChest = true;
+    this.campaign.ruby.step = 'decide';
+    this.campaign.ruby.held = 5;
+    this.campaign.fact('eic_rubies');
+    this.ui.audio?.craft();
+    this.ui.toast('💎 THE EAST INDIA STRONGBOX — five uncut rubies', 'gold');
+    this.ui.announce('You raise the East India Company strongbox. Five uncut rubies. Decide at the bell.');
+  }
+
+  _maybeRubyCourt() {
+    const r = this.campaign.ruby;
+    if (r.step !== 'decide' || r.held <= 0) return;
+    if (this._rubyCourtOpen || this.elapsed - (this._rubyCourtT || 0) < 4) return;
+    this._rubyCourtOpen = true;
+    this._rubyCourtT = this.elapsed;
+    this.ui.choice(
+      `💎 A ruby in your glove (${r.held} left). The river is watching.`,
+      [
+        { label: '⛑ Spend: hull +1 and full repair', value: 'hull' },
+        { label: '🫁 Spend: air tank +25', value: 'air' },
+        { label: '💧 Return it to the river', value: 'return' },
+        { label: 'Not yet', value: 'later' },
+      ],
+    ).then((v) => {
+      this._rubyCourtOpen = false;
+      if (v === 'later' || !v) return;
+      r.held--;
+      if (v === 'hull') {
+        this.hullMax += 1;
+        this.hull = this.hullMax;
+        r.spent++;
+        this.ui.toast('⛑ Hull reinforced with ruby-hard plate', 'good');
+      } else if (v === 'air') {
+        this.airMax += 25;
+        this.air = this.airMax;
+        r.spent++;
+        this.ui.toast('🫁 Air tank expanded — a deep breath of it', 'good');
+      } else {
+        r.returned++;
+        this.score += 40;
+        this.fx.confetti(this.scene, this.dock.bell.position.clone());
+        this.ui.toast(`💧 Returned to the river (+40) — ${r.returned}/3 for the River Folk`, 'gold');
+        if (r.returned >= 3) this.campaign.joinRiver();
+      }
+    });
+  }
+
+  _campaignPing() {
+    const c = this.campaign;
+    // parley: a gentle ping close to an elder is how you talk
+    for (const el of this.elders) {
+      if (el.mesh.position.distanceTo(this.pos) > 10) continue;
+      if (c.eel.step === 'parley' && !c.eel.parleyed.has(el.tribe)) {
+        c.eel.parleyed.add(el.tribe);
+        this.ui.audio?.zap();
+        this.ui.toast(el.tribe === 'Amp'
+          ? '⚡ AMP ELDER: "The Volts took the island. The charter would prove it — if it existed."'
+          : '⚡ VOLT ELDER: "The Amps hoard the current. Read the charter, if you can find it."', 'hint');
+        this.ui.announce(`You parley with the ${el.tribe} elder.`);
+        if (c.eel.parleyed.size >= 2) {
+          c.eel.step = 'fragments';
+          c.fact('eel_schism');
+        }
+      } else if (c.eel.step === 'restore' && !c.eel.returned.has(el.tribe)) {
+        c.eel.returned.add(el.tribe);
+        this.ui.audio?.craft();
+        this.ui.toast(`📜 The ${el.tribe} elder reads the restored charter…`, 'gold');
+        if (c.eel.returned.size >= 2) c.joinEels();
+      }
+    }
+    // the lament: loudspeaker at the Steelyard
+    if (c.whale.step === 'lament' && this.tools.has('loudspeaker')
+        && this.steelyard && this.steelyard.position.distanceTo(this.pos) < 12) {
+      c.whale.step = 'barge';
+      this.ui.audio?.whaleSong();
+      setTimeout(() => this.ui.audio?.whaleSong(), 1800);
+      setTimeout(() => this.ui.audio?.whaleSong(), 3600);
+      this._wakeWhale();
+      this._raisePod();
+      c.fact('candle_barge');
+      this.ui.toast('🎵 THE LAMENT SOUNDS — the ghosts are listening', 'gold');
+      this.ui.announce('The lament sounds over the Steelyard. The whale ghosts rise to listen.');
+    }
+    // depth charges under the candle barge
+    if (c.whale.step === 'barge' && this.candleBarge) {
+      for (const ch of this.charges) {
+        if (!ch.live) continue;
+        const d = ch.mesh.position.distanceTo(this.pos);
+        if (d > 7 && d < 18) {
+          const under = Math.abs(this.candleBarge.position.x - ch.mesh.position.x) < 11
+            && Math.abs(this.candleBarge.position.z - ch.mesh.position.z) < 8;
+          ch.live = false;
+          ch.mesh.visible = false;
+          ch.respawnAt = this.elapsed + 14;
+          this.ui.audio?.boom();
+          const burst = makeParticleCloud(50, 0xffa300, 1.4, 9);
+          burst.position.copy(ch.mesh.position);
+          burst.userData.age = 0;
+          this.scene.add(burst);
+          this.glints.push(burst);
+          if (under) {
+            c.whale.bargeHits++;
+            this.ui.toast(`🕯️ DIRECT HIT ON PALE & SONS (${c.whale.bargeHits}/2)`, 'gold');
+            if (c.whale.bargeHits >= 2) this._sinkBarge();
+          } else {
+            this.ui.toast('💨 The charge blows wide — time it under the barge', 'warn');
+          }
+        }
+      }
+    }
+    // the spark: all bergs penned, ping the pylon
+    if (this.campaign.stage === 'finale' && this.pylon
+        && this.campaign.finale.bergs.length
+        && this.campaign.finale.bergs.every(b => b.penned || b.dead)
+        && this.pylon.position.distanceTo(this.pos) < 14) {
+      this._spark();
+    }
+  }
+
+  _raisePod() {
+    for (let i = 0; i < 2; i++) {
+      const w = makeGhostWhale();
+      w.material.opacity = 0.55;
+      w.visible = true;
+      w.userData.phase = i * 2.4;
+      w.position.set(-70 + i * 30, -16 - i * 4, -30 + i * 20);
+      this.scene.add(w);
+      this.podWhales.push(w);
+    }
+  }
+
+  _sinkBarge() {
+    this.candleBarge.userData.sinking = 0;
+    this.ui.toast('🕯️ PALE & SONS IS GOING DOWN', 'gold');
+    this.ui.announce('The candle barge is sinking. The whale ghosts watch it go.');
+    // its cargo becomes honest salvage
+    for (let i = 0; i < 3; i++) {
+      const g = makeSalvageMesh('tea_chest');
+      g.position.set(this.candleBarge.position.x + (i - 1) * 5,
+        floorYAt(this.candleBarge.position.x, -22) + 0.5, -20 + i * 3);
+      this.scene.add(g);
+      this.salvage.push({ type: 'tea_chest', mesh: g, collected: false,
+        heavy: false, hidden: false, value: 30, _known: true });
+    }
+    this.campaign.joinWhales();
+  }
+
+  _beginFinale() {
+    // the pylon rises at Blight Corner
+    this.pylon = makePylon();
+    this.pylon.position.set(100, floorYAt(100, 64), 64);
+    this.scene.add(this.pylon);
+    const glow = glowSprite(0x9fdcff, 12, 0.5);
+    glow.position.y = 19;
+    glow.userData.irHot = true;
+    this.pylon.add(glow);
+    // the armada rises from the culverts
+    for (let i = 0; i < 6; i++) {
+      const mouth = this.dock.culverts[i % this.dock.culverts.length];
+      const m = makeFatberg(3.2 + Math.random());
+      m.userData.irColor = 0xffdd66;
+      m.position.set(mouth.x + (Math.random() - 0.5) * 8,
+        mouth.y + 4 + Math.random() * 6, mouth.z + 8 + Math.random() * 6);
+      this.scene.add(m);
+      if (this.ir) this._irApply(m);
+      this.campaign.finale.bergs.push({ mesh: m, penned: false, dead: false,
+        vel: new THREE.Vector3(), wobble: Math.random() * 9 });
+    }
+    if (!this.whaleActive) { this._wakeWhale(); }
+    if (!this.podWhales.length) this._raisePod();
+    this.ui.toast('🟤 THE BERG ARMADA RISES — herd them to Blight Corner!', 'warn');
+    this.ui.announce('The berg armada is rising. Ping near a berg and the whales will herd it toward Blight Corner.');
+  }
+
+  _stepCampaign(dt) {
+    const c = this.campaign;
+    if (c.stage === 'dormant') return;
+    // ancestor bones: swim close to gather
+    if (c.whale.step === 'bones') {
+      for (const b of this.bones) {
+        if (!b.taken && b.mesh.position.distanceTo(this.pos) < 3.6) {
+          b.taken = true;
+          this.scene.remove(b.mesh);
+          this.ui.audio?.pickup(30);
+          this.ui.toast(`🦴 ANCESTOR BONE (${this.bones.filter(x => x.taken).length}/3)`, 'good');
+        }
+      }
+      if (this.bones.every(b => b.taken)) {
+        c.whale.step = 'bury';
+        c.fact('steelyard');
+      }
+    } else if (c.whale.step === 'bury' && this.steelyard
+        && this.steelyard.position.distanceTo(this.pos) < 9) {
+      c.whale.bonesBuried = 3;
+      c.whale.step = 'speaker';
+      for (const plot of this.steelyard.userData.plots) plot.material = this.steelyard.children[1].material;
+      this.ui.audio?.bank(3);
+      this.ui.toast('⚓ THE BONES REST IN REMEMBERED GROUND', 'gold');
+      this.ui.announce('The bones are buried at the Steelyard. The ground remembers.');
+      c.fact('whale_lament');
+    } else if (c.whale.step === 'speaker' && this.tools.has('loudspeaker')) {
+      c.whale.step = 'lament';
+    }
+    // charter fragments
+    if (c.eel.step === 'fragments') {
+      for (const f of this.fragments) {
+        if (!f.taken && f.mesh.position.distanceTo(this.pos) < 3.6) {
+          f.taken = true;
+          c.eel.fragments++;
+          this.scene.remove(f.mesh);
+          this.ui.audio?.pickup(30);
+          this.ui.toast(`📜 CHARTER FRAGMENT (${c.eel.fragments}/3)`, 'good');
+        }
+      }
+      if (c.eel.fragments >= 3) {
+        c.eel.step = 'restore';
+        this.ui.toast('📜 The charter reads: "…held IN COMMON by all tribes…"', 'gold');
+      }
+    }
+    // elder eels idle in place, regal
+    for (const el of this.elders) {
+      el.phase += dt * 0.5;
+      el.mesh.position.y = el.home.y + Math.sin(el.phase) * 1.2;
+      el.mesh.rotation.y += dt * 0.15;
+    }
+    // the candle barge patrols until it doesn't
+    if (this.candleBarge) {
+      const cb = this.candleBarge;
+      if (cb.userData.sinking !== undefined) {
+        cb.userData.sinking += dt;
+        cb.position.y -= dt * 1.6;
+        cb.rotation.z += dt * 0.06;
+        if (cb.position.y < -30) { this.scene.remove(cb); this.candleBarge = null; }
+      } else {
+        cb.position.x += this._bargeDir * dt * 2.4;
+        if (cb.position.x > 110) this._bargeDir = -1;
+        if (cb.position.x < -110) this._bargeDir = 1;
+        for (const r of (cb.userData.rotors || [])) r.rotation.y += dt * 20;
+      }
+    }
+    for (const ch of this.charges || []) {
+      if (!ch.live && ch.respawnAt && this.elapsed > ch.respawnAt) {
+        ch.live = true;
+        ch.mesh.visible = true;
+        ch.mesh.position.set(ch.x, -6, -22);
+      }
+      if (ch.live) ch.mesh.position.y = -6 + Math.sin(this.elapsed * 1.3 + ch.x) * 0.4;
+    }
+    // pod whales converge on the last sonar ping — YOUR herding tool
+    const herd = this._lastPingAt;
+    for (const w of this.podWhales) {
+      const target = herd ? herd.clone().add(new THREE.Vector3(
+        Math.sin(this.elapsed * 0.4 + w.userData.phase) * 8, 3, Math.cos(this.elapsed * 0.5 + w.userData.phase) * 8))
+        : this.pos.clone().add(new THREE.Vector3(0, 6, 10));
+      target.y = Math.max(floorYAt(target.x, target.z) + 4, Math.min(-4, target.y));
+      const dir = target.sub(w.position);
+      const d = dir.length();
+      if (d > 1) w.position.addScaledVector(dir.normalize(), Math.min(9, d) * dt);
+      w.lookAt(w.position.clone().add(dir));
+      w.rotateY(-Math.PI / 2);
+    }
+    // finale: bergs flee whales, drift for the city, stick in the pen
+    if (c.stage === 'finale') {
+      if (this.pylon) this.pylon.userData.orb.material.emissive?.setHex(
+        Math.sin(this.elapsed * 6) > 0 ? 0x66c0ff : 0x1a3a55);
+      let penned = 0;
+      for (const b of c.finale.bergs) {
+        if (b.dead) continue;
+        const m = b.mesh;
+        b.wobble += dt;
+        m.rotation.y += dt * 0.15;
+        if (b.penned) {
+          penned++;
+          m.position.x = Math.max(76, m.position.x);
+          m.position.z = Math.max(46, m.position.z);
+          m.position.y += Math.sin(b.wobble) * 0.02;
+          continue;
+        }
+        // fear of the ghosts: pushed away from any pod whale
+        b.vel.multiplyScalar(1 - dt * 0.8);
+        for (const w of [this.whale, ...this.podWhales]) {
+          if (!w || !w.visible) continue;
+          const d = m.position.distanceTo(w.position);
+          if (d < 20) {
+            b.vel.addScaledVector(
+              _cur.subVectors(m.position, w.position).normalize(), (20 - d) * 0.5 * dt * 6);
+          }
+        }
+        // otherwise: rising toward the city (the north wall)
+        b.vel.z -= dt * 0.6;
+        b.vel.y += dt * 0.15;
+        m.position.addScaledVector(b.vel, dt);
+        m.position.x = Math.max(BOUNDS.minX + 6, Math.min(BOUNDS.maxX - 4, m.position.x));
+        m.position.z = Math.max(BOUNDS.minZ + 6, Math.min(BOUNDS.maxZ - 4, m.position.z));
+        m.position.y = Math.max(floorYAt(m.position.x, m.position.z) + 3, Math.min(-4, m.position.y));
+        if (m.position.x > 76 && m.position.z > 46) {
+          b.penned = true;
+          this.ui.audio?.bank(1);
+          this.ui.toast(`🟤 BERG PENNED (${c.finale.bergs.filter(x => x.penned).length}/${c.finale.bergs.length})`, 'gold');
+        }
+      }
+      c.finale.penned = c.finale.bergs.filter(x => x.penned).length;
+    }
+  }
+
+  // Harness shortcut: complete-with-success without playing the story.
+  _testWin() {
+    if (this.over) return;
+    this.score += 250;
+    this.won = true;
+    this.over = true;
+    this.ui.complete({ success: true, score: this.score, stats: {
+      artifacts: this.bankedTypes.size, codex: this.codex.size, tools: this.tools.size,
+    } });
+  }
+
+  _spark() {
+    const c = this.campaign;
+    if (c.stage !== 'finale' || c.finale.sparked) return;
+    c.finale.sparked = true;
+    c.stage = 'spark';
+    this.ui.audio?.zap();
+    this.ui.audio?.boom();
+    setTimeout(() => this.ui.audio?.boom(), 500);
+    setTimeout(() => this.ui.audio?.victory(), 1000);
+    for (const b of c.finale.bergs) {
+      b.dead = true;
+      const burst = makeParticleCloud(70, 0xffa300, 1.6, 14);
+      burst.position.copy(b.mesh.position);
+      burst.userData.age = 0;
+      this.scene.add(burst);
+      this.glints.push(burst);
+      this.scene.remove(b.mesh);
+    }
+    this.fx.confetti(this.scene, this.pylon.position.clone().add(new THREE.Vector3(0, 10, 0)));
+    this.fx.confetti(this.scene, this.pos.clone());
+    this.score += 500;
+    c.stage = 'won';
+    c.fact('victory');
+    this.won = true;
+    this.over = true;
+    this.ui.announce('The bergs go up over Blight Corner. Democracy is saved. The end.');
+    setTimeout(() => {
+      this.ui.complete({
+        success: true,
+        score: this.score,
+        storyWon: true,
+        stats: { artifacts: this.bankedTypes.size, codex: this.codex.size, tools: this.tools.size },
+      });
+    }, 3500);
+  }
+
   _stepParticles(dt) {
     // marine snow drifts down and wraps
     this.snow.material.opacity = this.ir ? 0.12 : 0.8;
@@ -1546,7 +2003,8 @@ export class WaterworldGame {
 
   // ------------------------------------------------------------- persistence
   snapshot() {
-    if (this.over) return null;   // a finished game should not be resumed
+    if (this.over) return null;
+    if (this.campaign.stage !== 'dormant') return null;   // a finished game should not be resumed
     return {
       pos: this.pos.toArray(), yaw: this.yaw, pitch: this.pitch,
       air: this.air, hull: this.hull, score: this.score,

--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -10,6 +10,8 @@ const $ = (id) => document.getElementById(id);
 const params = new URLSearchParams(location.search);
 const EMBED = window.parent !== window;
 const LITE = params.has('lite');
+const IS_TOUCH = matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window ||
+  navigator.maxTouchPoints > 0;
 
 const audio = new WaterAudio();
 let game = null;
@@ -108,6 +110,7 @@ function announce(text) { window.__mgA11y?.announce?.(text); }
 let lastHull, lastScore, lastObjText;
 function hud(s) {
   // the guide banner: what to do, which way, how far
+  $('objective').style.display = s.obj && !s.over ? '' : 'none';
   if (s.obj) {
     $('obj-text').textContent = `${s.obj.icon} ${s.obj.text}`;
     $('obj-arrow').style.transform = `rotate(${s.obj.deg}deg)`;
@@ -135,10 +138,11 @@ function hud(s) {
   bankBtn.hidden = !s.cargo || s.over;
   $('codex').textContent = `📖${s.codex}/${s.codexTotal}`;
   const held = [
-    ...s.tools.map(t => ({ grapple: '🪝', arclamp: '💡', fizzlance: '🫧' }[t] || '🔧')),
-    ...s.items.map(i => ({ magnet: '🧲', rope: '🪢', lamp: '🏮', battery: '🔋', soda: '📦', nozzle: '🔩' }[i] || '❓')),
+    ...s.tools.map(t => ({ grapple: '🪝', arclamp: '💡', fizzlance: '🫧', loudspeaker: '🔊' }[t] || '🔧')),
+    ...s.items.map(i => ({ magnet: '🧲', rope: '🪢', hook: '🪝', coil: '🌀', lamp: '🏮', battery: '🔋', soda: '📦', nozzle: '🔩' }[i] || '❓')),
   ];
   $('inv').textContent = held.join(' ') || '·';
+  $('seats').textContent = s.seats ? `🤝${s.seats}` : '';
   const irBtn = $('ir-btn');
   irBtn.classList.toggle('on', !!s.ir);
   irBtn.setAttribute('aria-pressed', String(!!s.ir));
@@ -148,11 +152,17 @@ function hud(s) {
 }
 
 function complete(result) {
+  document.body.classList.add('game-over');   // live UI stands down
   const el = $('endcard');
-  $('end-title').textContent = result.success ? '🎉 TREASURE RAISED! 🎉' : '💫 WHAT A DIVE!';
-  $('end-body').textContent = result.success
-    ? `The captain’s chest is aboard the bell! Score ${result.score}, with ${result.stats.codex} pieces of London history in your log. Marvellous.`
-    : `Score ${result.score} and ${result.stats.codex} history entries logged — the dock will still be there tomorrow. Dive again!`;
+  if (result.storyWon) {
+    $('end-title').textContent = '🎆 THE BERGS ARE BEATEN! 🎆';
+    $('end-body').textContent = `Methane, whale-song and one unified spark — Blight Corner goes up like a second Great Fire, backwards. Democracy is saved, and somewhere in City Hall a stinky wet wipe lands in the Mayor's lunch. Score ${result.score}, ${result.stats.codex} codex entries. The end.`;
+  } else {
+    $('end-title').textContent = result.success ? '🎉 A FINE DIVE! 🎉' : '💫 WHAT A DIVE!';
+    $('end-body').textContent = result.success
+      ? `Score ${result.score}, with ${result.stats.codex} pieces of London history in your log. Marvellous.`
+      : `Score ${result.score} and ${result.stats.codex} history entries logged — the dock will still be there tomorrow. Dive again!`;
+  }
   el.classList.add('show');
   audio.stopMusic();
   if (sdk && EMBED) {
@@ -173,7 +183,28 @@ function complete(result) {
   }
 }
 
-const ui = { hud, toast, fact, hint, announce, complete, audio };
+function choice(prompt, options) {
+  return new Promise((resolve) => {
+    const panel = $('choice-panel');
+    $('choice-prompt').textContent = prompt;
+    const box = $('choice-options');
+    box.replaceChildren();
+    for (const o of options) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.textContent = o.label;
+      b.addEventListener('click', () => {
+        panel.classList.remove('show');
+        resolve(o.value);
+      });
+      box.appendChild(b);
+    }
+    panel.classList.add('show');
+    box.firstChild?.focus();
+  });
+}
+
+const ui = { hud, toast, fact, hint, announce, complete, audio, choice };
 
 // ---------------------------------------------------------------- input
 // One mapping for real keyboards AND the shell's input service: the host
@@ -197,8 +228,17 @@ function setAction(action, down, fromRepeat) {
     releaseTimers[action] = setTimeout(() => game.setKey(action, false), fromRepeat ? 350 : 900);
   } else clearTimeout(releaseTimers[action]);
 }
+const PANELS = ['help-panel', 'log-panel', 'map-panel', 'choice-panel'];
+function closeTopPanel() {
+  for (const id of PANELS) {
+    const p = $(id);
+    if (p && p.classList.contains('show')) { p.classList.remove('show'); return true; }
+  }
+  return false;
+}
 document.addEventListener('keydown', (e) => {
   if (!started && (e.key === ' ' || e.key === 'Enter')) { startGame(); return; }
+  if (e.key === 'Escape' && closeTopPanel()) return;   // close beats sonar
   if ((e.key === 'i' || e.key === 'I') && !e.repeat) { game?.toggleIR(); return; }
   const action = KEYMAP[e.key] ?? KEYMAP[e.key?.toLowerCase?.()];
   if (!action) return;
@@ -281,7 +321,7 @@ function startGame() {
   $('splash').classList.remove('show');
   audio.ensure();
   if (!game) {
-    game = new WaterworldGame($('scene'), ui, { lite: LITE });
+    game = new WaterworldGame($('scene'), ui, { lite: LITE, touch: IS_TOUCH });
     game.init();
     if (pendingRestore) { game.restore(pendingRestore); pendingRestore = null; }
     window.__waterworld = {
@@ -294,7 +334,7 @@ function startGame() {
       grabAll: () => game.salvage.filter(s => !s.collected && !s.hidden && !s.heavy)
         .slice(0, 3).forEach(s => game._collect(s)),
       bank: () => game._bank(),
-      win: () => { game.hasChest = true; game.cargo.push({ type: 'captains_chest', value: 250 }); game._bank(); },
+      win: () => game._testWin(),
       lose: () => game._lose('Scuttled by the test harness.'),
     };
   }
@@ -337,13 +377,20 @@ $('end-again').addEventListener('click', () => location.reload());
 
 window.addEventListener('resize', () => game?.resize());
 
+// keyboard operability: Enter/Space on any chip fires its pointer handler
+for (const el of document.querySelectorAll('.chip, #bank-btn, #pad-toggle')) {
+  el.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    }
+  });
+}
+
 buildPad();
 // Touch-first means GESTURES first: brush to steer, tap to ping. The
 // d-pad is the last resort, parked behind the 🎮 chip until summoned.
-if (matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window ||
-    navigator.maxTouchPoints > 0) {
-  $('pad-toggle').dataset.touch = '1';
-}
+if (IS_TOUCH) $('pad-toggle').dataset.touch = '1';
 $('pad-toggle').addEventListener('pointerdown', (e) => {
   e.stopPropagation();
   const open = !$('pad').classList.contains('open');

--- a/magpie/waterworld/js/quests.js
+++ b/magpie/waterworld/js/quests.js
@@ -1,0 +1,193 @@
+// Waterworld campaign — THE RISING. Newly sentient fatbergs stir beneath
+// the dock and mean to take the city. You cannot fight them alone: build
+// a coalition of three — the unquiet ghosts of the whales, the divided
+// tribes of the electric eels, and the river itself, appeased by what
+// you do with the East India Company's ill-gotten rubies. Then herd the
+// risen bergs into Blight Corner and let the Eel Federation light it up.
+//
+// This module is the story state machine. game.js owns the world and
+// calls in; quests.js decides what the campaign wants next.
+
+export const STORY_FACTS = {
+  bergs_wake: {
+    title: 'THE RISING',
+    icon: '🟤',
+    text: 'The bergs are waking. Fat, wipes and grease, dreaming under London since the sewers were young — and now they want the city. You cannot stop them alone, Captain. Build a coalition of three.',
+  },
+  steelyard: {
+    title: 'THE STEELYARD',
+    icon: '⚓',
+    text: 'The Hanseatic League traded from the Steelyard for 400 years — Cannon Street Station stands on it now. Old ground, older law: what is buried there is remembered. The whale ghosts ask to rest in remembered ground.',
+  },
+  whale_lament: {
+    title: 'THE LAMENT',
+    icon: '🐋',
+    text: 'London burned whale oil for light and boiled spermaceti for candles. The whales were never mourned. A loudspeaker — magnet and living current — can carry a song sad enough to be heard by the dead.',
+  },
+  candle_barge: {
+    title: 'PALE & SONS',
+    icon: '🕯️',
+    text: 'The Pale family lit Mayfair on whale fat for six generations. Their candle drones still ship "heritage spermaceti blend". The ghosts will not join you while that barge floats.',
+  },
+  eel_schism: {
+    title: 'THE EEL SCHISM',
+    icon: '⚡',
+    text: 'The tribes split over the Eel Pie Charter: who holds the island, who holds the current. The charter was torn in three and the pieces scattered. Find them, and the tribes can read what was actually agreed.',
+  },
+  eel_federation: {
+    title: 'THE EEL FEDERATION',
+    icon: '🤝',
+    text: 'The charter, restored, says what both tribes forgot: the island was held IN COMMON. The tribes unite. The Federation grants you a spark-cell — a jar of living lightning, for when the moment comes.',
+  },
+  eic_rubies: {
+    title: 'ILL-GOTTEN GAINS',
+    icon: '💎',
+    text: 'The East India Company strongbox: uncut rubies, taken and never returned. The river remembers every cargo. Use them if you must, Captain — but what you return, the river repays.',
+  },
+  river_folk: {
+    title: 'THE RIVER FOLK',
+    icon: '🦭',
+    text: 'The seals, the dolphins, the bright fish — the river folk saw what you gave back. The third seat of the coalition is taken.',
+  },
+  the_corralling: {
+    title: 'BLIGHT CORNER',
+    icon: '💥',
+    text: 'The plan: the whale ghosts fear-herd the bergs wherever your sonar sings. The vents gas them fat with methane. And when every berg is penned in Blight Corner — the Federation throws the spark.',
+  },
+  victory: {
+    title: 'THE END',
+    icon: '🎆',
+    text: 'Methane, whale-song and one unified spark. The bergs go up over Blight Corner like a second Great Fire, backwards. Democracy is saved. Somewhere in City Hall, a stinky wet wipe lands in the Mayor\'s lunch. The end.',
+  },
+}
+
+// Coalition seats and their arc definitions.
+export class Campaign {
+  constructor(game) {
+    this.g = game;
+    this.stage = 'dormant';         // dormant → rising → finale → spark → won
+    this.coalition = { whales: false, eels: false, river: false };
+    // whale arc: bones → bury → speaker → lament → barge → JOINED
+    this.whale = { step: 'bones', bonesBuried: 0, bargeHits: 0 };
+    // eel arc: parley → fragments → restore → JOINED
+    this.eel = { step: 'parley', parleyed: new Set(), fragments: 0, returned: new Set() };
+    // ruby arc: chest → decide (per ruby) → JOINED (3+ returned)
+    this.ruby = { step: 'chest', held: 0, returned: 0, spent: 0 };
+    this.finale = { bergs: [], penned: 0, sparked: false };
+    this._facted = new Set();
+  }
+
+  fact(key) {
+    if (this._facted.has(key)) return;
+    this._facted.add(key);
+    const f = STORY_FACTS[key];
+    this.g.ui.fact(f.title, f.text, f.icon);
+    this.g.codex.add('story_' + key);
+  }
+
+  seats() { return Object.values(this.coalition).filter(Boolean).length; }
+
+  begin() {
+    if (this.stage !== 'dormant') return;
+    this.stage = 'rising';
+    this.fact('bergs_wake');
+    this.g._spawnCampaignSites();
+    this.g.ui.announce('The bergs are waking. Build a coalition of three.');
+  }
+
+  // Called when a coalition seat fills; three seats trigger the finale.
+  _seatCheck() {
+    if (this.stage === 'rising' && this.seats() >= 3) {
+      this.stage = 'finale';
+      this.fact('the_corralling');
+      this.g._beginFinale();
+    }
+  }
+
+  joinWhales() {
+    if (this.coalition.whales) return;
+    this.coalition.whales = true;
+    this.whale.step = 'joined';
+    this.g.ui.toast('🐋 THE WHALE GHOSTS JOIN THE COALITION', 'gold');
+    this.g.ui.announce('The whale ghosts join the coalition.');
+    this._seatCheck();
+  }
+
+  joinEels() {
+    if (this.coalition.eels) return;
+    this.coalition.eels = true;
+    this.eel.step = 'joined';
+    this.fact('eel_federation');
+    this.g.ui.toast('⚡ THE EEL FEDERATION JOINS THE COALITION', 'gold');
+    this._seatCheck();
+  }
+
+  joinRiver() {
+    if (this.coalition.river) return;
+    this.coalition.river = true;
+    this.ruby.step = 'joined';
+    this.fact('river_folk');
+    this.g.ui.toast('🦭 THE RIVER FOLK JOIN THE COALITION', 'gold');
+    this._seatCheck();
+  }
+
+  // The campaign's idea of what to do next — game.js merges this with
+  // survival objectives (air, spills). Returns {icon,text,target} or null.
+  objective() {
+    const g = this.g;
+    if (this.stage === 'dormant') return null;
+    if (this.stage === 'finale') {
+      const loose = this.finale.bergs.filter(b => !b.penned && !b.dead);
+      if (loose.length) {
+        return { icon: '🐋', text: `Ping near a berg — the whales herd it! ${this.finale.penned}/${this.finale.bergs.length} penned`, target: loose[0].mesh.position };
+      }
+      return { icon: '⚡', text: 'ALL PENNED — ping the eel pylon!', target: g.pylon.position };
+    }
+    if (this.stage === 'won' || this.stage === 'spark') return null;
+    // rising: offer the nearest actionable arc step
+    const options = [];
+    const w = this.whale, e = this.eel, r = this.ruby;
+    if (w.step === 'bones') {
+      const bone = g.bones.find(b => !b.taken);
+      if (bone) options.push({ icon: '🦴', text: `Whales: gather ancestor bones (${g.bones.filter(b => b.taken).length}/3)`, target: bone.mesh.position });
+    } else if (w.step === 'bury') {
+      options.push({ icon: '⚓', text: `Whales: bury the bones at the Steelyard stone (${this.whale.bonesBuried}/3)`, target: g.steelyard.position });
+    } else if (w.step === 'speaker') {
+      const part = g.quest.find(q => !q.taken && (q.id === 'magnet' || q.id === 'coil'));
+      options.push({ icon: '🔊', text: 'Whales: craft the loudspeaker — magnet + coil', target: part ? part.mesh.position : g.steelyard.position });
+    } else if (w.step === 'lament') {
+      options.push({ icon: '🎵', text: 'Whales: sing the lament at the Steelyard (press B there)', target: g.steelyard.position });
+    } else if (w.step === 'barge') {
+      options.push({ icon: '🕯️', text: `Whales: sink the candle barge — ping the charges under it (${this.whale.bargeHits}/2)`, target: g.candleBarge.position });
+    }
+    if (e.step === 'parley') {
+      const elder = g.elders.find(el => !this.eel.parleyed.has(el.tribe));
+      if (elder) options.push({ icon: '⚡', text: `Eels: parley with the ${elder.tribe} elder (press B near them)`, target: elder.mesh.position });
+    } else if (e.step === 'fragments') {
+      const frag = g.fragments.find(f => !f.taken);
+      if (frag) options.push({ icon: '📜', text: `Eels: recover the charter fragments (${this.eel.fragments}/3)`, target: frag.mesh.position });
+    } else if (e.step === 'restore') {
+      const elder = g.elders.find(el => !this.eel.returned.has(el.tribe));
+      if (elder) options.push({ icon: '🤝', text: `Eels: return the charter to the ${elder.tribe} elder`, target: elder.mesh.position });
+    }
+    if (r.step === 'chest') {
+      options.push({ icon: '💎', text: g.tools.has('grapple')
+        ? 'Rubies: raise the East India strongbox'
+        : 'Rubies: craft the grapple (hook + rope) for the strongbox', target: g.chest.mesh.position });
+    } else if (r.step === 'decide') {
+      options.push({ icon: '💎', text: `Rubies: decide at the bell — use or return (${r.held} held, ${r.returned} returned)`, target: g.dock.bell.position });
+    }
+    if (!options.length) return null;
+    // nearest actionable step wins
+    let best = options[0], bd = Infinity;
+    for (const o of options) {
+      const d = o.target ? o.target.distanceTo(g.pos) : 1e9;
+      if (d < bd) { bd = d; best = o; }
+    }
+    return best;
+  }
+
+  hudSeats() {
+    return `${this.coalition.whales ? '🐋' : '·'}${this.coalition.eels ? '⚡' : '·'}${this.coalition.river ? '🦭' : '·'}`;
+  }
+}

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -321,6 +321,99 @@ export function makeReefFish(color) {
   return g;
 }
 
+// ---- Campaign sites -------------------------------------------------
+
+// The Steelyard stone: a Hanseatic boundary marker, remembered ground.
+export function makeSteelyard() {
+  const g = new THREE.Group();
+  const plinth = new THREE.Mesh(new THREE.CylinderGeometry(2.6, 3.2, 1.2, 8), mat(0x4a5568));
+  plinth.position.y = 0.6;
+  g.add(plinth);
+  const stone = new THREE.Mesh(new THREE.CylinderGeometry(1.1, 1.5, 4.2, 6), mat(0x5c6b7c, { emissive: 0x101820 }));
+  stone.position.y = 3;
+  g.add(stone);
+  const seal = new THREE.Mesh(new THREE.TorusGeometry(0.8, 0.18, 8, 16), mat(P8.yellow, { emissive: 0x665500 }));
+  seal.position.set(0, 3.6, 1.05);
+  g.add(seal);
+  // grave-plots: three empty hollows waiting for the bones
+  g.userData.plots = [];
+  for (let i = 0; i < 3; i++) {
+    const plot = new THREE.Mesh(new THREE.CylinderGeometry(0.9, 0.9, 0.2, 10), mat(0x2a3440));
+    plot.position.set(Math.cos(i * 2.1) * 3.4, 0.15, Math.sin(i * 2.1) * 3.4);
+    g.add(plot);
+    g.userData.plots.push(plot);
+  }
+  return g;
+}
+
+// An ancestor bone: a great rib, half out of the silt.
+export function makeBone() {
+  const g = new THREE.Group();
+  const rib = new THREE.Mesh(new THREE.TorusGeometry(2.2, 0.32, 10, 18, Math.PI * 0.85), mat(0xe8e2d4, { emissive: 0x333026 }));
+  rib.rotation.z = 0.4 + Math.random() * 0.5;
+  g.add(rib);
+  return g;
+}
+
+// A charter fragment: torn vellum in a bottle-green glass case.
+export function makeFragment() {
+  const g = new THREE.Group();
+  const caseM = new THREE.Mesh(new THREE.BoxGeometry(0.9, 1.3, 0.3), mat(0x9fdcff, { emissive: 0x28506e }));
+  caseM.position.y = 0.7;
+  caseM.rotation.z = (Math.random() - 0.5) * 0.6;
+  g.add(caseM);
+  return g;
+}
+
+// An elder eel: bigger, calmer, crowned in living light.
+export function makeElderEel(tint) {
+  const g = new THREE.Group();
+  const head = makeEelHead();
+  head.scale.setScalar(1.7);
+  g.add(head);
+  const crown = new THREE.Mesh(new THREE.TorusGeometry(0.9, 0.12, 8, 12), mat(tint, { emissive: tint }));
+  crown.position.y = 1.1;
+  crown.rotation.x = 0.4;
+  g.add(crown);
+  g.userData.head = head;
+  return g;
+}
+
+// The candle company's drone cargo barge: PALE & SONS, est. 1712.
+export function makeDroneBarge() {
+  const g = makeBoatHull('barge');
+  // cargo of candle crates
+  for (let i = 0; i < 4; i++) {
+    const crate = new THREE.Mesh(new THREE.BoxGeometry(2.2, 1.6, 2.2), mat(0xcfc4a8));
+    crate.position.set(-6 + i * 4, 1.2, (i % 2) * 2 - 1);
+    g.add(crate);
+  }
+  // drone rotor masts — nobody crews this thing
+  for (const x of [-9, 0, 9]) {
+    const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.15, 0.15, 4, 8), mat(0x333944));
+    mast.position.set(x, 3, 0);
+    g.add(mast);
+    const rotor = new THREE.Mesh(new THREE.BoxGeometry(3.2, 0.08, 0.3), mat(0x556070));
+    rotor.position.set(x, 5, 0);
+    g.add(rotor);
+    (g.userData.rotors = g.userData.rotors || []).push(rotor);
+  }
+  return g;
+}
+
+// The Eel Federation's spark pylon, raised at Blight Corner.
+export function makePylon() {
+  const g = new THREE.Group();
+  const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 1.1, 18, 8), mat(0x37474f));
+  mast.position.y = 9;
+  g.add(mast);
+  const orb = new THREE.Mesh(new THREE.SphereGeometry(1.6, 16, 12), mat(0x9fdcff, { emissive: 0x3a7fb0 }));
+  orb.position.y = 19;
+  g.add(orb);
+  g.userData.orb = orb;
+  return g;
+}
+
 // A curious Thames seal — pure delight, zero threat. Now properly plump.
 export function makeSeal() {
   const g = new THREE.Group();

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -144,7 +144,9 @@ try {
   // reported drift glitch)
   const wobble = await page.evaluate(async () => {
     const g = window.__waterworld.game;
-    const s = g.salvage.find(s => !s.collected && !s.hidden && s.heavy);   // can't collect it
+    // the strongbox: heavy (uncollectable without grapple) AND in open
+    // water, away from collider-avoidance limit cycles
+    const s = g.salvage.find(s => s.type === 'captains_chest');
     window.__waterworld.teleport(s.mesh.position.x, s.mesh.position.y + 2, s.mesh.position.z);
     await new Promise(r => setTimeout(r, 1200));   // let the filter settle
     const yaws = [];
@@ -291,6 +293,52 @@ try {
   if (fish.schools >= 2 && fish.moved > 0.01) pass(`fish schools swirling (${fish.schools} schools)`);
   else fail(`boids inert: ${JSON.stringify(fish)}`);
 
+  // REACHABILITY: every quest item must be collectable — a rope inside
+  // wreck collision once made the game unwinnable (review finding)
+  const unreachable = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    const bad = [];
+    for (const q of g.quest) {
+      if (q.taken) continue;
+      window.__waterworld.teleport(q.mesh.position.x, q.mesh.position.y + 1, q.mesh.position.z);
+      await new Promise(r => setTimeout(r, 350));
+      if (!q.taken) bad.push(q.id);
+    }
+    return bad;
+  });
+  if (!unreachable.length) pass('all quest items reachable (grapple, loudspeaker, lamp, lance)');
+  else fail('UNREACHABLE quest items: ' + unreachable.join(','));
+
+  // CAMPAIGN SMOKE: the story machine advances through the whale + eel arcs
+  const story = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    const c = g.campaign;
+    c.begin();
+    const s0 = c.stage;
+    for (const b of g.bones) {
+      window.__waterworld.teleport(b.mesh.position.x, b.mesh.position.y + 1, b.mesh.position.z);
+      await new Promise(r => setTimeout(r, 350));
+    }
+    const afterBones = c.whale.step;
+    window.__waterworld.teleport(g.steelyard.position.x + 2, g.steelyard.position.y + 3, g.steelyard.position.z);
+    await new Promise(r => setTimeout(r, 400));
+    const afterBury = c.whale.step;
+    for (const el of g.elders) {
+      window.__waterworld.teleport(el.mesh.position.x + 3, el.mesh.position.y, el.mesh.position.z);
+      await new Promise(r => setTimeout(r, 250));
+      window.__waterworld.ping();
+      await new Promise(r => setTimeout(r, 1200));
+    }
+    return { s0, afterBones, afterBury, eelStep: c.eel.step, seats: c.seats() };
+  });
+  // afterBury is 'speaker' normally, or 'lament' when the reachability
+  // sweep above already auto-crafted the loudspeaker — both are legal
+  if (story.s0 === 'rising' && story.afterBones === 'bury'
+      && ['speaker', 'lament'].includes(story.afterBury)
+      && story.eelStep === 'fragments') {
+    pass(`campaign advances (whale: ${story.afterBury}, eels: ${story.eelStep})`);
+  } else fail('campaign machine stuck: ' + JSON.stringify(story));
+
   // the curious seal: spawn it and let it swim
   const seal = await page.evaluate(async () => {
     window.__waterworld.game._spawnSeal();
@@ -329,12 +377,35 @@ try {
     pass(`screenshot → ${SHOTDIR}/waterworld-play.png`);
   }
 
-  // win path: force the chest through banking, endcard must show
-  await page.evaluate(() => window.__waterworld.win());
-  await page.waitForSelector('#endcard.show', { timeout: 8000 });
-  const won = await page.evaluate(() => window.__waterworld.state().won);
-  if (won) pass('win path: endcard shown, state.won true');
-  else fail('win path broken');
+  // THE FINALE: coalition complete → berg armada → pen → SPARK → the end
+  const finale = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    const c = g.campaign;
+    c.coalition.whales = true;
+    c.coalition.eels = true;
+    c.joinRiver();                       // third seat triggers the finale
+    await new Promise(r => setTimeout(r, 400));
+    const bergs = c.finale.bergs.length;
+    c.finale.bergs.forEach(b => { b.penned = true; });
+    const p = g.pylon.position;
+    window.__waterworld.teleport(p.x - 6, p.y + 8, p.z);
+    await new Promise(r => setTimeout(r, 400));
+    window.__waterworld.ping();
+    await new Promise(r => setTimeout(r, 600));
+    return { bergs, stage: c.stage, won: g.won };
+  });
+  if (finale.bergs === 6 && finale.stage === 'won' && finale.won) {
+    pass(`FINALE: armada of ${finale.bergs} penned and sparked — story won`);
+  } else fail('finale broken: ' + JSON.stringify(finale));
+  await page.waitForSelector('#endcard.show', { timeout: 9000 });
+  const end = await page.evaluate(() => ({
+    title: document.getElementById('end-title').textContent,
+    uiDown: document.body.classList.contains('game-over'),
+    bannerGone: getComputedStyle(document.getElementById('objective')).display === 'none',
+  }));
+  if (/BERGS ARE BEATEN/.test(end.title) && end.uiDown && end.bannerGone) {
+    pass('story endcard up, live UI stood down');
+  } else fail('endcard state wrong: ' + JSON.stringify(end));
 
   if (pageErrors.length) fail('page errors: ' + pageErrors.join(' | '));
   else pass('zero page errors');

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -108,9 +108,12 @@
     text-shadow: 1px 1px 0 #000;
     box-shadow: 0 0 12px rgba(41,173,255,0.45);
     z-index: 21; pointer-events: none;
-    white-space: nowrap; overflow: hidden;
+    overflow: hidden;
   }
-  #obj-text { overflow: hidden; text-overflow: ellipsis; }
+  #obj-text {
+    overflow: hidden; line-height: 1.25;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  }
   #obj-arrow {
     display: inline-block;
     color: #ffec27; font-size: 1.25em;
@@ -231,6 +234,34 @@
   #log-list li.bad { color: #ff004d; }
   #log-list li.warn { color: #ffa300; }
   .log-t { color: #83769c; font-size: 0.85em; margin-right: 0.3em; }
+
+  /* ------- the decision modal (ruby court, story choices) ------- */
+  #choice-panel {
+    position: absolute; left: 50%; bottom: 22%;
+    transform: translateX(-50%);
+    width: min(94%, 26em);
+    display: none; flex-direction: column; gap: 0.5em;
+    background: rgba(10, 20, 50, 0.97);
+    border: 2px solid #ffec27; border-radius: 0.6em;
+    padding: 0.8em;
+    z-index: 48;
+  }
+  #choice-panel.show { display: flex; }
+  #choice-prompt { color: #ffec27; font-size: clamp(13px, 3.2vw, 16px); line-height: 1.4; }
+  #choice-options { display: flex; flex-direction: column; gap: 0.4em; }
+  #choice-options button {
+    font: inherit; font-size: clamp(12px, 3vw, 15px);
+    text-align: left;
+    background: rgba(29,43,83,0.8); color: #fff1e8;
+    border: 1px solid #29adff; border-radius: 0.4em;
+    padding: 0.5em 0.8em; min-height: 44px; cursor: pointer;
+  }
+  #choice-options button:focus-visible { outline: 2px solid #ffec27; outline-offset: 2px; }
+
+  /* when the end screen is up, the live UI stands down */
+  body.game-over #objective, body.game-over #toasts, body.game-over #fact,
+  body.game-over #bank-btn, body.game-over #choice-panel, body.game-over #pad,
+  body.game-over #pad-toggle { display: none !important; }
 
   /* ------- feedback flashes ------- */
   #flash {
@@ -368,6 +399,7 @@
     <span id="cargo">⚓—</span>
     <span id="codex">📖0/16</span>
     <span id="inv">·</span>
+    <span id="seats"></span>
   </div>
   <button id="bank-btn" type="button" aria-label="take the haul to the bell" hidden>🔔<span>BANK</span></button>
 
@@ -387,6 +419,7 @@
       <button id="help-close" type="button" aria-label="close help">✕</button>
     </div>
     <ul id="help-list">
+      <li><strong>THE STORY:</strong> your first banking wakes the bergs. Build the coalition of three — whale ghosts (bones → Steelyard → loudspeaker → sink the candle barge), the eel tribes (parley → find the torn charter), and the river (the East India rubies: spend or return). Then herd the risen bergs to Blight Corner and spark the pylon.</li>
       <li><strong>Brush the water</strong> — set a new course. She follows it, then resumes the hunt.</li>
       <li><strong>Tap the water</strong> — sonar ping: lights up treasure, stuns eels up close, pops mines at a safe distance. Pinged things stay on your 🗺 chart.</li>
       <li><strong>Double-tap</strong> (or double-tap A) — DASH: a burst of speed for a breath of air.</li>
@@ -419,6 +452,11 @@
     <ul id="log-list"></ul>
   </div>
 
+  <div id="choice-panel" role="dialog" aria-label="Decision">
+    <div id="choice-prompt"></div>
+    <div id="choice-options"></div>
+  </div>
+
   <div id="flash" aria-hidden="true"></div>
 
   <div id="toasts"></div>
@@ -432,8 +470,9 @@
   <div id="splash" class="overlay">
     <h2>WATERWORLD</h2>
     <p>— DOCKLANDS DEEP —</p>
-    <p>🫧 A sunny dive into a drowned London dock! Ping for treasure,
-       tickle history out of the mud, and bring it home to the glowing bell.</p>
+    <p>🫧 The fatbergs beneath London are WAKING — and they want the city.
+       Salvage the drowned past, and build a coalition to stop them:
+       the whale ghosts, the divided eel tribes, and the river itself.</p>
     <p>⚓ She sails herself, Captain — <strong>brush the water</strong> to set
        a new course, <strong>tap</strong> to ping the sonar.<br>
        ？ help · 📜 log · IR heat-vision · 🎮 summons a d-pad if you want one</p>


### PR DESCRIPTION
Implements danbri's story brief as a quest machine (`js/quests.js`): sentient fatbergs rise to take the city; build a coalition of three, then win the finale.

- **Whale ghosts:** ancestor bones → burial at the Steelyard stone (true Hanseatic ground under Cannon Street) → loudspeaker (magnet + coil) → the lament → sink the PALE & SONS candle-drone barge with timed depth charges.
- **Eel Federation:** parley with the Amp and Volt elders → recover the torn Eel Pie Charter (why the tribes fell out) → the island was held IN COMMON; the tribes unite.
- **River Folk:** raise the East India strongbox (grapple = hook + rope). Five uncut rubies — spend at the bell (hull/air upgrades) or return to the river; return three for the third seat.
- **Finale:** the armada rises; ghost whales herd to your last sonar ping; pen six bergs in Blight Corner and spark the pylon. Wet wipe → Mayor's lunch. The end.

Same pass ships the reviewer tribe's top fixes: quest-item reachability (+ playtest sweep), spill with a 2.5s pickup lock + strong scatter, cargo cap 8, ping air cost, autopilot never banks, end-screen UI stand-down, input-aware copy + grammar, Escape closes panels, keyboard-operable chips, whale visibility, choice modal.

Playtest at 34 assertions incl. a full finale run; shell e2e and html-validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_