### PR TITLE
Waterworld: material pass — PBR, environment light, grunge textures, AO

### DIFF
--- a/magpie/waterworld/js/game.js
+++ b/magpie/waterworld/js/game.js
@@ -9,7 +9,7 @@ import {
   P8, mat, buildDock, makeSub, makeEelHead, makeEelSegment, makeFatberg,
   makeMine, makeSalvageMesh, makeQuestMesh, makeParticleCloud,
   makeGhostWhale, makeSeal, makeDuck, BOUNDS, SHELF_Y, DEEP_Y, floorYAt, tint,
-  softDot,
+  softDot, makeEnvTexture,
 } from './world.js';
 import { UnderwaterFX, glowSprite, currentAt } from './fx.js';
 import { Composite } from './post.js';
@@ -135,6 +135,11 @@ export class WaterworldGame {
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(P8.navy);
     this.scene.fog = new THREE.FogExp2(P8.navy, 0.02);
+    // image-based light: the water column itself lights every Standard
+    // material — fresnel sheen on wet surfaces, glints on metal
+    this._envTex = makeEnvTexture();
+    this.scene.environment = this._envTex;
+    this.scene.environmentIntensity = 0.55;
     this.camera = new THREE.PerspectiveCamera(70, 16 / 9, 0.1, 400);
 
     // light through water: a friendly bright blue, dimming with depth
@@ -611,6 +616,7 @@ export class WaterworldGame {
     this.ir = !this.ir;
     this.fx.setIR(this.ir);
     if (this.ir) {
+      this.scene.environment = null;       // heat does not reflect
       this._irApply(this.scene);
       this.whale.material.color.set(0x3366ff);
       this.ui.toast('▣ THERMAL SIGHT', 'warn');
@@ -622,6 +628,7 @@ export class WaterworldGame {
       }
       this.ui.announce('Thermal view on. Warm things glow; the water goes dark.');
     } else {
+      this.scene.environment = this._envTex;
       this._irRestore(this.scene);
       this.whale.material.color.set(0xc8f0ff);
       this.ui.toast('▢ THERMAL OFF', 'hint');

--- a/magpie/waterworld/js/post.js
+++ b/magpie/waterworld/js/post.js
@@ -49,6 +49,23 @@ void main() {
     col.r *= 1.0 - d * 0.2;
   }
 
+  // -- crease shading: a neighbour meaningfully nearer than us occludes
+  //    us (cheap screen-space AO — grounds objects, shades corners).
+  //    Taps with a huge relative gap are a silhouette edge, not a
+  //    crease, and are rejected to avoid dark halos in the fog.
+  if (uHasDepth > 0.5) {
+    float c = linDepth(vUv);
+    float occ = 0.0;
+    vec2 px = 1.0 / uRes;
+    for (int i = 0; i < AO_TAPS; i++) {
+      float a = 6.2832 * float(i) / float(AO_TAPS);
+      vec2 o = vec2(cos(a), sin(a)) * px * (3.0 + 3.0 * float(i - (i / 2) * 2));
+      float rel = (c - linDepth(vUv + o)) / max(c, 1e-4);
+      if (rel > 0.004 && rel < 0.3) occ += min(rel * 10.0, 0.5);
+    }
+    col *= 1.0 - min(occ / float(AO_TAPS), 0.45);
+  }
+
   // -- crepuscular rays: march toward the sun, gather what glows
   if (uSunVis > 0.001 && uIR < 0.5) {
     vec2 stp = (uSun - vUv) / float(RAY_SAMPLES);
@@ -105,7 +122,7 @@ export class Composite {
     }
 
     this.mat = new THREE.ShaderMaterial({
-      defines: { RAY_SAMPLES: this.lite ? 10 : 22 },
+      defines: { RAY_SAMPLES: this.lite ? 10 : 22, AO_TAPS: this.lite ? 4 : 8 },
       uniforms: {
         tScene: { value: this.rt.texture },
         tDepth: { value: this.rt.depthTexture || this.rt.texture },
@@ -147,6 +164,11 @@ export class Composite {
 
   // sunDir: normalized direction TOWARD the sun in world space
   render(time, sunDir, { deep = 0, ir = false, rayAmt = 1 } = {}) {
+    if (!this.enabled) {                 // harness escape hatch: raw render
+      this.renderer.setRenderTarget(null);
+      this.renderer.render(this.scene, this.camera);
+      return;
+    }
     const u = this.mat.uniforms;
     u.uTime.value = time;
     u.uDeep.value = deep;

--- a/magpie/waterworld/js/world.js
+++ b/magpie/waterworld/js/world.js
@@ -1,8 +1,8 @@
-// Waterworld — the drowned dock. ART DIRECTION v2 (the picoCAD/blocky
-// constraints are officially retired): smooth-shaded organic forms,
-// full-resolution rendering, soft round particles, bioluminescent
-// accents. All geometry is still generated — no asset files — but
-// nothing is crunched, snapped or flat-shaded any more.
+// Waterworld — the drowned dock. ART DIRECTION v3: v2 retired the
+// picoCAD/blocky constraints; v3 retires the flat-Lambert "GL demo"
+// look. Every solid surface is PBR (MeshStandardMaterial) lit by a
+// procedural environment map, with generated grunge/bump textures on
+// the large surfaces. All assets are still code — no image files.
 
 import * as THREE from '../../../trees/vendor/three.module.min.js';
 
@@ -14,13 +14,156 @@ export const P8 = {
   blue: 0x29adff, mauve: 0x83769c, pink: 0xff77a8, peach: 0xffccaa,
 };
 
+// MATERIAL PASS (July 2026): flat Lambert read as a 1998 GL demo.
+// Everything solid is now MeshStandardMaterial — real specular response,
+// roughness variation, and an environment map (set in game.js) so metal
+// glints and wet surfaces sheen. Custom opts: rough, metal, bump
+// (bump scale; 0 disables the shared noise bump).
 const _mats = new Map();
 export function mat(color, opts = {}) {
   const key = color + JSON.stringify(opts);
   if (!_mats.has(key)) {
-    _mats.set(key, new THREE.MeshLambertMaterial({ color, ...opts }));
+    const { rough, metal, bump, tex, ...rest } = opts;
+    const m = new THREE.MeshStandardMaterial({
+      color,
+      roughness: rough ?? 0.82,
+      metalness: metal ?? 0.06,
+      ...rest,
+    });
+    if (bump !== 0) {
+      m.bumpMap = noiseTex();
+      m.bumpScale = bump ?? 0.35;
+    }
+    // tex: [kind, rx, ry] — a near-white detail map multiplied by the
+    // material colour, so grime rides on top of the tuned palette
+    if (tex) {
+      m.map = texRepeat(grungeTex(0xd8d4cc, tex[0]), tex[1] ?? 1, tex[2] ?? 1);
+    }
+    _mats.set(key, m);
   }
   return _mats.get(key);
+}
+
+// One tileable grayscale noise canvas, shared as the default bumpMap —
+// it breaks the mathematically perfect surface every primitive has.
+let _noiseTex = null;
+export function noiseTex() {
+  if (_noiseTex) return _noiseTex;
+  const S = 256;
+  const c = document.createElement('canvas');
+  c.width = c.height = S;
+  const g = c.getContext('2d');
+  g.fillStyle = '#808080';
+  g.fillRect(0, 0, S, S);
+  // layered blotches, drawn twice with wrap offsets so the tile seams hide
+  for (let layer = 0; layer < 3; layer++) {
+    const n = [180, 420, 900][layer];
+    const r = [26, 11, 4][layer];
+    for (let i = 0; i < n; i++) {
+      const x = Math.random() * S, y = Math.random() * S;
+      const v = Math.floor(96 + Math.random() * 120);
+      g.fillStyle = `rgba(${v},${v},${v},${0.16 - layer * 0.04})`;
+      for (const [ox, oy] of [[0, 0], [-S, 0], [S, 0], [0, -S], [0, S]]) {
+        g.beginPath();
+        g.arc(x + ox, y + oy, r * (0.5 + Math.random()), 0, 7);
+        g.fill();
+      }
+    }
+  }
+  _noiseTex = new THREE.CanvasTexture(c);
+  _noiseTex.wrapS = _noiseTex.wrapT = THREE.RepeatWrapping;
+  return _noiseTex;
+}
+
+// Procedural grunge: a tinted, weathered surface texture — blotches,
+// streaks and grime built on the base colour. kind: 'concrete' (mottled
+// with vertical water stains), 'metal' (horizontal wear + rivet seams),
+// 'wax' (greasy soft blotches). Cached per colour+kind.
+const _grunge = new Map();
+export function grungeTex(hex, kind = 'concrete') {
+  const key = hex + kind;
+  if (_grunge.has(key)) return _grunge.get(key);
+  const S = 256;
+  const c = document.createElement('canvas');
+  c.width = c.height = S;
+  const g = c.getContext('2d');
+  const col = new THREE.Color(hex);
+  const css = (m, a = 1) =>
+    `rgba(${Math.floor(col.r * 255 * m)},${Math.floor(col.g * 255 * m)},${Math.floor(col.b * 255 * m)},${a})`;
+  g.fillStyle = css(1);
+  g.fillRect(0, 0, S, S);
+  // mottling: darker and lighter patches of the same hue
+  for (let i = 0; i < 300; i++) {
+    const x = Math.random() * S, y = Math.random() * S;
+    g.fillStyle = css(0.45 + Math.random() * 1.0, 0.16 + Math.random() * 0.16);
+    for (const [ox, oy] of [[0, 0], [-S, 0], [S, 0], [0, -S], [0, S]]) {
+      g.beginPath();
+      g.arc(x + ox, y + oy, 6 + Math.random() * 26, 0, 7);
+      g.fill();
+    }
+  }
+  if (kind === 'concrete') {
+    // vertical water stains running down from random points
+    for (let i = 0; i < 42; i++) {
+      const x = Math.random() * S, y = Math.random() * S * 0.6;
+      const w = 2 + Math.random() * 7, h = 30 + Math.random() * 120;
+      const grad = g.createLinearGradient(0, y, 0, y + h);
+      grad.addColorStop(0, css(0.4, 0.42));
+      grad.addColorStop(1, css(0.4, 0));
+      g.fillStyle = grad;
+      g.fillRect(x - w / 2, y, w, h);
+    }
+  } else if (kind === 'metal') {
+    // horizontal brushed wear + dark plate seams
+    for (let i = 0; i < 40; i++) {
+      const y = Math.random() * S;
+      g.fillStyle = css(0.7 + Math.random() * 0.5, 0.10);
+      g.fillRect(0, y, S, 1 + Math.random() * 3);
+    }
+    for (let i = 0; i < 5; i++) {
+      const y = Math.floor(Math.random() * S);
+      g.fillStyle = css(0.4, 0.5);
+      g.fillRect(0, y, S, 2);
+    }
+  }
+  const t = new THREE.CanvasTexture(c);
+  t.wrapS = t.wrapT = THREE.RepeatWrapping;
+  t.colorSpace = THREE.SRGBColorSpace;
+  _grunge.set(key, t);
+  return t;
+}
+
+// The environment: a tiny equirect gradient — bright rippled surface
+// above, deep teal below, a sun smear. scene.environment turns every
+// Standard material's fresnel and roughness into visible light response.
+export function makeEnvTexture() {
+  const W = 128, H = 64;
+  const c = document.createElement('canvas');
+  c.width = W; c.height = H;
+  const g = c.getContext('2d');
+  const grad = g.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0.0, '#bfeaf2');
+  grad.addColorStop(0.42, '#3f96a8');
+  grad.addColorStop(0.55, '#1c5f74');
+  grad.addColorStop(1.0, '#04141f');
+  g.fillStyle = grad;
+  g.fillRect(0, 0, W, H);
+  // the sun, smeared by the surface
+  const sun = g.createRadialGradient(W * 0.3, H * 0.14, 1, W * 0.3, H * 0.14, 16);
+  sun.addColorStop(0, 'rgba(255,246,214,0.95)');
+  sun.addColorStop(1, 'rgba(255,246,214,0)');
+  g.fillStyle = sun;
+  g.fillRect(0, 0, W, H);
+  // surface ripple bands
+  for (let i = 0; i < 22; i++) {
+    const y = 2 + Math.random() * H * 0.32;
+    g.fillStyle = `rgba(230,250,255,${0.05 + Math.random() * 0.1})`;
+    g.fillRect(Math.random() * W, y, 10 + Math.random() * 40, 1 + Math.random() * 2);
+  }
+  const t = new THREE.CanvasTexture(c);
+  t.mapping = THREE.EquirectangularReflectionMapping;
+  t.colorSpace = THREE.SRGBColorSpace;
+  return t;
 }
 
 // One soft round dot, shared by every particle system — square GL points
@@ -41,6 +184,14 @@ export function softDot() {
   return _softDot;
 }
 
+// A texture clone with its own repeat (clones share the image — cheap).
+export function texRepeat(t, rx, ry) {
+  const c = t.clone();
+  c.repeat.set(rx, ry);
+  c.needsUpdate = true;
+  return c;
+}
+
 // Smooth primitive helpers for organic shapes.
 export function ball(parent, r, color, x = 0, y = 0, z = 0, opts = {}) {
   const m = new THREE.Mesh(new THREE.SphereGeometry(r, 18, 14), mat(color, opts));
@@ -49,15 +200,15 @@ export function ball(parent, r, color, x = 0, y = 0, z = 0, opts = {}) {
   return m;
 }
 
-export function box(parent, w, h, d, color, x = 0, y = 0, z = 0) {
-  const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat(color));
+export function box(parent, w, h, d, color, x = 0, y = 0, z = 0, opts = {}) {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat(color, opts));
   m.position.set(x, y, z);
   parent.add(m);
   return m;
 }
 
-export function cyl(parent, rt, rb, h, color, x = 0, y = 0, z = 0, seg = 16) {
-  const m = new THREE.Mesh(new THREE.CylinderGeometry(rt, rb, h, seg), mat(color));
+export function cyl(parent, rt, rb, h, color, x = 0, y = 0, z = 0, seg = 16, opts = {}) {
+  const m = new THREE.Mesh(new THREE.CylinderGeometry(rt, rb, h, seg), mat(color, opts));
   m.position.set(x, y, z);
   parent.add(m);
   return m;
@@ -114,7 +265,8 @@ export function makeSub() {
   }
   const hullGeo = new THREE.LatheGeometry(profile, 28);
   hullGeo.rotateZ(-Math.PI / 2);                   // axis along +x
-  const hull = new THREE.Mesh(hullGeo, mat(0xe09a3a, { emissive: 0x5a2c08 }));
+  const hull = new THREE.Mesh(hullGeo,
+    mat(0xe09a3a, { emissive: 0x5a2c08, rough: 0.42, metal: 0.5, tex: ['metal', 3, 2], bump: 0.12 }));
   hull.name = 'hull';
   g.add(hull);
   // sail: elliptical tower with a rounded cap
@@ -505,7 +657,8 @@ export function makeFatberg(radius = 3) {
     pos.setXYZ(i, v.x, v.y * 0.85, v.z);
   }
   geo.computeVertexNormals();
-  const m = new THREE.Mesh(geo, mat(0xa89f70, { emissive: 0x141c08 }));
+  const m = new THREE.Mesh(geo,
+    mat(0xa89f70, { emissive: 0x141c08, rough: 0.97, bump: 1.1, tex: ['wax', 2, 2] }));
   // the documented sweetcorn garnish, now rounded
   for (let i = 0; i < 7; i++) {
     const lump = new THREE.Mesh(new THREE.SphereGeometry(0.22, 10, 8), mat(P8.yellow));
@@ -661,7 +814,11 @@ function makeFloor(scene) {
   geo.computeVertexNormals();
   // caustics live IN the floor's fragment shader: animated light webs
   // dancing on the silt, fading out with depth (sunlight runs out)
-  const floorMat = new THREE.MeshLambertMaterial({ vertexColors: true });
+  const floorMat = new THREE.MeshStandardMaterial({
+    vertexColors: true, roughness: 0.96, metalness: 0,
+    map: texRepeat(grungeTex(0xd8d4cc, 'wax'), 30, 20),
+    bumpMap: texRepeat(noiseTex(), 26, 16), bumpScale: 1.4,
+  });
   floorMat.onBeforeCompile = (shader) => {
     shader.uniforms.uTime = { value: 0 };
     floorMat.userData.shader = shader;
@@ -691,7 +848,8 @@ function makeQuayWalls(scene) {
   const g = new THREE.Group();
   const H = 70, T = 6;
   const wall = (w, d, x, z) => {
-    const b = box(g, w, H, d, P8.dusk, x, -H / 2 + 2, z);
+    const b = box(g, w, H, d, P8.dusk, x, -H / 2 + 2, z,
+      { tex: ['concrete', 12, 5], rough: 0.92, bump: 1.3 });
     return b;
   };
   wall(BOUNDS.maxX - BOUNDS.minX + T * 2, T, 0, BOUNDS.minZ - T / 2);
@@ -755,8 +913,8 @@ export function makeCulverts(scene) {
 function makeCrane(scene) {
   const g = new THREE.Group();
   g.position.set(60, DEEP_Y, 40);
-  box(g, 4, 26, 4, P8.dusk, 0, 13, 0);
-  box(g, 22, 2.5, 2.5, P8.dusk, 8, 26, 0).rotation.z = -0.12;
+  box(g, 4, 26, 4, P8.dusk, 0, 13, 0, { tex: ['metal', 2, 6], rough: 0.6, metal: 0.6 });
+  box(g, 22, 2.5, 2.5, P8.dusk, 8, 26, 0, { tex: ['metal', 6, 1], rough: 0.6, metal: 0.6 }).rotation.z = -0.12;
   box(g, 2, 6, 2, P8.brown, 18, 21, 0);   // hook block, drooping
   cyl(g, 0.4, 0.4, 14, P8.dusk, 18, 13, 0);
   g.rotation.z = 0.35;                     // toppled, half fallen
@@ -769,7 +927,7 @@ function makeBarge(scene) {
   const g = new THREE.Group();
   g.position.set(-40, SHELF_Y + 1.5, 30);
   g.rotation.y = 0.8; g.rotation.z = 0.28;
-  box(g, 26, 5, 9, 0x5a3f48, 0, 2, 0);
+  box(g, 26, 5, 9, 0x5a3f48, 0, 2, 0, { tex: ['metal', 6, 2], rough: 0.68, metal: 0.45 });
   box(g, 24, 1.5, 7, P8.black, 0, 4.5, 0);     // open hold
   box(g, 5, 4, 8, P8.dusk, -9, 6, 0);          // wheelhouse
   box(g, 1.2, 6, 1.2, P8.brown, 6, 7, 2);      // broken mast
@@ -781,9 +939,9 @@ function makeWarehouse(scene) {
   const g = new THREE.Group();
   g.position.set(85, DEEP_Y, -30);
   // roofless brick shell, tumbled columns
-  box(g, 30, 14, 2, 0x4a4050, 0, 7, -10);
-  box(g, 30, 9, 2, 0x4a4050, 0, 4.5, 12);
-  box(g, 2, 12, 22, 0x4a4050, -15, 6, 1);
+  box(g, 30, 14, 2, 0x4a4050, 0, 7, -10, { tex: ['concrete', 6, 3], rough: 0.9, bump: 0.6 });
+  box(g, 30, 9, 2, 0x4a4050, 0, 4.5, 12, { tex: ['concrete', 6, 2], rough: 0.9, bump: 0.6 });
+  box(g, 2, 12, 22, 0x4a4050, -15, 6, 1, { tex: ['concrete', 4, 3], rough: 0.9, bump: 0.6 });
   for (let i = 0; i < 4; i++) {
     const c = cyl(g, 1, 1.2, 10, P8.dusk, -8 + i * 6, 1.5, 1, 6);
     c.rotation.z = 1.35; c.rotation.y = i;
@@ -972,7 +1130,7 @@ export function buildDock(scene) {
   const weeds = makeWeeds(scene);
   // signature undertones: each structure family keeps a faint emissive
   // identity — the mystery now comes from light, not wireframes
-  tint(quay, 0x1d6f8f, 0.6);
+  tint(quay, 0x1d6f8f, 0.3);   // low: emissive fill flattens the concrete grime
   for (const m of culverts) tint(m.group, 0x00e436, 0.8);
   tint(crane, 0xffa300, 0.3);
   tint(barge, 0xff77a8, 0.25);

--- a/magpie/waterworld/test/playtest.mjs
+++ b/magpie/waterworld/test/playtest.mjs
@@ -47,9 +47,28 @@ try {
   await page.waitForTimeout(1500);
   pass('game started, __waterworld hook up');
 
+  // The full composite (AO + rays) starves the swiftshader sim clock
+  // (~0.2× wall speed) and makes every timed window flaky. Run raw;
+  // the composite itself is asserted by the canvas check below, which
+  // re-enables it for one frame.
+  await page.evaluate(() => { window.__waterworld.game.post.enabled = false; });
+
+  // Kinetic assertions wait on the GAME clock, not the wall clock —
+  // wall-time windows starve when swiftshader frames run slow and made
+  // a different assertion flake on every loaded run.
+  await page.evaluate(() => {
+    window.__simWait = (secs) => new Promise((res) => {
+      const g = window.__waterworld.game, t0 = g.elapsed;
+      const iv = setInterval(() => {
+        if (g.elapsed - t0 >= secs) { clearInterval(iv); res(); }
+      }, 50);
+    });
+  });
+  const simAdvance = (secs) => page.evaluate((s) => window.__simWait(s), secs);
+
   // captain's helm: with nobody touching anything, she sails herself
   const ap0 = await page.evaluate(() => window.__waterworld.pos());
-  await page.waitForTimeout(2500);
+  await simAdvance(2.5);
   const ap1 = await page.evaluate(() => window.__waterworld.pos());
   const cruised = Math.hypot(ap1[0] - ap0[0], ap1[2] - ap0[2]);
   if (cruised > 3) pass(`autopilot cruises unaided (${cruised.toFixed(1)} units)`);
@@ -84,7 +103,7 @@ try {
     const g = window.__waterworld.game;
     g.vel.set(10, 0, 0);
     g.setBrake(true);
-    await new Promise(r => setTimeout(r, 700));
+    await window.__simWait(0.7);
     const v = g.vel.length();
     g.setBrake(false);
     return v;
@@ -117,7 +136,7 @@ try {
     const v0 = g.vel.length();
     g.setKey('a', true); g.setKey('a', false);
     g.setKey('a', true); g.setKey('a', false);
-    await new Promise(r => setTimeout(r, 120));
+    await window.__simWait(0.12);
     return { v0, v1: g.vel.length() };
   });
   if (dashed.v1 > dashed.v0 + 10) pass(`dash spikes speed (${dashed.v0.toFixed(1)} → ${dashed.v1.toFixed(1)})`);
@@ -183,10 +202,10 @@ try {
     // water, away from collider-avoidance limit cycles
     const s = g.salvage.find(s => s.type === 'captains_chest');
     window.__waterworld.teleport(s.mesh.position.x, s.mesh.position.y + 2, s.mesh.position.z);
-    await new Promise(r => setTimeout(r, 1200));   // let the filter settle
+    await window.__simWait(1.2);                   // let the filter settle
     const yaws = [];
     for (let i = 0; i < 8; i++) {
-      await new Promise(r => setTimeout(r, 200));
+      await window.__simWait(0.2);
       yaws.push(g.yaw);
     }
     let reversals = 0;
@@ -226,7 +245,9 @@ try {
   if (fit.scroll === fit.inner) pass(`page fits its frame (${fit.inner}px)`);
   else fail(`page overflows: scrollHeight ${fit.scroll} vs innerHeight ${fit.inner}`);
 
-  // the canvas must actually draw something
+  // the canvas must actually draw something — THROUGH the composite
+  await page.evaluate(() => { window.__waterworld.game.post.enabled = true; });
+  await page.waitForTimeout(600);
   const drawn = await page.evaluate(() => {
     const c = document.getElementById('scene');
     const gl = c.getContext('webgl2') || c.getContext('webgl');
@@ -235,8 +256,9 @@ try {
       8, 8, gl.RGBA, gl.UNSIGNED_BYTE, px);
     return px.some(v => v > 8);
   });
-  if (drawn) pass('canvas is rendering (non-black pixels)');
+  if (drawn) pass('canvas is rendering through the composite (non-black pixels)');
   else fail('canvas appears black');
+  await page.evaluate(() => { window.__waterworld.game.post.enabled = false; });
 
   // steer: hold left + thrust, the sub must move and turn
   const before = await page.evaluate(() => ({
@@ -293,7 +315,7 @@ try {
     const e = g.eels[0];
     window.__waterworld.teleport(e.pos.x + 12, e.pos.y, e.pos.z);
     const d0 = e.pos.distanceTo(g.pos);
-    await new Promise(r => setTimeout(r, 1200));
+    await window.__simWait(1.2);
     return d0 - e.pos.distanceTo(g.pos);
   });
   if (eelDelta > 1) pass(`eel gave chase (closed ${eelDelta.toFixed(1)} units)`);
@@ -372,6 +394,9 @@ try {
     for (const el of g.elders) {
       window.__waterworld.teleport(el.mesh.position.x + 3, el.mesh.position.y, el.mesh.position.z);
       await new Promise(r => setTimeout(r, 250));
+      // sonar cooldown counts SIM seconds; at swiftshader frame rates
+      // that is many wall seconds and the second ping would be swallowed
+      g._pingCooldown = 0;
       window.__waterworld.ping();
       await new Promise(r => setTimeout(r, 1200));
     }
@@ -446,6 +471,7 @@ try {
     const p = g.pylon.position;
     window.__waterworld.teleport(p.x - 6, p.y + 8, p.z);
     await new Promise(r => setTimeout(r, 400));
+    g._pingCooldown = 0;
     window.__waterworld.ping();
     await new Promise(r => setTimeout(r, 600));
     return { bergs, stage: c.stage, won: g.won };


### PR DESCRIPTION
Answer to "it still looks like an OpenGL demo": the flat one-colour Lambert materials were the cause. This pass makes surfaces respond to light and carry detail.

**PBR everywhere.** `mat()` now builds MeshStandardMaterial with per-material roughness/metalness. A tiny procedural equirect environment map (`makeEnvTexture`) lights the whole scene — fresnel sheen on wet surfaces, glints on the sub, the crane and the barge. The environment switches off in IR mode.

**Procedural surface detail.** Generated canvas textures — concrete with vertical water stains, brushed metal with plate seams, waxy mottle — plus one shared tileable bump map. Applied to the sub hull, quay walls, dock floor, warehouse, barge and crane. Still zero image asset files.

**Screen-space crease AO** in the post shader grounds objects and shades corners, with silhouette-edge rejection so the fog gets no dark halos. Fewer taps in `?lite`.

**Test hardening.** The heavier renderer dropped the headless swiftshader sim clock to ~0.2× wall speed, which made a different wall-clocked assertion flake on every loaded run. Kinetic assertions now wait on the game clock (`__simWait`), the harness turns the composite off after asserting it draws, and scripted pings clear the sonar cooldown (which counts sim seconds).

Verified: playtest ALL PASS twice, FINK shell e2e ALL PASS, IR on/off screenshots correct, material screenshots inspected at four locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_