### PR TITLE
Waterworld: smooth drag steering, hold-to-brake, Coalition board + lore whispers

### DIFF
--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -410,14 +410,14 @@ export class WaterworldGame {
     for (let i = 0; i < 4; i++) this._bubbleT = -1;   // a burst in the wake
   }
 
-  // A brush across the water is a course order from the captain: bank
-  // onto the swiped heading and hold it a while, then resume the hunt.
-  // dxN/dyN are normalised screen deltas (right and down positive).
+  // A brush across the water is a course order — one gesture, held a
+  // while. Kept for the test harness and coarse flicks; live dragging
+  // goes through steerDrag below, which feels like holding the nose.
   brush(dxN, dyN) {
-    const yaw = this.yaw - dxN * 3.4;
-    const pitch = Math.max(-0.8, Math.min(0.8, this.pitch - dyN * 2.2));
-    this._explore = { yaw, pitch, until: this.elapsed + 8 };
-    this.manualUntil = 0;          // the helm answers the brush at once
+    const yaw = this.yaw - dxN * 2.2;
+    const pitch = Math.max(-0.75, Math.min(0.75, this.pitch - dyN * 1.6));
+    this._explore = { yaw, pitch, until: this.elapsed + 5 };
+    this.manualUntil = 0;
     this.autopilot = true;
     this.ui.audio?.swish();
     if (this._brushCount < 3) {
@@ -427,6 +427,33 @@ export class WaterworldGame {
     this.ui.announce('New course set.');
   }
 
+  // INCREMENTAL drag steering: each pointer-move nudges the commanded
+  // course by the step since the last event. Dragging feels like
+  // holding the sub's nose, not like throwing orders — the fix for
+  // "lurchy". Down = dive, up = climb, and small drags do small things.
+  steerDrag(dxStep, dyStep) {
+    const live = this._explore && this.elapsed < this._explore.until;
+    const yaw = (live ? this._explore.yaw : this.yaw) - dxStep * 5.0;
+    const basePitch = live ? this._explore.pitch : this.pitch;
+    const pitch = Math.max(-0.75, Math.min(0.75, basePitch - dyStep * 3.4));
+    this._explore = { yaw, pitch, until: this.elapsed + 4 };
+    this.manualUntil = 0;
+    this.autopilot = true;
+  }
+
+  // Hold station: press and hold without moving. She kills way and
+  // hangs in the water until you let go. THE missing "slow down".
+  setBrake(on) {
+    if (on && !this._brake && !this.over) {
+      this.ui.announce('Holding station.');
+      if (!this._brakeShown) {
+        this._brakeShown = true;
+        this.ui.toast('⚓ Holding station — release to sail on', 'hint');
+      }
+    }
+    this._brake = on;
+  }
+
   // ------------------------------------------------------------- the helm
   // Sails toward the objective (or a brushed course), keeps off the
   // floor, the surface, the walls and the mines, pings as she hunts,
@@ -434,8 +461,14 @@ export class WaterworldGame {
   _helm(dt) {
     this._helmActive = true;
     // re-engaging after manual or a brush: start the filter from where
-    // the boat actually is, or the first frame swings from stale state
-    if (!this._helmWasActive) { this._smYaw = this.yaw; this._smPitch = this.pitch; }
+    // the boat actually is, or the first frame swings from stale state —
+    // and EASE the turn rate back in, so the takeover never yanks
+    if (!this._helmWasActive) {
+      this._smYaw = this.yaw;
+      this._smPitch = this.pitch;
+      this._helmEase = 0;
+    }
+    this._helmEase = Math.min(1, (this._helmEase ?? 1) + dt / 1.3);
     let desYaw, desPitch;
     const exploring = this._explore && this.elapsed < this._explore.until;
     const obj = exploring ? null : this._objective();
@@ -509,10 +542,12 @@ export class WaterworldGame {
     let dYaw = this._smYaw - this.yaw;
     while (dYaw > Math.PI) dYaw -= Math.PI * 2;
     while (dYaw < -Math.PI) dYaw += Math.PI * 2;
-    const turn = Math.max(-1.5 * dt, Math.min(1.5 * dt, dYaw));
+    const rate = 1.5 * this._helmEase;
+    const turn = Math.max(-rate * dt, Math.min(rate * dt, dYaw));
     this.yaw += turn;
-    this._helmTurn = Math.max(-0.5, Math.min(0.5, dYaw));
-    this.pitch += Math.max(-1.1 * dt, Math.min(1.1 * dt, this._smPitch - this.pitch));
+    this._helmTurn = Math.max(-0.5, Math.min(0.5, dYaw)) * this._helmEase;
+    this.pitch += Math.max(-1.1 * this._helmEase * dt,
+      Math.min(1.1 * this._helmEase * dt, this._smPitch - this.pitch));
     this._autoThrust = exploring || dist > 7;
     // she pings as she hunts — the sonar chimes are half the mood
     if (this._pingCooldown <= 0 && this.elapsed - this._lastAutoPing > 7 && !exploring) {
@@ -844,10 +879,10 @@ export class WaterworldGame {
       Math.cos(this.pitch) * Math.cos(this.yaw),
       Math.sin(this.pitch),
       -Math.cos(this.pitch) * Math.sin(this.yaw));
-    const thrusting = k.a || this._autoThrust;
-    const thrust = thrusting ? 34 : 9;   // brisker: ploddy is literal speed
+    const thrusting = (k.a || this._autoThrust) && !this._brake;
+    const thrust = this._brake ? 0 : (thrusting ? 34 : 9);
     this.vel.addScaledVector(fwd, thrust * dt);
-    this.vel.multiplyScalar(Math.pow(0.14, dt));            // water drag
+    this.vel.multiplyScalar(Math.pow(this._brake ? 0.02 : 0.14, dt));  // drag; brake kills way fast
     this.vel.y += Math.sin(this.elapsed * 0.8) * 0.06 * dt; // gentle swell
     currentAt(this.pos, this.elapsed, _cur);                 // the gyre tugs
     this.vel.addScaledVector(_cur, 0.35 * this.tide * dt);
@@ -1536,6 +1571,63 @@ export class WaterworldGame {
     this.chest.hidden = false;
     this.chest.mesh.visible = true;
     this.chest._known = true;
+
+    // lore whispers: swim near a story site and the world introduces
+    // itself — discovery for explorers, no help page required
+    this._whispers = [
+      { at: () => this.steelyard.position, r: 22, done: false,
+        text: '⚓ An old boundary stone below… something gathers around it.' },
+      { at: () => this.elders[0].mesh.position, r: 20, done: false,
+        text: '⚡ A crowned eel watches you. It says nothing — yet.' },
+      { at: () => this.elders[1].mesh.position, r: 20, done: false,
+        text: '⚡ Another crowned eel, coiled and cold. The two tribes do not speak.' },
+      { at: () => this.chest.mesh.position, r: 20, done: false,
+        text: '💎 A strongbox in the silt, branded EIC. Far too heavy to lift bare.' },
+      { at: () => this.candleBarge?.position, r: 26, done: false,
+        text: '🕯️ A drone barge hums overhead: PALE & SONS, EST. 1712.' },
+    ];
+  }
+
+  // The Coalition board — the story, readable at any moment. Rendered
+  // by main.js when the player taps the goal banner.
+  boardState() {
+    const c = this.campaign;
+    if (c.stage === 'dormant') {
+      return { title: 'THE DOCK IS QUIET', seats: '', rows: [
+        { icon: '🫧', text: 'Salvage the drowned past. Land a haul at the bell — and see what wakes.' },
+      ] };
+    }
+    const w = {
+      bones: `gather the ghosts' bones (${this.bones.filter(b => b.taken).length}/3)`,
+      bury: 'bury the bones at the Steelyard stone',
+      speaker: 'craft the loudspeaker — magnet + dynamo coil',
+      lament: 'sing the lament at the Steelyard (B there)',
+      barge: `sink the PALE & SONS barge — ping the charges under it (${c.whale.bargeHits}/2)`,
+      joined: 'JOINED ✓',
+    }[c.whale.step];
+    const e = {
+      parley: 'parley with both crowned elders (a gentle ping, up close)',
+      fragments: `find the torn Eel Pie Charter (${c.eel.fragments}/3)`,
+      restore: 'return the charter to both elders',
+      joined: 'JOINED ✓',
+    }[c.eel.step];
+    const r = {
+      chest: this.tools.has('grapple')
+        ? 'raise the East India strongbox'
+        : 'craft the grapple (hook + rope), then raise the strongbox',
+      decide: `rubies: ${c.ruby.held} held · ${c.ruby.returned}/3 returned · decide at the bell`,
+      joined: 'JOINED ✓',
+    }[c.ruby.step];
+    const rows = [
+      { icon: '🐋', text: `Whale ghosts — ${w}` },
+      { icon: '⚡', text: `Eel tribes — ${e}` },
+      { icon: '🦭', text: `The river — ${r}` },
+    ];
+    if (c.stage === 'finale') {
+      rows.push({ icon: '🟤', text: `THE RISING — herd the bergs with your sonar: ${c.finale.penned}/${c.finale.bergs.length} penned in Blight Corner` });
+    }
+    if (c.stage === 'won') rows.push({ icon: '🎆', text: 'The bergs are beaten. The end.' });
+    return { title: 'THE COALITION', seats: `${c.seats()}/3 seats`, rows };
   }
 
   _collectStrongbox(s) {
@@ -1725,6 +1817,16 @@ export class WaterworldGame {
   _stepCampaign(dt) {
     const c = this.campaign;
     if (c.stage === 'dormant') return;
+    // whispers: the world introduces its own story sites
+    for (const wh of this._whispers || []) {
+      if (wh.done) continue;
+      const p = wh.at();
+      if (p && p.distanceTo(this.pos) < wh.r) {
+        wh.done = true;
+        this.ui.toast(wh.text, 'hint');
+        this.ui.announce(wh.text.replace(/^[^ ]+ /, ''));
+      }
+    }
     // the ghosts' bones: swim close to gather
     if (c.whale.step === 'bones') {
       for (const b of this.bones) {

--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -107,7 +107,7 @@ function flash(cls) {
 
 function announce(text) { window.__mgA11y?.announce?.(text); }
 
-let lastHull, lastScore, lastObjText;
+let lastHull, lastScore, lastObjText, lastDepth;
 function hud(s) {
   // the guide banner: what to do, which way, how far
   $('objective').style.display = s.obj && !s.over ? '' : 'none';
@@ -130,7 +130,10 @@ function hud(s) {
   $('air-fill').classList.toggle('low', s.air < 0.25);
   $('hull').textContent = '▮'.repeat(Math.max(0, s.hull)) + '▯'.repeat(Math.max(0, s.hullMax - s.hull));
   $('score').textContent = String(s.score).padStart(5, '0');
-  $('depth').textContent = s.depth + 'm';
+  // depth with a live climb/dive marker — swipe feedback you can read
+  const dTrend = lastDepth === undefined ? '' : s.depth < lastDepth - 0.4 ? '▲' : s.depth > lastDepth + 0.4 ? '▼' : '';
+  lastDepth = s.depth;
+  $('depth').textContent = s.depth + 'm' + dTrend;
   $('cargo').textContent = s.cargo
     ? `⚓${s.cargo} ×${s.haulMult.toFixed(2)}${s.combo >= 2 ? ` 🔥${s.combo}` : ''}`
     : '⚓—';
@@ -228,7 +231,7 @@ function setAction(action, down, fromRepeat) {
     releaseTimers[action] = setTimeout(() => game.setKey(action, false), fromRepeat ? 350 : 900);
   } else clearTimeout(releaseTimers[action]);
 }
-const PANELS = ['help-panel', 'log-panel', 'map-panel', 'choice-panel'];
+const PANELS = ['help-panel', 'log-panel', 'map-panel', 'choice-panel', 'board-panel'];
 function closeTopPanel() {
   for (const id of PANELS) {
     const p = $(id);
@@ -257,37 +260,65 @@ document.addEventListener('keyup', (e) => {
 // canvas is ours even when the host owns the pad.
 {
   const sceneEl = $('scene');
+  const dragArrow = $('drag-arrow');
   let gesture = null;
+  let brakeTimer = null;
   sceneEl.addEventListener('pointerdown', (e) => {
     if (!started) return;
-    gesture = { x0: e.clientX, y0: e.clientY, t0: performance.now(), moved: false, last: 0 };
+    gesture = { x0: e.clientX, y0: e.clientY, lastX: e.clientX, lastY: e.clientY,
+      t0: performance.now(), moved: false, braking: false };
+    // press and HOLD without moving = hold station (the brake)
+    brakeTimer = setTimeout(() => {
+      if (gesture && !gesture.moved && game) {
+        gesture.braking = true;
+        audio.ensure();
+        game.setBrake(true);
+      }
+    }, 380);
   });
   sceneEl.addEventListener('pointermove', (e) => {
     if (!gesture || !game) return;
-    const dx = e.clientX - gesture.x0, dy = e.clientY - gesture.y0;
-    if (Math.hypot(dx, dy) > 24) {
+    const total = Math.hypot(e.clientX - gesture.x0, e.clientY - gesture.y0);
+    if (!gesture.moved && total > 14) {
       gesture.moved = true;
-      const now = performance.now();
-      if (now - gesture.last > 160) {
-        gesture.last = now;
-        audio.ensure();
-        game.brush(dx / window.innerWidth, dy / window.innerHeight);
-      }
+      clearTimeout(brakeTimer);
+      if (gesture.braking) { gesture.braking = false; game.setBrake(false); }
+      audio.ensure();
+    }
+    if (gesture.moved) {
+      // incremental: each move nudges the nose by the step since last
+      game.steerDrag(
+        (e.clientX - gesture.lastX) / window.innerWidth,
+        (e.clientY - gesture.lastY) / window.innerHeight);
+      gesture.lastX = e.clientX;
+      gesture.lastY = e.clientY;
+      // show the command: an arrow from where the drag began
+      const dx = e.clientX - gesture.x0, dy = e.clientY - gesture.y0;
+      dragArrow.style.display = 'block';
+      dragArrow.style.left = gesture.x0 + 'px';
+      dragArrow.style.top = gesture.y0 + 'px';
+      dragArrow.style.transform =
+        `translate(-50%,-50%) rotate(${Math.atan2(dy, dx) * 180 / Math.PI}deg)`;
+      dragArrow.style.width = Math.min(120, Math.hypot(dx, dy)) + 'px';
     }
   });
   let lastTapAt = 0;
-  const endGesture = (e) => {
-    if (gesture && game && !gesture.moved && performance.now() - gesture.t0 < 400) {
+  const endGesture = () => {
+    clearTimeout(brakeTimer);
+    dragArrow.style.display = 'none';
+    if (!gesture) return;
+    if (gesture.braking && game) game.setBrake(false);
+    else if (game && !gesture.moved && performance.now() - gesture.t0 < 380) {
       audio.ensure();
       const now = performance.now();
-      if (now - lastTapAt < 320) game.dash();   // double-tap = DASH
+      if (now - lastTapAt < 300) game.dash();   // double-tap = DASH
       else game._doPing();                      // a tap is a ping
       lastTapAt = now;
     }
     gesture = null;
   };
   sceneEl.addEventListener('pointerup', endGesture);
-  sceneEl.addEventListener('pointercancel', () => { gesture = null; });
+  sceneEl.addEventListener('pointercancel', endGesture);
 }
 
 // Own touch pad (standalone only — the shell provides one and tells us).
@@ -341,7 +372,7 @@ function startGame() {
   game.start();
   announce('Dive started. Brush the water to steer, tap to ping the sonar.');
   setTimeout(() => {
-    if (game && !game.over) hint('Brush to steer · tap ？ for help');
+    if (game && !game.over) hint('Drag to steer · hold still to brake · tap ？ for help');
   }, 2500);
 }
 
@@ -378,7 +409,7 @@ $('end-again').addEventListener('click', () => location.reload());
 window.addEventListener('resize', () => game?.resize());
 
 // keyboard operability: Enter/Space on any chip fires its pointer handler
-for (const el of document.querySelectorAll('.chip, #bank-btn, #pad-toggle')) {
+for (const el of document.querySelectorAll('.chip, #bank-btn, #pad-toggle, #objective')) {
   el.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -529,6 +560,39 @@ $('map-close').addEventListener('click', () => {
   $('map-panel').classList.remove('show');
   $('map-btn').setAttribute('aria-expanded', 'false');
   if (mapTimer) { clearInterval(mapTimer); mapTimer = null; }
+});
+
+// The Coalition board: tap the goal banner and the story lays itself
+// out — every arc, its current step, the seats filled. Discovery
+// without a walkthrough.
+function renderBoard() {
+  if (!game) return;
+  const b = game.boardState();
+  $('board-title').textContent = `🤝 ${b.title}${b.seats ? ' — ' + b.seats : ''}`;
+  const list = $('board-list');
+  list.replaceChildren();
+  for (const r of b.rows) {
+    const li = document.createElement('li');
+    li.textContent = `${r.icon} ${r.text}`;
+    if (/JOINED|The end/.test(r.text)) li.className = 'done';
+    list.appendChild(li);
+  }
+}
+let boardTimer = null;
+$('objective').addEventListener('pointerdown', (e) => {
+  e.stopPropagation();
+  const panel = $('board-panel');
+  const opening = !panel.classList.contains('show');
+  panel.classList.toggle('show', opening);
+  if (opening) {
+    renderBoard();
+    boardTimer = setInterval(renderBoard, 500);
+    announce('Coalition board open.');
+  } else if (boardTimer) { clearInterval(boardTimer); boardTimer = null; }
+});
+$('board-close').addEventListener('click', () => {
+  $('board-panel').classList.remove('show');
+  if (boardTimer) { clearInterval(boardTimer); boardTimer = null; }
 });
 
 // canvas a11y: name it and keep a live description of the dive

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -68,6 +68,41 @@ try {
   if (brushed) pass('brush gesture set an explore course');
   else fail('brush gesture ignored');
 
+  // drag steering: incremental nudges set a live course
+  const dragged = await page.evaluate(() => {
+    const g = window.__waterworld.game;
+    const y0 = g._explore ? g._explore.yaw : g.yaw;
+    g.steerDrag(0.15, 0.05);
+    g.steerDrag(0.15, 0.05);
+    return { moved: Math.abs(g._explore.yaw - y0) > 0.5, live: g._explore.until > g.elapsed };
+  });
+  if (dragged.moved && dragged.live) pass('drag steering nudges the course incrementally');
+  else fail('steerDrag broken: ' + JSON.stringify(dragged));
+
+  // hold station: the brake kills way
+  const braked = await page.evaluate(async () => {
+    const g = window.__waterworld.game;
+    g.vel.set(10, 0, 0);
+    g.setBrake(true);
+    await new Promise(r => setTimeout(r, 700));
+    const v = g.vel.length();
+    g.setBrake(false);
+    return v;
+  });
+  if (braked < 4) pass(`brake holds station (speed 10 → ${braked.toFixed(1)})`);
+  else fail(`brake weak: speed still ${braked.toFixed(1)}`);
+
+  // the coalition board opens from the goal banner
+  await page.evaluate(() => document.getElementById('objective')
+    .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true })));
+  const board = await page.evaluate(() => ({
+    shown: document.getElementById('board-panel').classList.contains('show'),
+    rows: document.querySelectorAll('#board-list li').length,
+  }));
+  if (board.shown && board.rows >= 1) pass(`coalition board opens from the banner (${board.rows} rows)`);
+  else fail('board broken: ' + JSON.stringify(board));
+  await page.click('#board-close');
+
   // the detailed boat: animated parts must exist
   const subParts = await page.evaluate(() => {
     const ud = window.__waterworld.game.sub.userData;

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -95,6 +95,7 @@
 
   /* ------- objective banner: always on, always pointing ------- */
   #objective {
+    font: inherit; text-align: left;
     position: absolute; left: 50%; top: 4.9em;
     transform: translateX(-50%);
     display: flex; align-items: center; gap: 0.5em;
@@ -107,9 +108,10 @@
     color: #fff1e8;
     text-shadow: 1px 1px 0 #000;
     box-shadow: 0 0 12px rgba(41,173,255,0.45);
-    z-index: 21; pointer-events: none;
+    z-index: 21; pointer-events: auto; cursor: pointer;
     overflow: hidden;
   }
+  #objective:focus-visible { outline: 2px solid #ffec27; outline-offset: 2px; }
   #obj-text {
     overflow: hidden; line-height: 1.25;
     display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
@@ -262,6 +264,39 @@
   body.game-over #objective, body.game-over #toasts, body.game-over #fact,
   body.game-over #bank-btn, body.game-over #choice-panel, body.game-over #pad,
   body.game-over #pad-toggle { display: none !important; }
+
+  /* the coalition board: the story, laid out */
+  #board-panel {
+    position: absolute; inset: auto 0.6em 22% 0.6em;
+    display: none; flex-direction: column;
+    background: rgba(8, 18, 45, 0.97);
+    border: 2px solid #ffec27;
+    z-index: 46;
+  }
+  #board-panel.show { display: flex; }
+  #board-list {
+    list-style: none; margin: 0;
+    padding: 0.6em 0.9em;
+    font-size: clamp(12px, 3vw, 15px); line-height: 1.6;
+    color: #dfe8f2;
+  }
+  #board-list li { margin-bottom: 0.4em; }
+  #board-list li.done { color: #00e436; }
+
+  /* the drag arrow: your steering command, made visible */
+  #drag-arrow {
+    position: absolute; display: none;
+    height: 4px; width: 60px;
+    background: linear-gradient(90deg, rgba(255,236,39,0.15), #ffec27);
+    border-radius: 2px;
+    transform-origin: 0 50%;
+    box-shadow: 0 0 10px rgba(255,236,39,0.7);
+    pointer-events: none; z-index: 27;
+  }
+  #drag-arrow::after {
+    content: ''; position: absolute; right: -7px; top: -5px;
+    border: 7px solid transparent; border-left-color: #ffec27;
+  }
 
   /* ------- feedback flashes ------- */
   #flash {
@@ -420,8 +455,10 @@
     </div>
     <ul id="help-list">
       <li><strong>THE STORY:</strong> your first banking wakes the bergs. Build the coalition of three — whale ghosts (their bones → Steelyard → loudspeaker → sink the candle barge), the eel tribes (parley → find the torn charter), and the river (the East India rubies: spend or return). Then herd the risen bergs to Blight Corner and spark the pylon.</li>
-      <li><strong>Brush the water</strong> — set a new course. She follows it, then resumes the hunt.</li>
+      <li><strong>Drag the water</strong> — you are holding her nose: drag right to turn right, drag DOWN to dive, UP to climb. She holds the course, then resumes the hunt.</li>
       <li><strong>Tap the water</strong> — sonar ping: lights up treasure, stuns eels up close, pops mines at a safe distance. Pinged things stay on your 🗺 chart.</li>
+      <li><strong>Press and HOLD still</strong> — hold station (the brake). Release to sail on.</li>
+      <li><strong>Tap the goal banner</strong> — the Coalition board: every task, its progress, the seats filled.</li>
       <li><strong>Double-tap</strong> (or double-tap A) — DASH: a burst of speed for a breath of air.</li>
       <li><strong>🔔 BANK</strong> — the haul multiplier grows with every item you carry (×3 tops!) — but a hit knocks half your cargo loose. Banking is YOUR call.</li>
       <li><strong>Grab fast for COMBOS</strong> — quick successive finds are worth more.</li>
@@ -438,11 +475,22 @@
     </ul>
   </div>
 
-  <div id="objective" aria-hidden="true">
-    <span id="obj-arrow">➤</span>
+  <button id="objective" type="button"
+       aria-label="current goal — tap for the coalition board">
+    <span id="obj-arrow" aria-hidden="true">➤</span>
     <span id="obj-text">✨ Dive in!</span>
-    <span id="obj-dist"></span>
+    <span id="obj-dist" aria-hidden="true"></span>
+  </button>
+
+  <div id="board-panel" role="dialog" aria-label="Coalition board">
+    <div class="panel-head">
+      <span id="board-title">🤝 THE COALITION</span>
+      <button id="board-close" type="button" aria-label="close board">✕</button>
+    </div>
+    <ul id="board-list"></ul>
   </div>
+
+  <div id="drag-arrow" aria-hidden="true"></div>
 
   <div id="log-panel" role="dialog" aria-label="Ship's log">
     <div class="panel-head">


### PR DESCRIPTION
Controls: live dragging nudges the course incrementally (drag-the-nose, not swipe impulses); a visible drag arrow shows the command; press-and-hold = hold station (the brake); the autopilot eases back in instead of yanking; depth gains a ▲/▼ climb/dive marker. Drag down = dive, up = climb, documented in help.

Discovery: the goal banner is now a button — tapping it opens the **Coalition board** (every arc, current step, progress, seats filled), so players of any strength can see the campaign without the help walkthrough. Lore whispers introduce story sites in-world when you swim near them.

Playtest at 37 assertions; shell e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_