### PR TITLE
Phase 2 Slab 2: nest the compile step inside the runner (boxes in boxes)

### DIFF
--- a/.claude/skills/fink/SKILL.md
+++ b/.claude/skills/fink/SKILL.md
@@ -1162,10 +1162,15 @@ AND down. `e2e-storyrunner.mjs` proves containment: `parent.FoafOS` /
 `parent.FinkInkEngine` / `parent.document` all throw from inside.
 - This runs PARALLEL to the live host-side player (unchanged, still
   privileged). It is NOT yet a replacement — no media (C8), no
-  link/navigate wiring, and the compile step still runs in the runner's
-  own frame rather than a nested throwaway iframe (inner-integrity
-  follow-up). Threat model + phases:
+  link/navigate wiring. Threat model + phases:
   `docs/fink-story-sandbox-threatmodel-20260728.md`.
+- **Boxes within boxes (Slab 2):** the runner does NOT run the story's JS
+  in its own frame — `extractInBox()` runs it in a nested throwaway
+  `sandbox="allow-scripts"` iframe using the frozen backticks
+  `INSTALL_CAPTURE_SOURCE`, and gets back only harvested strings. So a
+  hostile `.fink.js` can't touch the runner's own foaf, let alone the
+  host. Recursion end to end: shell → runner → compile box; shell →
+  runner → governed guest.
 - `app-sdk.js` grew `foaf.storyRequest` and `foaf.bus`, and now replays
   `onInit` to a late (module) listener — app.init can land before a
   `type=module` app registers its handler; without the replay the app

--- a/docs/fink-story-sandbox-threatmodel-20260728.md
+++ b/docs/fink-story-sandbox-threatmodel-20260728.md
@@ -358,10 +358,19 @@ and still ship, because containment contains its mistakes.
   guest — up AND down). `e2e-storyrunner.mjs` proves the box: from inside,
   `parent.FoafOS` / `parent.FinkInkEngine` / `parent.document` all throw
   `SecurityError` (C13 closed by construction). It runs PARALLEL to the live
-  host-side player, which is untouched. Remaining Slab 2+: media verbs
-  (C8), link/navigate wiring (C4/C12), nesting the compile step in a
-  throwaway iframe INSIDE the runner (inner integrity), and reaching feature
-  parity so the boxed runner can replace the host-side player.
+  host-side player, which is untouched.
+
+  **Slab 2 landed (2026-07-28): boxes within boxes.** The compile step no
+  longer runs in the runner's own frame — `extractInBox()` runs the
+  untrusted `.fink.js` in a NESTED throwaway `sandbox="allow-scripts"`
+  iframe (opaque origin) via the frozen `INSTALL_CAPTURE_SOURCE`, and the
+  runner receives only harvested strings. The recursion now holds end to
+  end: shell → runner → compile box, and shell → runner → (governed)
+  launched guest — sandboxed all the way up AND down. `e2e-storyrunner.mjs`
+  proves it: the demo's file-level JS sets a canary that, had it run in the
+  runner frame, would land on the runner window; it does not.
+  Remaining Slab 3+: media verbs (C8), link/navigate wiring (C4/C12), and
+  feature parity so the boxed runner can replace the host-side player.
 - **Phase 3 — POLICY: the trust graph + session integrity, default fork.**
   Typed edges (`relationType` + optional `# INTEGRITY:`) weighed over
   MULTIPLE signals (hash, origin, signature, reputation, consent — §5), not

