### PR TITLE
Shell: ?app=&lt;id&gt; deep link to open an app after boot

### DIFF
--- a/inklet/finkapp/foafos-shell.js
+++ b/inklet/finkapp/foafos-shell.js
@@ -1451,6 +1451,15 @@ function buildUI() {
   }
   FoafOS.launchApp = launchApp;
 
+  // One-tap deep link: `?app=<id>` opens an app straight after boot, so a
+  // shareable URL can drop someone into the boxed Story Runner (or any app
+  // the root offers) without hunting through the drawer. `rootOffers`/
+  // attenuation still gate it — a link cannot open what the root withholds.
+  try {
+    const wanted = new URLSearchParams(location.search).get('app');
+    if (wanted) setTimeout(() => { try { launchApp(wanted); } catch (e) { /* refused */ } }, 300);
+  } catch (e) { /* no location */ }
+
   // The sandbox an app gets, derived from its declared capabilities.
   //
   // `allow-scripts` alone yields an OPAQUE ORIGIN: no parent.document, no


### PR DESCRIPTION
A one-tap way to try the boxed Story Runner (and the menubar) without hunting through the drawer:

```
inklet/finkapp/?app=storyrunner
```

`?app=<id>` opens that app straight after boot. `rootOffers` + attenuation still gate it — a link cannot open what the root withholds. No effect when the param is absent; the mandatory Hampstead journey stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh

---
_Generated by [Claude Code](https://claude.ai/code/session_01226zDbvMzR1YWGKH8Y9prh)_