### PR TITLE
storyrunner audio: broker to the host (the iOS widget-audio fix)

### DIFF
--- a/inklet/apps/storyrunner/storyrunner.js
+++ b/inklet/apps/storyrunner/storyrunner.js
@@ -135,11 +135,14 @@ function handleTag(tag) {
   }
 }
 
-// Audio, BOXED and GOVERNED. A looping bed for `# AUDIO: <file>`, played by
-// an <audio> element in the runner's own frame, its volume driven by the
-// shell's master level (foaf.onAudio) so the dock's mute reaches it. Synth
-// audio (`# AUDIO: synth:*`) is the host's FinkFoley — not reachable from
-// the box; named, not silent.
+// Audio as a HOST service — and the iOS fix. Inside foafos the runner does
+// NOT play audio in its own sandboxed frame (iOS blocks a cross-origin
+// frame with no gesture unlock); it asks the SHELL to play it via
+// FinkAudio, which lives in the gesture-unlocked host document and is
+// already governed by the master volume. Standalone (no shell), it falls
+// back to an in-frame element so dev still hears something. Synth audio
+// (`# AUDIO: synth:*`) is the host's FinkFoley — not reachable from the
+// box; named, not silent.
 let _audioEl = null;
 let _audioLevel = 1;
 
@@ -147,20 +150,28 @@ function playAudio(value) {
   const v = (value || '').trim();
   if (/^synth:/i.test(v)) { setStatus('(synth audio is host-only, not in the boxed runner)'); return; }
   if (!v) return;
-  stopAudio();
+  state.audio = v;
+  if (window.foaf?.storyRequest) {
+    // brokered to the shell — plays from the host document (iOS-friendly)
+    storyRequest('story.audio', { url: resolveStoryUrl(v), action: 'play' });
+    return;
+  }
+  stopAudio();                                   // standalone dev fallback
   _audioEl = new Audio(v);
   _audioEl.loop = true;
   _audioEl.volume = _audioLevel;
   _audioEl.play().catch(() => { /* autoplay may wait for a gesture */ });
-  state.audio = v;
 }
 
 function stopAudio() {
-  if (_audioEl) { try { _audioEl.pause(); } catch (e) { /* gone */ } _audioEl = null; }
   state.audio = null;
+  if (window.foaf?.storyRequest) { storyRequest('story.audio', { action: 'stop' }); return; }
+  if (_audioEl) { try { _audioEl.pause(); } catch (e) { /* gone */ } _audioEl = null; }
 }
 
-// The shell's master volume/mute, applied to the runner's bed.
+// The shell's master volume/mute. When brokered, FinkAudio already applies
+// it host-side; we only drive the standalone fallback element. Recorded
+// either way so "is the box governed" is observable.
 function applyAudioLevel({ level }) {
   _audioLevel = level;
   if (_audioEl) _audioEl.volume = level;

--- a/inklet/finkapp/foafos-shell.js
+++ b/inklet/finkapp/foafos-shell.js
@@ -1516,7 +1516,7 @@ function buildUI() {
         };
         const verb = String(d.verb || '');
         const need = { 'story.launch': 'story:launch', 'story.link': 'story:link',
-                       'story.navigate': 'story:navigate' }[verb];
+                       'story.navigate': 'story:navigate', 'story.audio': 'audio' }[verb];
         bus.publish('story.request', {
           summary: `${app.name}: ${verb}`, appId: app.id, verb, detail: d.detail,
         });
