### PR TITLE
Waterworld: facts become one slim line — no more panels over the action

### DIFF
--- a/magpie/waterworld/js/main.js
+++ b/magpie/waterworld/js/main.js
@@ -56,43 +56,49 @@ const toastQueue = [];
 let toastActive = false;
 function _nextToast() {
   if (toastActive || !toastQueue.length) return;
-  const { text, cls } = toastQueue.shift();
-  if ($('fact').classList.contains('show') && cls !== 'bad' && cls !== 'gold') {
-    _nextToast();                       // routine news yields to the fact
-    return;
-  }
+  const { text, cls, onTap } = toastQueue.shift();
   toastActive = true;
   const box = $('toasts');
   const t = document.createElement('div');
   t.className = 'toast ' + cls;
   t.textContent = text;
+  if (onTap) {
+    t.classList.add('tappable');
+    t.addEventListener('pointerdown', (e) => { e.stopPropagation(); onTap(); });
+  }
   box.appendChild(t);
-  const life = (cls === 'bad' || cls === 'gold') ? 4200 : cls === 'hint' ? 4800 : 3200;
+  const life = cls.includes('factoid') ? 6000
+    : (cls === 'bad' || cls === 'gold') ? 4200 : cls === 'hint' ? 4800 : 3200;
   setTimeout(() => {
     t.classList.add('out');
     setTimeout(() => { t.remove(); toastActive = false; _nextToast(); }, 450);
   }, life);
 }
-function toast(text, cls = '') {
+function toast(text, cls = '', onTap = null) {
   addLog(text, cls);
-  toastQueue.push({ text, cls });
+  toastQueue.push({ text, cls, onTap });
   while (toastQueue.length > 3) toastQueue.shift();
   _nextToast();
 }
 
-let factTimer = null;
+// A fact is ONE slim gold line now — never a panel over the action. The
+// full text lives in the ship's log (tap the line to open it) and is
+// read in full by the announcer.
+function openLogPanel() {
+  const panel = $('log-panel');
+  if (!panel.classList.contains('show')) {
+    renderLog();
+    panel.classList.add('show');
+    $('log-btn').classList.remove('unread');
+    $('log-btn').setAttribute('aria-expanded', 'true');
+  }
+}
 function fact(title, text, icon) {
-  const f = $('fact');
-  $('fact-icon').textContent = icon || '📜';
-  $('fact-title').textContent = title;
-  $('fact-text').textContent = text;
-  f.classList.add('show');
-  $('toasts').replaceChildren();        // the fact is THE message right now
-  toastActive = false;
-  if (factTimer) clearTimeout(factTimer);
-  // long enough to read, tappable away, and always kept in the log
-  factTimer = setTimeout(() => { f.classList.remove('show'); _nextToast(); }, 9000);
   addLog(`${icon || '📜'} ${title} — ${text}`, 'gold');
+  toastQueue.unshift({ text: `${icon || '📜'} ${title} — tap for the tale 📜`,
+    cls: 'gold factoid', onTap: openLogPanel });
+  while (toastQueue.length > 3) toastQueue.pop();
+  _nextToast();
   announce(`${title}. ${text}`);
 }
 
@@ -387,7 +393,6 @@ $('auto-btn').addEventListener('pointerdown', (e) => {
     : '🕹 Manual helm — you have the boat, Captain', 'hint');
   announce(game.autopilot ? 'Autopilot on' : 'Manual helm');
 });
-$('fact').addEventListener('pointerdown', () => $('fact').classList.remove('show'));
 $('log-btn').addEventListener('pointerdown', (e) => {
   e.stopPropagation();
   const panel = $('log-panel');

--- a/magpie/waterworld/waterworld.html
+++ b/magpie/waterworld/waterworld.html
@@ -104,7 +104,7 @@
     background: rgba(10, 25, 60, 0.85);
     border: 2px solid #29adff;
     border-radius: 2em;
-    font-size: clamp(13px, 3.4vmin, 18px);
+    font-size: clamp(12px, 3vw, 15px);
     color: #fff1e8;
     text-shadow: 1px 1px 0 #000;
     box-shadow: 0 0 12px rgba(41,173,255,0.45);
@@ -148,6 +148,8 @@
   .toast.gold { border-color: #ffec27; color: #ffec27; }
   .toast.hint { border-color: #83769c; color: #c2c3c7; font-style: italic; }
   .toast.out { opacity: 0; }
+  .toast.tappable { pointer-events: auto; cursor: pointer; }
+  .toast.factoid { border-width: 2px; font-weight: 600; }
 
   /* ------- ship's log ------- */
   #log-btn { color: #29adff; border-color: #29adff; }
@@ -261,7 +263,7 @@
   #choice-options button:focus-visible { outline: 2px solid #ffec27; outline-offset: 2px; }
 
   /* when the end screen is up, the live UI stands down */
-  body.game-over #objective, body.game-over #toasts, body.game-over #fact,
+  body.game-over #objective, body.game-over #toasts,
   body.game-over #bank-btn, body.game-over #choice-panel, body.game-over #pad,
   body.game-over #pad-toggle { display: none !important; }
 
@@ -314,21 +316,6 @@
     100% { opacity: 0; }
   }
 
-  #fact {
-    position: absolute; left: 50%; bottom: 18%;
-    transform: translate(-50%, 20px);
-    width: min(92%, 30em);
-    background: rgba(29,43,83,0.92);
-    border: 2px solid #ffec27;
-    padding: 0.6em 0.9em;
-    z-index: 23;
-    opacity: 0; pointer-events: none;
-    transition: opacity 0.4s, transform 0.4s;
-  }
-  #fact.show { opacity: 1; transform: translate(-50%, 0); }
-  #fact-title { color: #ffec27; font-size: clamp(12px, 2.6vmin, 16px); letter-spacing: 0.1em; }
-  #fact-text { color: #fff1e8; font-size: clamp(11px, 2.4vmin, 15px); margin-top: 0.3em; line-height: 1.35; }
-  #fact-icon { float: right; font-size: 1.6em; margin-left: 0.4em; }
 
   /* ------- overlays ------- */
   .overlay {
@@ -508,12 +495,6 @@
   <div id="flash" aria-hidden="true"></div>
 
   <div id="toasts"></div>
-
-  <div id="fact" role="note">
-    <span id="fact-icon">📜</span>
-    <div id="fact-title"></div>
-    <div id="fact-text"></div>
-  </div>
 
   <div id="splash" class="overlay">
     <h2>WATERWORLD</h2>


### PR DESCRIPTION
Field screenshot showed a shark encounter hidden behind the THAMES SHARKS text panel. Fact panels are abolished: a fact is now one slim tappable gold line in the single-toast stream (tap → full text in the ship's log; the aria announcer still reads the whole passage). The goal banner type shrinks so its verb stops truncating at 390px. Interactive decisions (ruby court) remain panels — those are the action.

Playtest and shell e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_