### PR TITLE
Make the app-tree border real: a launched game is the runner's child

### DIFF
--- a/docs/foafos-menubar-20260729.md
+++ b/docs/foafos-menubar-20260729.md
@@ -25,13 +25,28 @@ Apps publish in their **own scoped namespace** — the sandbox already allows
 `app.<id>.*`, so a boxed guest needs no new grant. The menubar, being
 trusted shell furniture (host-side), reads them all.
 
-## The hierarchy
-Groups are ordered and **indented by app-tree depth** (`FoafOS.apps`): a
-story's readouts at one level, its running minigame's nested beneath. A
-group appears when its app starts publishing and disappears when the app
-closes (`minigame.instance {closed}`). This is the nesting the flat
-parallel/tabbed view lacked — one story owning the frame, its guests'
-dashboards tucked under it.
+## The hierarchy reflects a REAL border (not a display nesting)
+Groups are ordered and **indented by app-tree depth** (`FoafOS.apps`) — but
+the point is what that tree *means*. It is not a cosmetic nesting; it is the
+**instantiation / control / capability border**:
+
+- **Instantiation.** When the boxed runner launches a minigame
+  (`story.launch`), the shell records the requesting runner's node and
+  parents the game **under that runner** — not under a global story/root
+  node. So the game is genuinely the runner's child because the runner
+  genuinely made it. (Correction, 2026-07-29: an earlier cut parented
+  launched games under the global story node, so the menubar's nesting was
+  faithful to a tree that was itself wrong. Fixed — see
+  `e2e-storyrunner.mjs` "instantiation border real".)
+- **Control.** Closing the runner **cascades** to its child game (the tree's
+  close cascade tears the guest down). Asserted.
+- **Capability.** The child's grant ⊆ the parent's (attenuation). The runner
+  therefore holds what it confers (`input`, `vars:read/write`) — a game it
+  launches cannot exceed it. Asserted.
+
+A group appears when its app starts publishing and disappears when the app
+closes. So the indent in the menubar is a true statement about who made,
+controls, and bounds whom — the border the flat parallel/tabbed view hid.
 
 ## Contributing (any app)
 ```js

--- a/inklet/finkapp/foafos-apps.js
+++ b/inklet/finkapp/foafos-apps.js
@@ -159,7 +159,12 @@ export const APPS = [
     // no `story` override: the runner defaults to its own ./demo.fink.js,
     // resolved relative to the RUNNER frame (a finkapp-relative path would
     // resolve against the wrong base once fetched inside the box)
-    capabilities: ['story:launch', 'story:link', 'story:navigate', 'audio'],
+    // It holds what it CONFERS: a minigame it launches becomes its child,
+    // and attenuation requires the child's caps ⊆ the runner's. So the
+    // runner carries input + vars:read/write on behalf of the games it
+    // instantiates — the capability border is real, not cosmetic.
+    capabilities: ['story:launch', 'story:link', 'story:navigate', 'audio',
+                   'input', 'vars:read', 'vars:write'],
     bus: { publish: ['app.storyrunner.*'], subscribe: ['wm.mode', 'audio.volume', 'ui.skin'] } },
   // MIGRATED (July 2026) — and it was the LAST `same-origin` holder, so the
   // whole registry is now sandboxed. Found because the ROBBAMP tile was DEAD

--- a/inklet/finkapp/foafos-shell.js
+++ b/inklet/finkapp/foafos-shell.js
@@ -479,6 +479,10 @@ const busGrantsFor = (type, app) => app?.bus || {
   subscribe: ['wm.mode', 'audio.volume', 'story.state'],
 };
 const gameNodes = new Map();       // minigame instance id -> tree node id
+// One-shot hint set by a boxed runner's story.launch: "the next minigame
+// of this type was instantiated by this app node." Read+cleared by the
+// minigame.instance handler so the game parents under its real launcher.
+let _pendingGameParent = null;
 bus.subscribe('minigame.instance', (e) => {
   if (e.source !== 'local') return;
   const { id, type, closed } = e.data || {};
@@ -491,8 +495,18 @@ bus.subscribe('minigame.instance', (e) => {
     return;
   }
   const app = appById(type);
+  // The instantiation border, made real: if a boxed runner launched this
+  // game (story.launch recorded which node asked), parent it under THAT
+  // runner — not the global story/root node. Then the tree reflects the
+  // truth the menubar renders: who instantiated whom, whose close cascades
+  // to it, and whose capability grant bounds it (attenuation). The hint is
+  // one-shot and only trusted if the recorded parent is still alive.
+  let parentId = (storyNode || FoafOS.rootNode)?.id || null;
+  const hint = _pendingGameParent;
+  _pendingGameParent = null;
+  if (hint && hint.type === type && apps.get(hint.parentNodeId)) parentId = hint.parentNodeId;
   const node = apps.spawn({
-    appId: type, parentId: (storyNode || FoafOS.rootNode)?.id || null,
+    appId: type, parentId,
     capabilities: app?.capabilities || [],
     label: app?.name || type, surface: 'stage',
     // endMinigame() is the real teardown — `closeMinigame` does not
@@ -1530,6 +1544,10 @@ function buildUI() {
           if (verb === 'story.launch') {
             const game = String(d.detail?.game || '').toLowerCase();
             if (!game) { reply({ ok: false, reason: 'bad-params' }); return; }
+            // Record the real instantiator so the game parents under THIS
+            // runner's node (win.dataset.instance), reflecting the true
+            // control/instantiation/capability border in the tree.
+            _pendingGameParent = { type: game, parentNodeId: win.dataset.instance || null };
             window.FinkMinigames?.startMinigame?.(game);
             reply({ ok: true, launched: game });
           } else if (verb === 'story.audio') {

--- a/inklet/finkapp/test/e2e-storyrunner.mjs
+++ b/inklet/finkapp/test/e2e-storyrunner.mjs
@@ -219,6 +219,25 @@ try {
     pass(`capUse tallied story:link (${use['story:link']}) and story:launch (${use['story:launch']})`);
   } else fail('capUse ledger missing a story:* use: ' + JSON.stringify(use));
 
+  // ── 5b. THE BORDER IS REAL — the launched game is a CHILD of the runner
+  // in the app tree (instantiation), not a sibling under story/root. Its
+  // caps are bounded by the runner's (attenuation), and closing the runner
+  // cascades to it (control). This is the hierarchy the menubar reflects.
+  await page.waitForTimeout(400);
+  const tree = await page.evaluate(() => {
+    const apps = FoafOS.apps;
+    const runner = [...apps.nodes.values()].find((n) => n.appId === 'storyrunner');
+    const game = [...apps.nodes.values()].find((n) => n.appId === 'waterworld');
+    return {
+      runner: !!runner, game: !!game,
+      gameUnderRunner: !!(runner && game && game.parentId === runner.id),
+      gameCapsBounded: !!(runner && game && game.capabilities.every((c) => runner.capabilities.includes(c))),
+    };
+  });
+  if (tree.gameUnderRunner && tree.gameCapsBounded) {
+    pass('instantiation border real: the game is a CHILD of the runner, caps bounded by it');
+  } else fail('tree border wrong: ' + JSON.stringify(tree));
+
   // ── 6. POLICY: a cross-origin link is refused; unknown verbs too ─────
   const xorigin = await frame.evaluate(() =>
     window.foaf.storyRequest('story.link', { url: 'https://evil.example/x.fink.js' }));
@@ -241,6 +260,19 @@ try {
   if (direction.declaredDefault === 'boxed' && direction.legacyPending && direction.legacyIssue === 779) {
     pass(`default surface = boxed; host player flagged pending-delete (auto-boot ${direction.autoBoot} until #${direction.legacyIssue})`);
   } else fail('default switch / pending-delete flag wrong: ' + JSON.stringify(direction));
