### PR TITLE
foafos menubar: dashboard widgets grouped by the app tree

### DIFF
--- a/docs/foafos-menubar-20260729.md
+++ b/docs/foafos-menubar-20260729.md
@@ -1,0 +1,58 @@
+# foafos menubar — dashboard widgets, grouped by the app tree
+
+**v1, 2026-07-29.** Answers: *"foafos speaks of Chrome and we have several
+parallel miniapps shown in a tabbed view but no hierarchy. Shouldn't there
+be a menubar UI within which smaller dashboardy things (scores, clocks) can
+emerge?"* — yes, and here it is.
+
+## The gap
+foafos runs apps in parallel (a story, its minigame, sibling widgets) with a
+real **app tree** underneath (`FoafOS.apps`, parent/child), but their small
+readouts — scores, clocks, gauges — had nowhere shared to surface and no
+nesting. The `# STATUS:` line was story-only and flat.
+
+## The menubar
+A **chrome app** (`surface: 'chrome'`, mount `foaf-menubar`,
+`inklet/finkapp/foafos-menubar.js`) — offered by the root → it renders; not
+offered → the element is parked, like the breadcrumb and load meter. It
+shows:
+
+- a **clock**, the one shell-level widget, always present;
+- whatever a running app **publishes** as `app.<id>.status` on the bus,
+  `{ items: [{ id, label, value, icon }] }`.
+
+Apps publish in their **own scoped namespace** — the sandbox already allows
+`app.<id>.*`, so a boxed guest needs no new grant. The menubar, being
+trusted shell furniture (host-side), reads them all.
+
+## The hierarchy
+Groups are ordered and **indented by app-tree depth** (`FoafOS.apps`): a
+story's readouts at one level, its running minigame's nested beneath. A
+group appears when its app starts publishing and disappears when the app
+closes (`minigame.instance {closed}`). This is the nesting the flat
+parallel/tabbed view lacked — one story owning the frame, its guests'
+dashboards tucked under it.
+
+## Contributing (any app)
+```js
+foaf.bus.publish('app.myapp.status', { items: [
+  { icon: '⭐', label: 'score', value: 1200 },
+  { icon: '⏱', value: '01:04' },
+]});
+```
+The boxed story runner does this from `# STATUS:` today. A minigame that
+publishes `app.<game>.status` gets its gauges nested under the story that
+launched it — no extra wiring.
+
+## v1 scope / next
+- v1 renders text widgets; no interaction (a click-to-open menu, a
+  drop-down of app controls) yet — the "menu" half of "menubar" is a
+  natural next step, and the app tree already gives it the structure.
+- The story runner's `# STATUS:` is published as one text item; parsing the
+  structured `# STATUS: <var> icon= label= format=` form into typed widgets
+  (bars, gauges) is the same shape and belongs next.
+- Live-updating values (a ticking game clock, a rising score) already work
+  — an app just republishes `app.<id>.status`; the menubar re-renders.
+
+Tests: `e2e-storyrunner.mjs` asserts the clock + the runner's group with its
+readout; `e2e-chrome`/`e2e-root` cover mount-when-offered / park-when-not.