--- a/inklet/apps/storyrunner/demo.fink.js
+++ b/inklet/apps/storyrunner/demo.fink.js
@@ -27,3 +27,8 @@ You climb into a dry maintenance loft. A different way in.
 Either way, the dock is waiting.
 -> END
 `;
+// A .fink.js is executable JS. This benign line stands in for any code a
+// story's file runs: if extraction happened in the RUNNER frame it would
+// land on the runner's window; because it happens in a NESTED box, the
+// runner never sees it. The e2e asserts the runner has no __stpr_canary.
+try { window.__stpr_canary = 'ran-in-frame'; } catch (e) { /* boxed */ }

--- a/inklet/apps/storyrunner/storyrunner.js
+++ b/inklet/apps/storyrunner/storyrunner.js
@@ -6,27 +6,66 @@
 // `parent.FoafOS` and never writes host DOM. That is the "sandboxed all the
 // way up" containment the live host-side player does not yet have.
 //
-// Extraction uses the frozen @foafos/backticks kernel (browser-safe entry).
-// Compilation uses the real inkjs (global). NO hackparsing (CLAUDE.md).
-//
-// HONEST LIMIT (hardening follow-up): the story's JS runs via new Function
-// in THIS frame, so a hostile story could tamper with this runner's own
-// app-sdk — but it still cannot exceed the runner's grant or reach the
-// host, because the frame is opaque-origin. Nesting the compile step in a
-// throwaway iframe (backticks INSTALL_CAPTURE_SOURCE) closes that inner gap
-// next; the OUTER containment (no host reach) holds now and is what the
-// e2e proves.
+// Boxes within boxes ("all the way down"). The shell boxes this runner; the
+// runner boxes the COMPILE step. The story's JS never runs in the runner's
+// own frame — it runs in a nested throwaway opaque-origin iframe, using the
+// frozen backticks INSTALL_CAPTURE_SOURCE. So a hostile .fink.js cannot even
+// touch this runner's foaf/app-sdk, let alone the host. The runner receives
+// only harvested strings. Compilation uses the real inkjs. NO hackparsing.
 
-import { createCapture, firstInkOf } from '../../../packages/backticks/src/index.js';
+import { INSTALL_CAPTURE_SOURCE } from '../../../packages/backticks/src/index.js';
 
 const $ = (id) => document.getElementById(id);
 const state = {
   storyUrl: null, ready: false, prose: [], choices: [], bg: null,
-  ended: false, requests: [],
+  ended: false, requests: [], boxedCompile: false,
 };
 let story = null;
 
 function setStatus(msg) { $('status').textContent = msg; }
+
+// Extract the ink from a .fink.js by RUNNING it in a nested sandboxed
+// iframe (opaque origin), not in this frame. Returns { ink, blocks }.
+function extractInBox(src) {
+  return new Promise((resolve) => {
+    const frame = document.createElement('iframe');
+    frame.setAttribute('sandbox', 'allow-scripts');   // opaque origin, no same-origin
+    frame.style.display = 'none';
+    // The nested box installs the FROZEN capture (byte-identical to the
+    // kernel — proved in backticks/test/browser-source.test.js), runs the
+    // untrusted story, harvests, and posts back only strings.
+    frame.srcdoc = `<!DOCTYPE html><meta charset="utf-8"><script>
+      var FINK_SIGILS = { oooOO: 'text/x-ink' };
+      var install = ${INSTALL_CAPTURE_SOURCE};
+      var harvest = install(window, FINK_SIGILS);
+      addEventListener('message', function (e) {
+        if (!e.data || e.data.type !== 'fink-exec') return;
+        try { (new Function(e.data.src))(); } catch (err) { /* post-capture throw */ }
+        parent.postMessage({ type: 'fink-harvested', result: harvest() }, '*');
+      });
+      parent.postMessage({ type: 'fink-box-ready' }, '*');
+    <\/script>`;
+    let done = false;
+    const finish = (result) => {
+      if (done) return; done = true;
+      window.removeEventListener('message', onMsg);
+      frame.remove();
+      resolve(result || { ink: '', blocks: [] });
+    };
+    const onMsg = (e) => {
+      if (e.source !== frame.contentWindow || !e.data) return;
+      if (e.data.type === 'fink-box-ready') {
+        frame.contentWindow.postMessage({ type: 'fink-exec', src }, '*');
+      } else if (e.data.type === 'fink-harvested') {
+        const r = e.data.result || {};
+        finish({ ink: r.firstInk || '', blocks: r.blocks || [] });
+      }
+    };
+    window.addEventListener('message', onMsg);
+    setTimeout(() => finish(null), 4000);            // never hang the runner
+    document.body.appendChild(frame);
+  });
+}
 
 // Prose is added as TEXT, never innerHTML — contained AND xss-proof.
 function addProse(text, cls) {
@@ -130,17 +169,10 @@ async function boot(config) {
     setStatus('could not load story: ' + e.message);
     return;
   }
-  // Extract ink with the frozen kernel: install the sigils, run the file's
-  // JS in THIS frame (contained by the opaque origin), harvest the ink.
-  const { globals, blocks } = createCapture();
-  const names = Object.keys(globals);
-  try {
-    // eslint-disable-next-line no-new-func
-    new Function(...names, src)(...names.map((n) => globals[n]));
-  } catch {
-    // window/document touches throw AFTER the sigils ran — blocks stand.
-  }
-  const ink = firstInkOf(blocks);
+  // Extract ink in a NESTED sandbox — the story's JS never touches this
+  // runner. Boxes within boxes: shell → runner → compile box.
+  const { ink } = await extractInBox(src);
+  state.boxedCompile = true;
   if (!ink) { setStatus('no ink content found'); return; }
   try {
     story = new inkjs.Compiler(ink).Compile();

--- a/inklet/finkapp/test/e2e-storyrunner.mjs
+++ b/inklet/finkapp/test/e2e-storyrunner.mjs
@@ -108,6 +108,17 @@ try {
   if (contained) pass(`no host reach from the box (${JSON.stringify(reach)})`);
   else fail('BOX LEAKS to host: ' + JSON.stringify(reach));
 
+  // ── 3b. boxes within boxes: the story's JS ran in a NESTED sandbox, ──
+  // not in the runner frame. The demo's file-level JS sets __stpr_canary;
+  // if it had run in the runner frame, the runner window would carry it.
+  const inner = await frame.evaluate(() => ({
+    boxed: !!window.__storyrunner.state.boxedCompile,
+    canaryInRunner: typeof window.__stpr_canary,     // 'undefined' when boxed
+  }));
+  if (inner.boxed && inner.canaryInRunner === 'undefined') {
+    pass('compile step nested in its own box — story JS never touched the runner');
+  } else fail('inner box leaked: ' + JSON.stringify(inner));
+
   // ── 4. a choice that hits # MINIGAME: surfaces as a governed request ──
   // Choose option 0 ("Take the torch") → hatch → # MINIGAME: waterworld.
   await frame.evaluate(() => window.__storyrunner.choose(0));


### PR DESCRIPTION
Continues *"sandboxed apps all the way up and down."* Slab 1 boxed the runner; this closes the one remaining inner gap — the story's own JS was still executing in the runner's frame.

**`extractInBox()`** now runs the untrusted `.fink.js` in a **nested throwaway `sandbox="allow-scripts"` iframe** (opaque origin) using the frozen backticks `INSTALL_CAPTURE_SOURCE`. The runner receives only harvested strings. A hostile story can no longer touch the runner's own `foaf`/app-sdk, let alone the host.

**The recursion now holds end to end — all the way up AND down:**
```
shell → runner → compile box
shell → runner → (governed) launched guest
```

**Proven, not asserted.** The demo's file-level JS sets a canary that, had it run in the runner frame, would land on the runner window. `e2e-storyrunner.mjs` asserts the runner window has no such canary — so the story JS demonstrably ran in the nested box, not the runner. Every Slab 1 assertion (no host reach, `# BG:` contained to the frame, `# MINIGAME:` → governed `story.launch`, named refusals) still passes.

Only the runner app, its demo fixture, and the containment test change; the frozen `INSTALL_CAPTURE_SOURCE` is used exactly as designed (byte-equivalence to the kernel is already locked by `backticks/test/browser-source.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_