@@ -1532,6 +1532,21 @@ function buildUI() {
             if (!game) { reply({ ok: false, reason: 'bad-params' }); return; }
             window.FinkMinigames?.startMinigame?.(game);
             reply({ ok: true, launched: game });
+          } else if (verb === 'story.audio') {
+            // Audio is a HOST service — and this is the iOS fix. A
+            // sandboxed frame has no gesture unlock, so `new Audio()`
+            // inside the box is throttled/blocked on iOS. Playing through
+            // FinkAudio (this document, gesture-unlocked, already governed
+            // by the master volume) is both the correct capability model
+            // and the thing that actually plays on a phone.
+            const action = d.detail?.action || 'play';
+            if (action === 'stop') { window.FinkAudio?.stop?.(); reply({ ok: true, action }); return; }
+            let base, target;
+            try { base = new URL(frame.src); target = new URL(String(d.detail?.url || ''), base); }
+            catch { reply({ ok: false, reason: 'bad-url' }); return; }
+            if (target.origin !== base.origin) { reply({ ok: false, reason: 'cross-origin-blocked' }); return; }
+            window.FinkAudio?.play?.(target.href, target.href);
+            reply({ ok: true, url: target.href });
           } else {
             // link (# FINK: follow) / navigate. The shell AUTHORIZES the
             // destination; the boxed runner does the contained fetch+render.

--- a/inklet/finkapp/test/e2e-storyrunner.mjs
+++ b/inklet/finkapp/test/e2e-storyrunner.mjs
@@ -137,19 +137,22 @@ try {
     pass(`feature: pinned image, prose below (${feat.mediaH}/${feat.stageH}px)`);
   } else fail('feature media wrong: ' + JSON.stringify(feat));
 
-  // ── 4b. AUDIO: a governed, boxed bed. # AUDIO: plays a looping element,
-  // and the shell's master volume reaches it via foaf.onAudio.
-  const audio0 = await frame.evaluate(() => window.__storyrunner.state.audio);
-  if (audio0 && /ambient\.wav/.test(audio0)) pass('# AUDIO: started a looping bed in the box');
-  else fail('audio bed not started: ' + JSON.stringify(audio0));
-  // turn the shell's master volume down; the runner's bed must follow
-  const audioGoverned = await page.evaluate(async () => {
-    FoafOS.audio.setVolume(0.25);
-    await new Promise((r) => setTimeout(r, 300));
-    return document.querySelector('iframe[src*="storyrunner"]') ? null : true;
-  });
+  // ── 4b. AUDIO is a HOST service (the iOS fix). # AUDIO: must be BROKERED
+  // to the shell — played from the host document, not with new Audio()
+  // inside the sandboxed frame (which iOS throttles) — and governed by the
+  // shell master volume.
+  const audio0 = await frame.evaluate(() => ({
+    src: window.__storyrunner.state.audio,
+    brokered: window.__storyrunner.state.requests.some(
+      (r) => r.verb === 'story.audio' && r.detail?.action === 'play'),
+  }));
+  if (audio0.src && /ambient\.wav/.test(audio0.src) && audio0.brokered) {
+    pass('# AUDIO: brokered to the shell (host document — iOS-friendly), not played in the box');
+  } else fail('audio not brokered: ' + JSON.stringify(audio0));
+  await page.evaluate(() => FoafOS.audio.setVolume(0.25));
+  await page.waitForTimeout(300);
   const lvl = await frame.evaluate(() => window.__storyrunner.state.audioLevel);
-  if (lvl <= 0.26) pass(`shell master volume reaches the boxed bed (level ${lvl})`);
+  if (lvl <= 0.26) pass(`shell master volume reaches the runner (level ${lvl})`);
   else fail('master volume did not reach the runner: ' + lvl);
   await page.evaluate(() => FoafOS.audio.setVolume(1));
 


### PR DESCRIPTION
Addresses the iOS observation: audio from widgets is reticent. It was a real bug in the boxed runner — iOS throttles/blocks audio from a cross-origin sandboxed frame that has no user-gesture unlock, which is exactly where the runner lives, so its in-frame `new Audio()` bed would not play on a phone.

The fix is also the correct capability model — **audio is a host service**:
- The runner no longer plays audio itself inside foafos. `# AUDIO:` is **brokered** — `story.audio {url, action}` → the shell plays it via `FinkAudio`, which lives in the gesture-unlocked **host document** and is already governed by the master volume. iOS plays it; the dock's mute still reaches it.
- `story.audio` requires the `audio` capability, is same-origin gated, and is tallied in the `capUse` ledger like the other `story:*` effects.
- Standalone (no shell) keeps the in-frame element so dev still hears something.

`e2e-storyrunner` now asserts `# AUDIO:` is **brokered** (a `story.audio` play request), *not* played in the box, and that the master volume still governs it. Neighbour suites green: caps, foafos, audio-leak, waterworld.

(The second point from the same note — a menubar/status-tray for small dashboard widgets with hierarchy — is a design I'm writing up separately, not in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_