### PR TITLE
Waterworld lore: the bones belong to the ghosts themselves

### DIFF
--- a/magpie/waterworld/README.md
+++ b/magpie/waterworld/README.md
@@ -17,7 +17,8 @@ procedural lo-fi WebAudio, no external assets.
 Your first banking wakes the sentient fatbergs; they mean to take the
 city. Build a coalition of three, then win the finale:
 
-- **Whale ghosts:** gather three ancestor bones → bury them at the
+- **Whale ghosts:** gather the ghosts' three bones (or are the ghosts
+  only a guilty city's imagination?) → bury them at the
   Steelyard stone (Hanseatic ground — Cannon Street Station stands on it,
   which is true) → craft the loudspeaker (magnet + dynamo coil) → sing
   the lament → sink the PALE & SONS candle-drone barge by ping-detonating

--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -1487,7 +1487,7 @@ export class WaterworldGame {
     const syGlow = glowSprite(0xbfd4e8, 7, 0.4);
     syGlow.position.y = 4;
     this.steelyard.add(syGlow);
-    // three ancestor bones, scattered where whales would rest
+    // three bones of the ghosts, scattered where the whales went down
     for (const [x, z] of [[-15, 62], [52, -58], [88, 48]]) {
       const b = makeBone();
       b.position.set(x, floorYAt(x, z) + 0.8, z);
@@ -1725,14 +1725,14 @@ export class WaterworldGame {
   _stepCampaign(dt) {
     const c = this.campaign;
     if (c.stage === 'dormant') return;
-    // ancestor bones: swim close to gather
+    // the ghosts' bones: swim close to gather
     if (c.whale.step === 'bones') {
       for (const b of this.bones) {
         if (!b.taken && b.mesh.position.distanceTo(this.pos) < 3.6) {
           b.taken = true;
           this.scene.remove(b.mesh);
           this.ui.audio?.pickup(30);
-          this.ui.toast(`🦴 ANCESTOR BONE (${this.bones.filter(x => x.taken).length}/3)`, 'good');
+          this.ui.toast(`🦴 A GHOST'S BONE (${this.bones.filter(x => x.taken).length}/3)`, 'good');
         }
       }
       if (this.bones.every(b => b.taken)) {

--- a/magpie/waterworld/js/quests.js
+++ b/magpie/waterworld/js/quests.js
@@ -22,7 +22,7 @@ export const STORY_FACTS = {
   whale_lament: {
     title: 'THE LAMENT',
     icon: '🐋',
-    text: 'London burned whale oil for light and boiled spermaceti for candles. The whales were never mourned. A loudspeaker — magnet and living current — can carry a song sad enough to be heard by the dead.',
+    text: 'London burned whale oil for light and boiled spermaceti for candles. The whales were never mourned. A loudspeaker — magnet and living current — can carry a song sad enough to be heard by the dead. If they can hear. If they are there at all.',
   },
   candle_barge: {
     title: 'PALE & SONS',
@@ -149,7 +149,7 @@ export class Campaign {
     const w = this.whale, e = this.eel, r = this.ruby;
     if (w.step === 'bones') {
       const bone = g.bones.find(b => !b.taken);
-      if (bone) options.push({ icon: '🦴', text: `Whales: gather ancestor bones (${g.bones.filter(b => b.taken).length}/3)`, target: bone.mesh.position });
+      if (bone) options.push({ icon: '🦴', text: `Whales: gather the ghosts' bones (${g.bones.filter(b => b.taken).length}/3)`, target: bone.mesh.position });
     } else if (w.step === 'bury') {
       options.push({ icon: '⚓', text: `Whales: bury the bones at the Steelyard stone (${this.whale.bonesBuried}/3)`, target: g.steelyard.position });
     } else if (w.step === 'speaker') {

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -346,7 +346,8 @@ export function makeSteelyard() {
   return g;
 }
 
-// An ancestor bone: a great rib, half out of the silt.
+// A ghost's bone: a great rib, half out of the silt — if the ghosts
+// are real, these are theirs; if not, the guilt is real enough.
 export function makeBone() {
   const g = new THREE.Group();
   const rib = new THREE.Mesh(new THREE.TorusGeometry(2.2, 0.32, 10, 18, Math.PI * 0.85), mat(0xe8e2d4, { emissive: 0x333026 }));

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -419,7 +419,7 @@
       <button id="help-close" type="button" aria-label="close help">✕</button>
     </div>
     <ul id="help-list">
-      <li><strong>THE STORY:</strong> your first banking wakes the bergs. Build the coalition of three — whale ghosts (bones → Steelyard → loudspeaker → sink the candle barge), the eel tribes (parley → find the torn charter), and the river (the East India rubies: spend or return). Then herd the risen bergs to Blight Corner and spark the pylon.</li>
+      <li><strong>THE STORY:</strong> your first banking wakes the bergs. Build the coalition of three — whale ghosts (their bones → Steelyard → loudspeaker → sink the candle barge), the eel tribes (parley → find the torn charter), and the river (the East India rubies: spend or return). Then herd the risen bergs to Blight Corner and spark the pylon.</li>
       <li><strong>Brush the water</strong> — set a new course. She follows it, then resumes the hunt.</li>
       <li><strong>Tap the water</strong> — sonar ping: lights up treasure, stuns eels up close, pops mines at a safe distance. Pinged things stay on your 🗺 chart.</li>
       <li><strong>Double-tap</strong> (or double-tap A) — DASH: a burst of speed for a breath of air.</li>


### PR DESCRIPTION
Lore correction from the owner: not "ancestor bones" — the bones of the ghosts themselves. The lament codex card now also allows the second reading: the ghosts may be figments of a guilty city's imagination. The song is sung either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_