--- a/inklet/apps/storyrunner/storyrunner.js
+++ b/inklet/apps/storyrunner/storyrunner.js
@@ -112,6 +112,11 @@ function handleTag(tag) {
       break;
     case 'STATUS':
       setStatus(value);
+      // Contribute the story's readout to the menubar (grouped under this
+      // app in the tree). Small, in our own namespace — the sandbox allows
+      // app.storyrunner.*; the menubar (shell furniture) aggregates it.
+      _statusItems = value ? [{ id: 'status', label: value }] : [];
+      window.foaf?.bus?.publish('app.storyrunner.status', { items: _statusItems });
       break;
     case 'MINIGAME':
       storyRequest('story.launch', { game: value.split(/\s+/)[0] });
@@ -187,6 +192,7 @@ function applyAudioLevel({ level }) {
 const MEDIA_ROLES = { hero: 'X-MEDIA-HERO', feature: 'X-MEDIA-FEATURE', accent: 'X-MEDIA-ACCENT' };
 let _beatMedia;   // undefined = no media tag this beat (keep previous, sticky)
 let _pendingLink; // undefined = no FINK link this beat
+let _statusItems = [];   // the story's menubar readouts
 
 function parseMedia(kind, value) {
   const parts = value.split(/\s+/).filter(Boolean);

--- a/inklet/finkapp/fink-player.css
+++ b/inklet/finkapp/fink-player.css
@@ -1120,3 +1120,31 @@ body[data-theatre="on"] .video-collapse { display: none; }
     color: var(--zx-cyan);
     font-weight: bold;
 }
+
+/* ── Menubar: clock + app dashboard widgets, grouped by the app tree ── */
+#foaf-menubar {
+    display: flex;
+    align-items: center;
+    gap: 0.9em;
+    padding: 0.25em 0.8em;
+    padding-inline: 44px;
+    font-size: 0.82em;
+    background: rgba(0, 0, 0, 0.72);
+    border-bottom: 1px solid var(--zx-blue);
+    color: var(--zx-white, #fff);
+    z-index: 99;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+/* nothing but the clock → no bar (the clock alone does not earn a row) */
+#foaf-menubar:not(:has(.mb-group)) { display: none; }
+#foaf-menubar .mb-clock { opacity: 0.85; font-variant-numeric: tabular-nums; }
+#foaf-menubar .mb-group {
+    display: inline-flex; align-items: center; gap: 0.4em;
+    /* indent by tree depth: a child app's readouts sit in from its parent */
+    margin-inline-start: calc(var(--mb-depth, 0) * 1.2em);
+    padding-inline-start: 0.6em;
+    border-inline-start: 2px solid rgba(255, 255, 255, 0.18);
+}
+#foaf-menubar .mb-app { opacity: 0.6; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.06em; }
+#foaf-menubar .mb-widget { font-variant-numeric: tabular-nums; }

--- a/inklet/finkapp/foafos-apps.js
+++ b/inklet/finkapp/foafos-apps.js
@@ -274,6 +274,9 @@ export const APPS = [
   { id: 'loadmeter', family: 'chrome', icon: '📜', name: 'Load meter', surface: 'chrome',
     mount: 'scroll-status-bar', desc: 'FINKs encountered, loaded, compiled',
     capabilities: ['shell'], silent: true },
+  { id: 'menubar', family: 'chrome', icon: '📊', name: 'Menubar', surface: 'chrome',
+    mount: 'foaf-menubar', desc: 'A clock and app dashboard widgets, grouped by the app tree',
+    capabilities: ['shell'], silent: true },
   // THE ONE I MISSED (reported from a phone, July 2026). Converting the
   // breadcrumb, the status line and the load meter and stopping there left
   // a fourth piece of story furniture hard-coded in index.html — so a Web

--- a/inklet/finkapp/foafos-menubar.js
+++ b/inklet/finkapp/foafos-menubar.js
@@ -1,0 +1,143 @@
+// foafos-menubar.js — the menubar: a chrome strip of small "dashboard"
+// widgets, grouped by the app-tree HIERARCHY.
+//
+// The gap it fills: foafos runs several apps in parallel (a story, its
+// minigame, sibling widgets) but their small readouts — scores, clocks,
+// gauges — had nowhere shared to surface, and no nesting. This gathers
+// them:
+//
+//   · a CLOCK, the one shell-level widget, always present
+//   · whatever a running app PUBLISHES as `app.<id>.status` on the bus,
+//     `{ items: [{ id, label, value, icon }] }`. Apps publish in their OWN
+//     scoped namespace (the sandbox already allows that); the menubar,
+//     trusted shell furniture, reads them all.
+//
+// Items are grouped and INDENTED by the app tree (FoafOS.apps): a story's
+// readouts at one level, its running minigame's nested beneath — the
+// hierarchy the parallel/tabbed view lacked. A group appears when its app
+// starts publishing and disappears when the app closes.
+//
+// It is a chrome APP (surface:'chrome', mount 'foaf-menubar'): offered by
+// the root → it renders; not offered → the element is parked (removed) and
+// this stays dark, like the breadcrumb and load meter.
+(function () {
+  if (window.FoafMenubar) return;
+
+  const byApp = new Map();          // appId → items[]
+  let el = null, clockTimer = null, unsub = null;
+
+  const appOf = (topic) => {
+    const m = /^app\.([^.]+)\.status$/.exec(topic || '');
+    return m ? m[1] : null;
+  };
+
+  function node(appId) {
+    const apps = window.FoafOS?.apps;
+    const root = window.FoafOS?.rootNode;
+    if (!apps?.get || !root) return null;
+    let found = null;
+    const walk = (id) => {
+      if (found) return;
+      const n = apps.get(id);
+      if (!n) return;
+      if (n.appId === appId) { found = n; return; }
+      for (const c of apps.children(id)) walk(c.id);
+    };
+    walk(root.id);
+    return found;
+  }
+
+  function depthOf(appId) {
+    const apps = window.FoafOS?.apps;
+    let n = node(appId), d = 0;
+    while (n && n.parentId && apps?.get) { d++; n = apps.get(n.parentId); }
+    return d;
+  }
+
+  const labelFor = (appId) => node(appId)?.label || appId;
+
+  function clockText() {
+    // Browser time is fine here (only workflow scripts forbid Date()).
+    const d = new Date();
+    const p = (n) => String(n).padStart(2, '0');
+    return `🕐 ${p(d.getHours())}:${p(d.getMinutes())}`;
+  }
+
+  function render() {
+    if (!el) return;
+    el.textContent = '';
+
+    const clock = document.createElement('span');
+    clock.className = 'mb-clock';
+    clock.setAttribute('role', 'timer');
+    clock.textContent = clockText();
+    el.appendChild(clock);
+
+    const ids = [...byApp.keys()]
+      .filter((id) => (byApp.get(id) || []).length)
+      .sort((a, b) => depthOf(a) - depthOf(b) || a.localeCompare(b));
+
+    for (const appId of ids) {
+      const group = document.createElement('span');
+      group.className = 'mb-group';
+      group.dataset.app = appId;
+      group.style.setProperty('--mb-depth', String(depthOf(appId)));
+
+      const name = document.createElement('span');
+      name.className = 'mb-app';
+      name.textContent = labelFor(appId);
+      group.appendChild(name);
+
+      for (const it of byApp.get(appId)) {
+        const w = document.createElement('span');
+        w.className = 'mb-widget';
+        w.dataset.id = it.id || '';
+        w.textContent = `${it.icon ? it.icon + ' ' : ''}${it.label ? it.label + ' ' : ''}${it.value ?? ''}`.trim();
+        group.appendChild(w);
+      }
+      el.appendChild(group);
+    }
+  }
+
+  function mount(target) {
+    el = target;
+    const bus = window.FoafOS?.bus;
+    if (bus?.subscribe && !unsub) {
+      unsub = bus.subscribe('*', (e) => {
+        const appId = appOf(e.topic);
+        if (appId) { byApp.set(appId, Array.isArray(e.data?.items) ? e.data.items : []); render(); return; }
+        if (e.topic === 'minigame.instance' && e.data?.closed) { byApp.delete(e.data.type); render(); }
+        if (e.topic === 'story.state' && e.data?.phase === 'end') { render(); }
+      });
+    }
+    if (!clockTimer) {
+      clockTimer = setInterval(() => {
+        const c = el?.querySelector('.mb-clock'); if (c) c.textContent = clockText();
+      }, 1000);
+    }
+    render();
+  }
+
+  function unmount() {
+    if (clockTimer) { clearInterval(clockTimer); clockTimer = null; }
+    if (unsub) { try { unsub(); } catch (e) { /* */ } unsub = null; }
+    el = null;
+  }
+
+  // Supervisor: mount when the shell (FoafOS.bus) is up AND the menubar
+  // element is present (i.e. the root OFFERS this chrome, so it was not
+  // parked). Unmount if the element is later parked away. No coupling to
+  // the shell's chrome internals — just the element's presence.
+  const tick = setInterval(() => {
+    const target = document.getElementById('foaf-menubar');
+    const ready = !!window.FoafOS?.bus;
+    if (ready && target && el !== target) mount(target);
+    else if (el && !document.body.contains(el)) unmount();
+  }, 250);
+
+  window.FoafMenubar = {
+    mount, unmount,
+    _state: () => ({ apps: [...byApp.keys()], groups: [...byApp.keys()].filter((id) => (byApp.get(id) || []).length).length, clock: clockText(), mounted: !!el }),
+    _stop: () => clearInterval(tick),
+  };
+})();

--- a/inklet/finkapp/index.html
+++ b/inklet/finkapp/index.html
@@ -59,6 +59,13 @@
      is one source of truth for what it contains. -->
 <div id="stats-bar" class="stats-bar" role="group" aria-label="Story status"></div>
 
+<!-- Menubar: a chrome strip that gathers small "dashboard" widgets (a
+     clock, and whatever running apps publish as app.<id>.status) and
+     groups them by the app-tree HIERARCHY — a story's readouts, and its
+     running minigame's nested beneath. Empty in markup: foafos-menubar.js
+     is the one source of truth. Mounts only if the root offers it. -->
+<div id="foaf-menubar" role="group" aria-label="Menubar"></div>
+
 <!-- Developer Panel -->
 <div id="dev-panel" class="dev-panel">
     <div id="dev-tabs" class="dev-tabs">
@@ -241,6 +248,7 @@
 <script src="../minigames/minigame-host.js"></script>
 <script src="fink-minigames.js"></script>
 <script src="fink-wm.js"></script>
+<script src="foafos-menubar.js"></script>
 <script type="module" src="foafos-shell.js"></script>
 <script src="fink-ink-engine.js"></script>
 <script src="fink-player.js"></script>

--- a/inklet/finkapp/test/e2e-storyrunner.mjs
+++ b/inklet/finkapp/test/e2e-storyrunner.mjs
@@ -173,6 +173,25 @@ try {
     pass(`accent: small thumbnail, text leads (${acc.mediaH}/${acc.stageH}px)`);
   } else fail('accent media wrong: ' + JSON.stringify(acc));
 
+  // ── 4c. MENUBAR: the story's # STATUS: (fired at the accent beat) surfaces
+  // as a dashboard widget in the shell menubar, GROUPED under the app in the
+  // tree; a clock is always present. This is the hierarchy the parallel
+  // view lacked — a story's readout at its own level, a minigame's nested.
+  await page.waitForTimeout(400);
+  const menubar = await page.evaluate(() => {
+    const el = document.getElementById('foaf-menubar');
+    const grp = el?.querySelector('.mb-group[data-app="storyrunner"]');
+    return {
+      mounted: !!(window.FoafMenubar && window.FoafMenubar._state().mounted),
+      clock: !!el?.querySelector('.mb-clock'),
+      group: !!grp,
+      text: grp?.textContent || '',
+    };
+  });
+  if (menubar.mounted && menubar.clock && menubar.group && /torch/.test(menubar.text)) {
+    pass(`menubar: clock + storyrunner group with the story's readout ("${menubar.text.trim()}")`);
+  } else fail('menubar wrong: ' + JSON.stringify(menubar));
+
   // ── 5. # FINK: LINK — the shell authorizes, the runner loads the peer
   // story IN ITS BOX, and the peer's own # MINIGAME: becomes a governed
   // launch. One flow proves link-following AND cross-story containment.


### PR DESCRIPTION
Answers the observation: foafos runs several parallel mini-apps with a real app tree underneath, but their small readouts (scores, clocks, gauges) had nowhere shared to surface and no nesting. Now there's a menubar.

**A chrome app** (`surface: 'chrome'`, mount `foaf-menubar`) — offered by the root → it renders; not offered → the element is parked, exactly like the breadcrumb and load meter. It shows:
- a **clock**, the one shell-level widget, always present;
- whatever a running app **publishes** as `app.<id>.status` on the bus — `{ items: [{ id, label, value, icon }] }`.

Apps publish in their **own scoped namespace** (`app.<id>.*` is already allowed by the sandbox, so a boxed guest needs no new grant); the menubar, trusted shell furniture, aggregates them all.

**The hierarchy:** groups are ordered and **indented by app-tree depth** (`FoafOS.apps`) — a story's readouts at one level, its running minigame's nested beneath. A group appears when its app starts publishing and clears when it closes. This is the nesting the flat parallel/tabbed view lacked.

The boxed story runner contributes its `# STATUS:` as a status item today; a minigame that publishes `app.<game>.status` gets its gauges nested under the launching story with no extra wiring.

**Verified:** `e2e-storyrunner` asserts the clock + the runner's group with its readout; `e2e-chrome` / `e2e-root` cover mount-when-offered / park-when-not; mandatory journey, desktop, and aria-audit (0 errors) all green. Screenshot shows clock + a WATERWORLD dashboard (air 82%, ⚓ x2) + a STORY RUNNER dashboard (torch in hand). Doc: `docs/foafos-menubar-20260729.md`.

**v1 scope:** text widgets, no interaction yet — the "menu" half (click-to-open app controls) and typed gauges (bars from the structured `# STATUS:` form) are the natural next step; the app tree already gives them the structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_