### PR TITLE
storyrunner: tally story:* in the capUse ledger (Running ⓘ truthfulness)

### DIFF
--- a/inklet/finkapp/foafos-shell.js
+++ b/inklet/finkapp/foafos-shell.js
@@ -1522,6 +1522,10 @@ function buildUI() {
         });
         if (!need) { reply({ ok: false, reason: 'unknown-verb' }); return; }
         if (!caps.includes(need)) { reply({ ok: false, reason: 'denied' }); return; }
+        // Keep the Running ⓘ "utilized" ledger truthful: a boxed runner's
+        // narrative effects are a broker path like storage/secrets/verb/
+        // audio, and must tally the same way (parked-work note, 2026-07-28).
+        tallyCap(app.id, need);
         try {
           if (verb === 'story.launch') {
             const game = String(d.detail?.game || '').toLowerCase();

--- a/inklet/finkapp/test/e2e-storyrunner.mjs
+++ b/inklet/finkapp/test/e2e-storyrunner.mjs
@@ -133,6 +133,12 @@ try {
   if (sawGoverned) pass('the shell governed the launch request (bus story.request)');
   else fail('shell never saw the story.launch request');
 
+  // the Running ⓘ "utilized" ledger must count the narrative effect —
+  // story:* is a broker path like storage/secrets/verb/audio
+  const tallied = await page.evaluate(() => FoafOS.capUse('storyrunner')?.['story:launch'] || 0);
+  if (tallied >= 1) pass(`capUse tallied story:launch (${tallied})`);
+  else fail('story:launch not counted in the capUse ledger: ' + tallied);
+
   // ── 5. withheld capability is refused (named, not silent) ────────────
   const refusal = await frame.evaluate(async () => {
     // story.navigate is granted here but not implemented; story.link too.


### PR DESCRIPTION
Cross-session coordination fix. The Running panel's per-app **"utilized"** ledger (`tallyCap` / `FoafOS.capUse` in `foafos-shell.js`, from the Running-panel thread) is fed by the storage / secrets / verb / audio broker paths. The boxed runner's `story.request` handler is a **new broker path** and was not tallying, so a `story:launch` would be invisible in the ⓘ panel — "utilized" would under-report.

Fix: `tallyCap(app.id, need)` right after the grant check passes — same placement and meaning as the other broker paths (tally a held capability when the app exercises it). `e2e-storyrunner.mjs` now asserts `capUse('storyrunner')['story:launch'] >= 1`.

Checked the other two parked-work overlap points; neither conflicts:
- **Observability steps 2–5** (`fink-devpanel.js` / `fink-ui.js` / engine tag loop) — the runner refactor is a *parallel* app and left all three untouched.
- **Suspension / switcher / story provenance** (`AppTree.setSuspended`, node capabilities, `parentId` chains, `FinkPlayer.currentStoryUrl`, `FinkNavigation.generateUrlHash`) — untouched by this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_