+
+  // ── 8. CONTROL border (LAST — it detaches the runner frame): closing the
+  // runner subtree tears down its child game. Real control, real cascade.
+  const cascade = await page.evaluate(() => {
+    const apps = FoafOS.apps;
+    const runner = [...apps.nodes.values()].find((n) => n.appId === 'storyrunner');
+    const before = [...apps.nodes.values()].some((n) => n.appId === 'waterworld');
+    apps.close(runner.id);
+    const after = [...apps.nodes.values()].some((n) => n.appId === 'waterworld');
+    return { before, after };
+  });
+  if (cascade.before && !cascade.after) pass('control border real: closing the runner cascaded to its child game');
+  else fail('close did not cascade to the child game: ' + JSON.stringify(cascade));
 
   if (pageErrors.length) fail('page errors: ' + pageErrors.join(' | '));
   else pass('zero page errors');


### PR DESCRIPTION
Addresses the critique that the menubar hierarchy "sounded fake" — the nesting should reflect real **control / instantiation / capability** borders, not a cosmetic indent. It didn't, in two ways, both now fixed.

**1. Instantiation was wired wrong.** A minigame launched by the boxed runner was parented under the *global* story/root node, not under the runner that launched it — so the menubar was faithfully rendering a tree that was itself wrong. Now `story.launch` records the requesting runner's node (`win.dataset.instance`) as a one-shot hint, and the `minigame.instance` handler parents the game under **that** node. The game is the runner's child because the runner made it.

**2. The capability border is now real.** The child's caps ⊆ the parent's (attenuation), so the runner holds what it confers — `input`, `vars:read/write` — and a game it launches cannot exceed it. (Without this the spawn-under-runner would be *refused* — which is the border doing its job.)

**Control** falls out of the tree: closing the runner **cascades** to its child game.

All three borders are asserted in `e2e-storyrunner`:
- instantiation: `game.parentId === runner node id`
- capability: game caps ⊆ runner caps
- control: `close(runner)` removes the child game (this test runs last — it detaches the runner frame)

The menubar now indents by **real** depth: the runner at depth 1, a game it launched at depth 2 — measured 17.7px vs 35.4px margin. Doc corrected to say what the tree *means*.

Neighbours green: instances, waterworld, caps, bus, foafos, chrome, root, desktop, mandatory journey.

Known follow-up: the menubar should sit above stage game windows (z-index) so a launched game doesn't cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_